### PR TITLE
[Fix] Opaque ids

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -33,24 +33,24 @@ namespace Shopify.Tests
             Cart cart = ShopifyBuy.Client().Cart();
 
             Dictionary<string,object> data = new Dictionary<string,object>();
-            data.Add("id", "gid://shopify/ProductVariant/20756129347");
+            data.Add("id", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==");
 
             ProductVariant variant = new ProductVariant(data);
 
-            cart.LineItems.AddOrUpdate("gid://shopify/ProductVariant/20756129155", 33);
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
             cart.LineItems.AddOrUpdate(variant, 2);
-            cart.LineItems.AddOrUpdate("gid://shopify/Product/7336568131");
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=");
 
             Assert.AreEqual(3, cart.LineItems.All().Count, "has 3 items in cart");
-            Assert.AreEqual(33, cart.LineItems.Get("gid://shopify/ProductVariant/20756129155").quantity, "variant 20756129155 quantity is 33");
-            Assert.AreEqual(2, cart.LineItems.Get("gid://shopify/ProductVariant/20756129347").quantity, "variant 20756129347 quantity is 2");
-            Assert.AreEqual(1, cart.LineItems.Get("gid://shopify/Product/7336568131").quantity, "variant 7336568131 quantity is 1");
+            Assert.AreEqual(33, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==").quantity, "variant 20756129155 quantity is 33");
+            Assert.AreEqual(2, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==").quantity, "variant 20756129347 quantity is 2");
+            Assert.AreEqual(1, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=").quantity, "variant 7336568131 quantity is 1");
 
-            bool didDelete = cart.LineItems.Delete("gid://shopify/ProductVariant/20756129155");
+            bool didDelete = cart.LineItems.Delete("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==");
             Assert.AreEqual(2, cart.LineItems.All().Count, "After remove had 2 items in cart");
             Assert.IsTrue(didDelete, "returned true when deleting");
 
-            didDelete = cart.LineItems.Delete("gid://shopify/ProductVariant/iamnotreal");
+            didDelete = cart.LineItems.Delete("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC9pYW1ub3RyZWFs");
             Assert.IsFalse(didDelete, "returned false when did not delete");
         }
 
@@ -60,8 +60,8 @@ namespace Shopify.Tests
 
             Cart cart = ShopifyBuy.Client().Cart();
 
-            cart.LineItems.AddOrUpdate("gid://shopify/ProductVariant/20756129155", 33);
-            cart.LineItems.AddOrUpdate("gid://shopify/ProductVariant/20756129347", 2);
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
 
             Assert.AreEqual("http://graphql.myshopify.com/cart/20756129155:33,20756129347:2?access_token=1234", cart.GetWebCheckoutLink());
             Assert.AreEqual("http://graphql.myshopify.com/cart/20756129155:33,20756129347:2?access_token=1234&note=i-am-a-note", cart.GetWebCheckoutLink("i-am-a-note"));
@@ -71,8 +71,8 @@ namespace Shopify.Tests
         public void ModifyLineItems() {
             ShopifyBuy.Init(new MockLoader());
 
-            string productId1 = "gid://shopify/ProductVariant/20756129155";
-            string productId2 = "gid://shopify/ProductVariant/20756129347";
+            string productId1 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+            string productId2 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==";
             List<AttributeInput> attributes1 = new List<AttributeInput>() {
                 new AttributeInput("fancy", "i am fancy"),
                 new AttributeInput("boring", "i am boring")
@@ -128,7 +128,7 @@ namespace Shopify.Tests
                         ""edges"": [
                         {
                             ""node"": {
-                            ""id"": ""gid://shopify/ProductVariant/28472670531"",
+                            ""id"": ""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yODQ3MjY3MDUzMQ=="",
                             ""selectedOptions"": [
                                 {
                                 ""name"": ""Size"",
@@ -143,7 +143,7 @@ namespace Shopify.Tests
                         },
                         {
                             ""node"": {
-                            ""id"": ""gid://shopify/ProductVariant/28472705027"",
+                            ""id"": ""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yODQ3MjcwNTAyNw=="",
                             ""selectedOptions"": [
                                 {
                                 ""name"": ""Size"",
@@ -158,7 +158,7 @@ namespace Shopify.Tests
                         },
                         {
                             ""node"": {
-                            ""id"": ""gid://shopify/ProductVariant/28472705091"",
+                            ""id"": ""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yODQ3MjcwNTA5MQ=="",
                             ""selectedOptions"": [
                                 {
                                 ""name"": ""Size"",
@@ -173,7 +173,7 @@ namespace Shopify.Tests
                         },
                         {
                             ""node"": {
-                            ""id"": ""gid://shopify/ProductVariant/28472705155"",
+                            ""id"": ""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yODQ3MjcwNTE1NQ=="",
                             ""selectedOptions"": [
                                 {
                                 ""name"": ""Size"",

--- a/Assets/IntegrationTests/TestShopifyProductsById.cs
+++ b/Assets/IntegrationTests/TestShopifyProductsById.cs
@@ -51,7 +51,7 @@ namespace Shopify.Unity.Tests
 
                     IntegrationTest.Pass();
                 },
-                "gid://shopify/Product/9895281475", "gid://shopify/Product/9895284291"
+                "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyODE0NzU=", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyODQyOTE="
             );
         }
     }   

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -334,10 +334,13 @@ namespace <%= namespace %> {
 
                 hasLineItem = true;
 
-                string[] variandIdSplit = lineItem.variantId.Split('/');
+                string variantId = System.Text.Encoding.UTF8.GetString(
+                    Convert.FromBase64String(lineItem.variantId)
+                );
 
-                // variant id's are in this form:
-                // gid://shopify/ProductVariant/123123
+                // convert from variant gid to variant id
+                string[] variandIdSplit = variantId.Split('/');
+
                 url.Append(variandIdSplit[variandIdSplit.Length - 1]);
                 url.Append(":");
                 url.Append(lineItem.quantity);

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -353,7 +353,7 @@ namespace <%= namespace %> {
         /// ShopifyBuy.Client().products((products, errors, httpError) => {
         ///     Debug.Log(products[0].title()); // "Snare Boot"
         ///     Debug.Log(products[1].title()); // "Neptune Boot"
-        /// }, "gid://shopify/Product/9895276099", "gid://shopify/Product/9895279043");
+        /// }, "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyNzYwOTk=", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyNzkwNDM=");
         /// \endcode
         public void products(ResponseProductsHandler callback, string firstProductId, params string[] otherProductIds) {
             List<string> productIds = new List<string>();
@@ -400,8 +400,8 @@ namespace <%= namespace %> {
         /// \code
         /// // Example usage querying two product ids using a List<string>
         /// List<string> productIds = new List<string>() {
-        ///     "gid://shopify/Product/9895276099",
-        ///     "gid://shopify/Product/9895279043"
+        ///     "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyNzYwOTk=",
+        ///     "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyNzkwNDM="
         /// };
         ///
         /// ShopifyBuy.Client().products((products, errors, httpError) => {


### PR DESCRIPTION
I created this PR if we end up going with opaque ids for the Storefront API. I will still need to rebuild documentation since some of the code docs had refs to gids.

The implementation to decode the variant id in cart is just temporary. Later I will implement generating checkout links via the Storefront API.