### PR TITLE
[Fix] Input Object Namespace

### DIFF
--- a/Assets/Editor/MockLoader.cs
+++ b/Assets/Editor/MockLoader.cs
@@ -2,6 +2,7 @@ namespace Shopify.Tests {
     using System;
     using System.Text;
     using System.Collections.Generic;
+    using Shopify.Unity;
     using Shopify.Unity.GraphQL;
     using Shopify.Unity.SDK;
 

--- a/Assets/Editor/TestGraphBuilder.cs
+++ b/Assets/Editor/TestGraphBuilder.cs
@@ -2,6 +2,7 @@ namespace Shopify.Tests
 {
     using System;
     using NUnit.Framework;
+    using Shopify.Unity;
     using Shopify.Unity.SDK;
     using Shopify.Unity.GraphQL;
 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -111,7 +111,7 @@ module GraphQLGenerator
           File.write("#{path_graphql}/#{type.name}Query.cs", reformat(TYPE_ERB.result(binding)))
           File.write("#{path_graphql}/#{type.name}.cs", reformat(TYPE_RESPONSE_ERB.result(binding)))
         elsif type.input_object? || type.kind == 'ENUM'
-          File.write("#{path_graphql}/#{type.name}.cs", reformat(TYPE_ERB.result(binding)))
+          File.write("#{path}/#{type.name}.cs", reformat(TYPE_ERB.result(binding)))
         end 
       end
     end 

--- a/scripts/generator/graphql_generator/csharp/type.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type.cs.erb
@@ -1,6 +1,10 @@
 <% isRoot = schema.root_name?(type.name) %>
 <% isQueryRoot = type.name == schema.query_root_name %>
+<% if type.kind == 'INPUT_OBJECT' || type.kind == 'ENUM' %>
+namespace <%= namespace %> {
+<% else %>
 namespace <%= namespace %>.GraphQL {
+<% end %>
     using System;
     using System.Text;
     using System.Collections.Generic;


### PR DESCRIPTION
I've moved all input objects to `Shopify.Unity` from `Shopify.Unity.GraphQL`.

The reason for this move is that if you're building queries you would have had to do:
```cs
using Shopify.Unity;
using Shopify.Unity.GraphQL;
```

Now you'd just need to do:
```cs
using Shopify.Unity;
```

All query builders still live in `Shopify.Unity.GraphQL` but they are exposed by `ShopifyBuy`. To show this in code if I was doing:
```
using Shopify.Unity;

ShopifyBuy.Client().Mutation((query) => query
  .customerCreate((qc) => qc
    .customer((qcustomer) => qcustomer
      .email()
    ),
    new CustomerCreateInput(email: "some@email.com")
  ),
  (response, errors, httpError) => {
    Debug.Log("customer created with email: " + response.customerCreate().customer().email());
  }
);
```

In the above example before this PR because we were using `CustomerCreateInput` we'd need to drop in`using Shopify.Unity.GraphQL;`