### PR TITLE
[Fix] Response object namespace

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -35,7 +35,7 @@ namespace Shopify.Tests
             Dictionary<string,object> data = new Dictionary<string,object>();
             data.Add("id", "gid://shopify/ProductVariant/20756129347");
 
-            Shopify.Unity.GraphQL.ProductVariant variant = new Shopify.Unity.GraphQL.ProductVariant(data);
+            ProductVariant variant = new ProductVariant(data);
 
             cart.LineItems.AddOrUpdate("gid://shopify/ProductVariant/20756129155", 33);
             cart.LineItems.AddOrUpdate(variant, 2);

--- a/Assets/Editor/TestFieldAlias.cs
+++ b/Assets/Editor/TestFieldAlias.cs
@@ -3,6 +3,7 @@ namespace Shopify.Tests
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Shopify.Unity;
     using Shopify.Unity.SDK;
     using Shopify.Unity.GraphQL;
     using Shopify.Unity.MiniJSON;

--- a/Assets/Editor/TestRelay.cs
+++ b/Assets/Editor/TestRelay.cs
@@ -2,9 +2,10 @@ namespace Shopify.Tests {
     using NUnit.Framework;
     using System;
     using System.Collections.Generic;
+    using Shopify.Unity;
+    using Shopify.Unity.SDK;
     using Shopify.Unity.GraphQL;
     using Shopify.Unity.MiniJSON;
-    using Shopify.Unity.SDK;
 
     class CollectionTestQueries {
         public static QueryRootQuery query1 = (new QueryRootQuery()).shop(s => s.

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'ostruct'
+require 'fileutils'
 require_relative './csharp/scalar'
 require_relative './reformatter'
 
@@ -73,13 +74,16 @@ module GraphQLGenerator
 
     def save(path)
       path_graphql = "#{path}/GraphQL"
-
+    
       begin
         Dir.mkdir(path_graphql)
       rescue Errno::EEXIST
       end
 
-      # output classes on root
+      Dir["#{path}/**/*.cs"].reject{ |f| f[%r{Vendor/}] }.each do |file|
+        FileUtils.rm(file)
+      end
+
       %w(
         ShopifyBuy
         Cart
@@ -117,7 +121,7 @@ module GraphQLGenerator
         # output 
         if type.object? || type.interface?
           File.write("#{path_graphql}/#{type.name}Query.cs", reformat(TYPE_ERB.result(binding)))
-          File.write("#{path_graphql}/#{type.name}.cs", reformat(TYPE_RESPONSE_ERB.result(binding)))
+          File.write("#{path}/#{type.name}.cs", reformat(TYPE_RESPONSE_ERB.result(binding)))
         elsif type.input_object? || type.kind == 'ENUM'
           File.write("#{path}/#{type.name}.cs", reformat(TYPE_ERB.result(binding)))
         end 

--- a/scripts/generator/graphql_generator/csharp/type_response.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type_response.cs.erb
@@ -1,4 +1,4 @@
-namespace <%= namespace %>.GraphQL {
+namespace <%= namespace %> {
     using System;
     using System.Collections;
     using System.Collections.Generic;


### PR DESCRIPTION
This PR is similar to #35 

Users are most likely to interact with input objects and objects that deserialize responses. #35 moved input objects to the root namespace. This PR moves response/deserializer classes to the root namespace also.

I also added functionality to [clear all](https://github.com/Shopify/unity-buy-sdk/compare/fix/namespace-response?expand=1#diff-d5d01c70fbde6fe22a01914e2c5386b9R83) generates files before generating new ones. This will ensure that generation is less error prone in the future.