### PR TITLE
[Fixes] Adding access_token to permalink

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -63,8 +63,8 @@ namespace Shopify.Tests
             cart.LineItems.AddOrUpdate("gid://shopify/ProductVariant/20756129155", 33);
             cart.LineItems.AddOrUpdate("gid://shopify/ProductVariant/20756129347", 2);
 
-            Assert.AreEqual("http://graphql.myshopify.com/cart/20756129155:33,20756129347:2", cart.GetWebCheckoutLink());
-            Assert.AreEqual("http://graphql.myshopify.com/cart/20756129155:33,20756129347:2?note=i-am-a-note", cart.GetWebCheckoutLink("i-am-a-note"));
+            Assert.AreEqual("http://graphql.myshopify.com/cart/20756129155:33,20756129347:2?access_token=1234", cart.GetWebCheckoutLink());
+            Assert.AreEqual("http://graphql.myshopify.com/cart/20756129155:33,20756129347:2?access_token=1234&note=i-am-a-note", cart.GetWebCheckoutLink("i-am-a-note"));
         }
 
         [Test]

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -249,10 +249,12 @@ namespace <%= namespace %> {
                 url.Append(":");
                 url.Append(lineItem.quantity);
             }
+
+            url.Append("?access_token=");
+            url.Append(Client.AccessToken);
             
             if (note != null) {
-                url.Append("?");
-                url.Append("note=");
+                url.Append("&note=");
                 url.Append(note);
             }
 


### PR DESCRIPTION
This PR fixes adding `access_token` to generated permalinks. Also fixes #40 