### PR TITLE
[Fix] Query Product Variant Id

### DIFF
--- a/Assets/Editor/MockLoader.cs
+++ b/Assets/Editor/MockLoader.cs
@@ -313,6 +313,7 @@ namespace Shopify.Tests {
 
                 edges.Append(String.Format(@"{{
                     ""node"": {{
+                        ""id"": ""{0}"",
                         ""available"": true,
                         ""images"": [],
                         ""title"": ""variant{0}"",

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
@@ -78,6 +78,7 @@ namespace <%= namespace %>.SDK {
 
         public void ProductVariant(ProductVariantQuery variant) {
             variant
+            .id()
             .available()
             .images(pnvi => pnvi
                 .altText()


### PR DESCRIPTION
This PR just simply adds in querying id on `ProductVariant` in `DefaultQueries`.