### PR TITLE
[Feature] Different Image Resolutions

### DIFF
--- a/Assets/Editor/TestFieldAlias.cs
+++ b/Assets/Editor/TestFieldAlias.cs
@@ -24,6 +24,24 @@ namespace Shopify.Tests
         }
 
         [Test]
+        public void QuerySameFieldWithAndWithoutAlias() {
+            QueryRootQuery query = new QueryRootQuery();
+            query.node(
+                node => node.id(),
+                alias: "an_alias", id: "1234"
+            );
+
+            query.node(
+                node => node.id(), id: "1234"
+            );
+
+            Assert.AreEqual(
+                @"{node___an_alias:node (id:""1234""){__typename id }node (id:""1234""){__typename id }}",
+                query.ToString()
+            );
+        }
+
+        [Test]
         public void ExceptionIsThrownForBlankAliasInQuery() {
             AliasException caughtError = null;
             QueryRootQuery query = new QueryRootQuery();

--- a/Assets/IntegrationTests/TestShopifyCollections.cs
+++ b/Assets/IntegrationTests/TestShopifyCollections.cs
@@ -2,6 +2,7 @@ namespace Shopify.Unity.Tests
 {
     using UnityEngine;
     using Shopify.Unity;
+    using System.Collections.Generic;
 
     [IntegrationTest.DynamicTest ("TestScene")]
     [IntegrationTest.SucceedWithAssertions]
@@ -17,6 +18,26 @@ namespace Shopify.Unity.Tests
                     IntegrationTest.Assert(collections.Count > 0, "Loaded collections");
                     IntegrationTest.Assert("Home page" == collections[0].title(), "First collection is: Home page");
                     
+                    List<string> aliases = new List<string>() {
+                        "pico",
+                        "pico",
+                        "icon",
+                        "thumb",
+                        "small",
+                        "compact",
+                        "medium",
+                        "large",
+                        "grande",
+                        "resolution_1024",
+                        "resolution_2048"
+                    };
+
+                    foreach(string alias in aliases) {
+                        // this will throw an exception if image was not queried with alias
+                        // no collections in our test store have values
+                        collections[0].image(alias);
+                    }
+
                     IntegrationTest.Pass();
                 }
             );

--- a/Assets/IntegrationTests/TestShopifyProducts.cs
+++ b/Assets/IntegrationTests/TestShopifyProducts.cs
@@ -2,6 +2,8 @@ namespace Shopify.Unity.Tests
 {
     using UnityEngine;
     using Shopify.Unity;
+    using Shopify.Unity.GraphQL;
+    using System.Collections.Generic;
 
     [IntegrationTest.DynamicTest ("TestScene")]
     [IntegrationTest.SucceedWithAssertions]
@@ -17,6 +19,36 @@ namespace Shopify.Unity.Tests
                     IntegrationTest.Assert(products.Count == 3, "Loaded products");
                     IntegrationTest.Assert("beans" == products[0].title(), "Title product 0: beans");
                     IntegrationTest.Assert("Orphean Steel Bag" == products[1].title(), "Title product 1: Orphean Steel Bag");
+
+                    List<string> aliases = new List<string>() {
+                        "pico",
+                        "pico",
+                        "icon",
+                        "thumb",
+                        "small",
+                        "compact",
+                        "medium",
+                        "large",
+                        "grande",
+                        "resolution_1024",
+                        "resolution_2048"
+                    };
+                    
+                    foreach(string imageAlias in aliases) {
+                        IntegrationTest.Assert(null != products[0].images(imageAlias), string.Format("images alias {0} was queried", imageAlias));
+                    }
+
+                    List<ProductVariant> variants = (List<ProductVariant>) products[0].variants();
+                    
+                    foreach(string imageAlias in aliases) {
+                        // this will throw an exception if not queried
+                        variants[0].image(imageAlias);
+                    }
+
+                    // this will throw an exception if not queried
+                    variants[0].image();
+
+                    IntegrationTest.Assert(null != products[0].images(), "images with no alias queried");
 
                     IntegrationTest.Pass();
                 }

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
@@ -1,32 +1,43 @@
 namespace <%= namespace %>.SDK {
+    using System.Collections.Generic;
     using <%= namespace %>.GraphQL;
 
     public class ProductsQueries {
-        public void ShopProducts(QueryRootQuery query, int first = 250, string after = null) {
+        public void ShopProducts(QueryRootQuery query, Dictionary<string,int> imageResolutions, int first = 250, string after = null) {
             query.shop(s => s
                 .products(pc => pc
                     .edges(e => e
-                        .node(p => p
+                        .node((p) => { p
                             .id()
                             .title()
                             .descriptionHtml()
-                            .images(
-                                ic => ImageConnection(ic),
-                                first: DefaultQueries.MaxPageSize
-                            )
                             .options(pn => pn
                                 .name()
                                 .values()
                             )
                             .variants(
-                                pvc => ProductVariantConnection(pvc),
+                                pvc => ProductVariantConnection(pvc, imageResolutions),
                                 first: DefaultQueries.MaxPageSize
                             )
                             .collections(
                                 pcc => CollectionConnection(pcc),
                                 first: DefaultQueries.MaxPageSize
                             )
-                        )
+                            .images(
+                                ic => ImageConnection(ic),
+                                first: DefaultQueries.MaxPageSize
+                            );
+
+                            foreach(string alias in imageResolutions.Keys) {
+                                p.images(
+                                    ic => ImageConnection(ic),
+                                    first: DefaultQueries.MaxPageSize,
+                                    maxWidth: imageResolutions[alias],
+                                    maxHeight: imageResolutions[alias],
+                                    alias: alias
+                                );
+                            }
+                        })
                         .cursor()
                     )
                     .pageInfo(pi => pi
@@ -48,10 +59,10 @@ namespace <%= namespace %>.SDK {
             );
         }
 
-        public void ProductVariantConnection(ProductVariantConnectionQuery variantConnection) {
+        public void ProductVariantConnection(ProductVariantConnectionQuery variantConnection, Dictionary<string,int> imageResolutions) {
             variantConnection
             .edges(pve => pve
-                .node(pnv => ProductVariant(pnv))
+                .node(pnv => ProductVariant(pnv, imageResolutions))
                 .cursor()
             )
             .pageInfo(pvp => pvp
@@ -76,7 +87,7 @@ namespace <%= namespace %>.SDK {
             .src();
         }
 
-        public void ProductVariant(ProductVariantQuery variant) {
+        public void ProductVariant(ProductVariantQuery variant, Dictionary<string,int> imageResolutions) {
             variant
             .id()
             .available()
@@ -92,26 +103,31 @@ namespace <%= namespace %>.SDK {
                 .value()
             )
             .weightUnit();
+
+            foreach(string alias in imageResolutions.Keys) {
+                variant.image(
+                    pnvi => pnvi
+                    .altText()
+                    .src(),
+                    maxWidth: imageResolutions[alias], maxHeight: imageResolutions[alias], alias: alias
+                );
+            }
         }
 
         public void Collection(CollectionQuery collection) {
             collection
             .id()
-            .image(pci => pci
-                .altText()
-                .src()
-            )
             .title()
             .updatedAt();
         }
     }
 
     public class CollectionsQueries {
-        public void ShopCollections(QueryRootQuery query, int first = 250, string after = null) {
+        public void ShopCollections(QueryRootQuery query, Dictionary<string, int> imageResolutions, int first = 250, string after = null) {
             query.shop(s => s
                 .collections(cc => cc
                     .edges(e => e
-                        .node(c => Collection(c))
+                        .node(c => Collection(c, imageResolutions))
                         .cursor()
                     )
                     .pageInfo(pi => pi
@@ -122,7 +138,7 @@ namespace <%= namespace %>.SDK {
             );
         }
 
-        public void Collection(CollectionQuery collection) {
+        public void Collection(CollectionQuery collection, Dictionary<string, int> imageResolutions) {
             collection
             .id()
             .image(pci => pci
@@ -134,6 +150,18 @@ namespace <%= namespace %>.SDK {
             .products(pc => ProductConnection(pc),
                 first: DefaultQueries.MaxPageSize
             );
+
+            
+            foreach(string alias in imageResolutions.Keys) {
+                collection
+                .image(pci => pci
+                    .altText()
+                    .src(),
+                    maxWidth: imageResolutions[alias], 
+                    maxHeight: imageResolutions[alias],
+                    alias: alias
+                );
+            }
         }
 
         public void ProductConnection(ProductConnectionQuery productConnection) {

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -64,6 +64,19 @@ namespace <%= namespace %> {
     public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, List<string> errors, string httpError);
 
     public class ShopifyClient {
+        public static Dictionary<string,int> defaultImageSizes = new Dictionary<string, int>() {
+            {"pico", 16},
+            {"icon", 32},
+            {"thumb", 50},
+            {"small", 100},
+            {"compact", 160},
+            {"medium", 240},
+            {"large", 480},
+            {"grande", 600},
+            {"resolution_1024", 1024},
+            {"resolution_2048", 2048}
+        };
+
         public string ApiKey {
             get {
                 return _ApiKey;
@@ -98,7 +111,11 @@ namespace <%= namespace %> {
             Loader = new QueryLoader(loader);
         }
 
-        public void products(ResponseProductsHandler callback, int? first = null, string after = null) {
+        public void products(ResponseProductsHandler callback, int? first = null, string after = null, Dictionary<string,int> imageResolutions = null) {
+            if (imageResolutions == null) {
+                imageResolutions = defaultImageSizes;
+            }
+
             GetProductsList((products, errors, httpError) => {
                 if (httpError != null) {
                     callback(null, null, httpError);
@@ -117,7 +134,7 @@ namespace <%= namespace %> {
                         new ConnectionQueryInfo(
                             getConnection: (p) => ((Product) p).variants(),
                             query: (p, variantsAfter) => {
-                                ((ProductQuery) p).variants(vc => DefaultQueries.products.ProductVariantConnection(vc),
+                                ((ProductQuery) p).variants(vc => DefaultQueries.products.ProductVariantConnection(vc, defaultImageSizes),
                                     first: DefaultQueries.MaxPageSize, after: variantsAfter
                                 );
                             }
@@ -132,6 +149,21 @@ namespace <%= namespace %> {
                         )
                     };
 
+                    foreach(string alias in imageResolutions.Keys) {
+                        connectionInfos.Add(new ConnectionQueryInfo(
+                            getConnection: (p) => ((Product) p).images(alias),
+                            query: (p, imagesAfter) => {
+                                ((ProductQuery) p).images(ic => DefaultQueries.products.ImageConnection(ic),
+                                    first: DefaultQueries.MaxPageSize, 
+                                    after: imagesAfter, 
+                                    maxWidth: imageResolutions[alias],
+                                    maxHeight: imageResolutions[alias],
+                                    alias: alias
+                                );
+                            }
+                        ));
+                    }
+
                     ConnectionLoader loader = new ConnectionLoader(Loader);
                     List<Node> nodes = products.ConvertAll(p => (Node) p);
                     
@@ -139,7 +171,7 @@ namespace <%= namespace %> {
                         callback(nodesResult.ConvertAll(n => (Product) n), errorsNode, httpErrorsNode);
                     });
                 }
-            }, first: first, after: after);
+            }, imageResolutions: imageResolutions, first: first, after: after);
         }
 
         public void collections(ResponseCollectionsHandler callback, int? first = null, string after = null) {
@@ -244,7 +276,7 @@ namespace <%= namespace %> {
             );
         }
 
-        private void GetProductsList(ResponseProductsHandler callback, int? first = null, string after = null) {
+        private void GetProductsList(ResponseProductsHandler callback, Dictionary<string,int> imageResolutions, int? first = null, string after = null) {
             ConnectionLoader loader = new ConnectionLoader(Loader);
             int countToLoad = first == null ? int.MaxValue : (int) first;
 
@@ -264,6 +296,7 @@ namespace <%= namespace %> {
                         query = new QueryRootQuery();
                         DefaultQueries.products.ShopProducts(
                             query: query, 
+                            imageResolutions: imageResolutions,
                             first: countToLoad > DefaultQueries.MaxPageSize ? DefaultQueries.MaxPageSize : countToLoad, 
                             after: edges != null ? edges[edges.Count - 1].cursor() : after
                         );
@@ -307,7 +340,8 @@ namespace <%= namespace %> {
                         DefaultQueries.collections.ShopCollections(
                             query: query, 
                             first: countToLoad > DefaultQueries.MaxPageSize ? DefaultQueries.MaxPageSize : countToLoad, 
-                            after: edges != null ? edges[edges.Count - 1].cursor() : after
+                            after: edges != null ? edges[edges.Count - 1].cursor() : after,
+                            imageResolutions: defaultImageSizes
                         );
                     }
 


### PR DESCRIPTION
One of the first issues Snowman has hit is getting urls for different resolutions of images.

The `js-buy-sdk` will return a image src urls at different set resolutions:
https://github.com/Shopify/js-buy-sdk/blob/master/src/models/image-model.js#L3-L14

This PR modifies default queries to add the same functionality as what the `js-buy-sdk` has for: product images, product variant image, and collections image.