### PR TITLE
[Feature] Logging + Documenting Deprecated Fields

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -100,6 +100,7 @@ module GraphQLGenerator
         SDK/MutationResponse
         SDK/QueryResponse
         SDK/ILoader
+        SDK/Log
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 
@@ -274,11 +275,15 @@ module GraphQLGenerator
     end
 
     def enum_values(type)
-      type.enum_values.clone.unshift(UNKNOWN_ENUM).map{ |enum| "#{summary_doc(enum.description)}\n#{enum.name}" }.join(",\n")
+      type.enum_values.clone.unshift(UNKNOWN_ENUM).map{ |enum| "#{deprecation_doc_for(enum)}#{summary_doc(enum.description)}\n#{enum.name}" }.join(",\n")
     end
 
     def pretty_doc(documentation)
       "/// #{documentation.split("\n").map{|part| part.strip }.join("\n/// ")}"
+    end
+
+    def deprecation_doc_for(item)
+      "/// \\deprecated #{item.deprecation_reason}\n" if item.deprecated?
     end
 
     def summary_doc(description)
@@ -373,11 +378,11 @@ module GraphQLGenerator
       params_doc = params_doc(field.args);
       
       if field.description
-        return "#{summary_doc(field.description)}\n#{params_doc}"
+        return "#{deprecation_doc_for(field)}#{summary_doc(field.description)}\n#{params_doc}"
       elsif params_doc != ""
-        return params_doc
+        return "#{deprecation_doc_for(field)}#{params_doc}"
       else
-        return ""
+        return "#{deprecation_doc_for(field)}"
       end
     end
 
@@ -389,9 +394,9 @@ module GraphQLGenerator
       end
 
       if field.description
-        return "#{summary_doc(field.description)}\n#{alias_doc}"
+        return "#{deprecation_doc_for(field)}#{summary_doc(field.description)}\n#{alias_doc}"
       else
-        return alias_doc
+        return "#{deprecation_doc_for(field)}#{alias_doc}"
       end
     end
   end

--- a/scripts/generator/graphql_generator/csharp/SDK/Log.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Log.cs.erb
@@ -1,0 +1,13 @@
+namespace <%= namespace %>.SDK {
+    #if !SHOPIFY_MONO_UNIT_TEST
+    using UnityEngine;
+    #endif
+
+    public class Log {
+        public static void DeprecatedQueryField(string typeName, string fieldName, string deprecationReason) {
+            #if !SHOPIFY_MONO_UNIT_TEST
+            Debug.LogWarning("The field `" + typeName + "." + fieldName + "` is deprecated with the following deprecation message:\n" + deprecationReason);
+            #endif
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp/type.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type.cs.erb
@@ -47,6 +47,10 @@ namespace <%= namespace %>.GraphQL {
             <% type.fields(include_deprecated: true).each do |field| %>
                 <%= docs_query_field(field) %>
                 public <%= type.classify_name %>Query <%= escape_reserved_word(field.name) %>(<%= field_args(field) %>) {
+                    <% if field.deprecated? %>
+                    Log.DeprecatedQueryField("<%= type.name %>", "<%= field.name %>", "<%= field.deprecation_reason %>");
+                    <% end %>
+
                     <%# now we we want to handle generating arguments %>
                     <% if field.args.any? %>
                         if (alias != null) {


### PR DESCRIPTION
This PR adds deprecation messages for deprecated fields in docs and also adds logging warnings when querying deprecated fields.

In documentation this looks like this:
<img width="701" alt="screen shot 2017-04-17 at 10 02 05 am" src="https://cloud.githubusercontent.com/assets/496903/25091057/fc3a996a-2354-11e7-88d7-bfbed477bd05.png">

In Unity when querying a deprecated field you get the following:
<img width="578" alt="screen shot 2017-04-17 at 9 48 50 am" src="https://cloud.githubusercontent.com/assets/496903/25091064/0ae06a94-2355-11e7-836a-8254ac7932ba.png">
