### PR TITLE
fixing README link to Testing in Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Unity Buy SDK allows Unity developers to query and sell products from Shopif
 - [Build the GraphQL client](#build-the-unity-buy-sdk)
 - [Testing](#testing)
     + [Testing in Unity](#testing-in-unity)
-    + [Testing in Terminal](#testing-in-terminal)
+    + [Testing in Terminal](#testing-in-terminal-using-headless-unity)
 
 ## Features
 


### PR DESCRIPTION
## Problem

Link for `Testing in Terminal` in README is broken.

## Solution

Use the correct name for the link.

@mikkoh 