### PR TITLE
[FIX] Refactor CartLineItem to be generic

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -42,9 +42,10 @@ namespace Shopify.Tests
             cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=");
 
             Assert.AreEqual(3, cart.LineItems.All().Count, "has 3 items in cart");
-            Assert.AreEqual(33, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==").quantity, "variant 20756129155 quantity is 33");
-            Assert.AreEqual(2, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==").quantity, "variant 20756129347 quantity is 2");
-            Assert.AreEqual(1, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=").quantity, "variant 7336568131 quantity is 1");
+            Assert.AreEqual(33, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==").Quantity, "variant 20756129155 Quantity is 33");
+            Assert.AreEqual(2, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==").Quantity, "variant 20756129347 Quantity is 2");
+            Assert.AreEqual(1, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=").Quantity, "variant 7336568131 Quantity is 1");
+            Assert.AreEqual(null, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=").ID, "variant 7336568131 ID is null");
 
             bool didDelete = cart.LineItems.Delete("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==");
             Assert.AreEqual(2, cart.LineItems.All().Count, "After remove had 2 items in cart");
@@ -73,13 +74,13 @@ namespace Shopify.Tests
 
             string productId1 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
             string productId2 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==";
-            List<AttributeInput> attributes1 = new List<AttributeInput>() {
-                new AttributeInput("fancy", "i am fancy"),
-                new AttributeInput("boring", "i am boring")
+            Dictionary<string, string> attributes1 = new Dictionary<string, string>() {
+                {"fancy", "i am fancy"},
+                {"boring", "i am boring"}
             };
-            List<AttributeInput> attributes2 = new List<AttributeInput>() {
-                new AttributeInput("animal", "lion"),
-                new AttributeInput("spotted", "no")
+            Dictionary<string, string> attributes2 = new Dictionary<string, string>() {
+                {"animal", "lion"},
+                {"spotted", "no"}
             };
 
             Cart cart = ShopifyBuy.Client().Cart();
@@ -91,12 +92,12 @@ namespace Shopify.Tests
             cart.LineItems.AddOrUpdate(productId1, null, attributes1);
             cart.LineItems.AddOrUpdate(productId2, 6, attributes2);
 
-            Assert.AreEqual(100, cart.LineItems.Get(productId1).quantity, "variant 20756129155 quantity is 100 after change");
-            Assert.AreEqual(6, cart.LineItems.Get(productId2).quantity, "variant 20756129155 quantity is 100 after change");
-            Assert.AreEqual("i am fancy", cart.LineItems.Get(productId1).customAttributes[0].value);
-            Assert.AreEqual("i am boring", cart.LineItems.Get(productId1).customAttributes[1].value);
-            Assert.AreEqual("lion", cart.LineItems.Get(productId2).customAttributes[0].value);
-            Assert.AreEqual("no", cart.LineItems.Get(productId2).customAttributes[1].value);
+            Assert.AreEqual(100, cart.LineItems.Get(productId1).Quantity, "variant 20756129155 Quantity is 100 after change");
+            Assert.AreEqual(6, cart.LineItems.Get(productId2).Quantity, "variant 20756129155 Quantity is 100 after change");
+            Assert.AreEqual("i am fancy", cart.LineItems.Get(productId1).CustomAttributes["fancy"]);
+            Assert.AreEqual("i am boring", cart.LineItems.Get(productId1).CustomAttributes["boring"]);
+            Assert.AreEqual("lion", cart.LineItems.Get(productId2).CustomAttributes["animal"]);
+            Assert.AreEqual("no", cart.LineItems.Get(productId2).CustomAttributes["spotted"]);
         }
 
         [Test]
@@ -212,12 +213,12 @@ namespace Shopify.Tests
             cart.LineItems.AddOrUpdate(product, selectedOptions1, 3);
             cart.LineItems.AddOrUpdate(product, selectedOptions2, 123);
 
-            Assert.AreEqual(3, cart.LineItems.Get(product, selectedOptions1).quantity, "was able to set using selected options");
-            Assert.AreEqual(123, cart.LineItems.Get(product, selectedOptions2).quantity, "was able to set using selected options");
+            Assert.AreEqual(3, cart.LineItems.Get(product, selectedOptions1).Quantity, "was able to set using selected options");
+            Assert.AreEqual(123, cart.LineItems.Get(product, selectedOptions2).Quantity, "was able to set using selected options");
 
             cart.LineItems.AddOrUpdate(product, selectedOptions1, 13);
 
-            Assert.AreEqual(13, cart.LineItems.Get(product, selectedOptions1).quantity, "was able to reset using selected options");
+            Assert.AreEqual(13, cart.LineItems.Get(product, selectedOptions1).Quantity, "was able to reset using selected options");
 
             Assert.IsTrue(cart.LineItems.Delete(product, selectedOptions1), "returned true when line item was deleted");
             Assert.IsFalse(cart.LineItems.Delete(product, selectedOptions3), "returned false when no line item existed");

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -55,6 +55,29 @@ namespace Shopify.Tests
             Assert.IsFalse(didDelete, "returned false when did not delete");
         }
 
+        public void TestCastingLineItems() {
+            ShopifyBuy.Init(new MockLoader());
+
+            Cart cart = ShopifyBuy.Client().Cart();
+            string variandId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+
+            cart.LineItems.AddOrUpdate(variandId, 33, new Dictionary<string, string>() {
+                {"fun", "things"}
+            });
+
+            CheckoutLineItemInput input = (CheckoutLineItemInput) cart.LineItems.Get(variandId);
+            CheckoutLineItemUpdateInput updateInput = (CheckoutLineItemUpdateInput) cart.LineItems.Get(variandId);
+
+            Assert.IsNotNull(input);
+            Assert.IsNotNull(updateInput);
+            Assert.IsNotNull(input.customAttributes);
+            Assert.IsNotNull(updateInput.customAttributes);
+            Assert.AreEqual("fun", input.customAttributes[0].key);
+            Assert.AreEqual("fun", updateInput.customAttributes[0].key);
+            Assert.AreEqual("things", input.customAttributes[0].value);
+            Assert.AreEqual("things", updateInput.customAttributes[0].value);
+        }
+
         [Test]
         public void TestPermalink() {
             ShopifyBuy.Init(new MockLoader());

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -81,10 +81,9 @@ namespace Shopify.Tests
         }
 
         [Test]
-        public void TestModifyingCustomAttributesErrors() {
+        public void TestModifyingCustomAttributesMadeLineNotBeSaved() {
             ShopifyBuy.Init(new MockLoader());
 
-            NotSupportedException exception = null;
             Cart cart = ShopifyBuy.Client().Cart();
             string variandId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
 
@@ -92,13 +91,15 @@ namespace Shopify.Tests
                 {"fun", "things"}
             });
 
-            try {
-                cart.LineItems.Get(variandId).CustomAttributes["fun"] = "nope";
-            } catch(NotSupportedException e) {
-                exception = e;
-            }
+            Assert.IsFalse(cart.LineItems.Get(variandId).IsSaved, "initially is not saved");
 
-            Assert.IsNotNull(exception, "Threw an expection when trying to modify CustomAttributes directly");
+            cart.LineItems.Get(variandId).GetCheckoutLineItemUpdateInput();
+
+            Assert.IsTrue(cart.LineItems.Get(variandId).IsSaved, "after get input is saved");
+
+            cart.LineItems.Get(variandId).CustomAttributes["fun"] = "stuff";
+
+            Assert.IsFalse(cart.LineItems.Get(variandId).IsSaved, "after change is not saved");
         }
 
         [Test]

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -1,5 +1,6 @@
 namespace Shopify.Tests
 {
+    using System;
     using System.Collections.Generic;
     using NUnit.Framework;
     using Shopify.Unity;
@@ -55,6 +56,7 @@ namespace Shopify.Tests
             Assert.IsFalse(didDelete, "returned false when did not delete");
         }
 
+        [Test]
         public void TestCastingLineItems() {
             ShopifyBuy.Init(new MockLoader());
 
@@ -76,6 +78,27 @@ namespace Shopify.Tests
             Assert.AreEqual("fun", updateInput.customAttributes[0].key);
             Assert.AreEqual("things", input.customAttributes[0].value);
             Assert.AreEqual("things", updateInput.customAttributes[0].value);
+        }
+
+        [Test]
+        public void TestModifyingCustomAttributesErrors() {
+            ShopifyBuy.Init(new MockLoader());
+
+            NotSupportedException exception = null;
+            Cart cart = ShopifyBuy.Client().Cart();
+            string variandId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+
+            cart.LineItems.AddOrUpdate(variandId, 33, new Dictionary<string, string>() {
+                {"fun", "things"}
+            });
+
+            try {
+                cart.LineItems.Get(variandId).CustomAttributes["fun"] = "nope";
+            } catch(NotSupportedException e) {
+                exception = e;
+            }
+
+            Assert.IsNotNull(exception, "Threw an expection when trying to modify CustomAttributes directly");
         }
 
         [Test]

--- a/Assets/Shopify/examples.txt.meta
+++ b/Assets/Shopify/examples.txt.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c506dabb6ea2a47bf829c8a418353319
-timeCreated: 1492698964
-licenseType: Free
-TextScriptImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -91,6 +91,7 @@ module GraphQLGenerator
         SDK/InputBase
         SDK/InputValueToString
         SDK/CastUtils
+        SDK/CartLineItems
         SDK/ValidationUtils
         SDK/AbstractResponse
         SDK/NoQueryException

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -95,6 +95,7 @@ module GraphQLGenerator
         SDK/ValidationUtils
         SDK/AbstractResponse
         SDK/NoQueryException
+        SDK/ObservableDictionary
         SDK/AliasException
         SDK/InvalidServerResponseException
         SDK/DefaultQueries

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -14,266 +14,6 @@ namespace <%= namespace %> {
     }
 
     /// <summary>
-    /// Is used to add, update, or delete line items in a <see ref="Cart">Cart </see>.
-    /// </summary>
-    public class CartLineItems {
-        private List<CheckoutLineItemInput> LineItems = new List<CheckoutLineItemInput>();
-
-        /// <summary>
-        /// Adds or updates an existing line item using a variant id.
-        /// </summary>
-        /// <param name="variantId">variant id for a <see ref="ProductVariant">ProductVariant </see></param>
-        /// <param name="quantity">the number of items you'd like to order for variantId</param>
-        /// <param name="customAttributes">can be used to define extra information for this line item</param>
-        /// \code
-        /// // Example that updates the quantity of items to be purchased to 3.
-        /// // If no line item exists for `variantId`, then a new line item is created
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// cart.LineItems.AddOrUpdate(variantId, 3);
-        /// \endcode
-        public void AddOrUpdate(string variantId, long? quantity = null, List<AttributeInput> customAttributes = null) {
-            CheckoutLineItemInput input = Get(variantId);
-
-            if (input != null) {
-                if (quantity != null) {
-                    input.quantity = (long) quantity;
-                }
-
-                if (customAttributes != null) {
-                    input.customAttributes = customAttributes;
-                }
-            } else {
-                if (quantity == null) {
-                    quantity = 1;
-                }
-
-                LineItems.Add(
-                  new CheckoutLineItemInput(
-                    variantId: variantId,
-                    quantity: (long) quantity,
-                    customAttributes: customAttributes
-                  )
-                );
-            }
-        }
-
-        /// <summary>
-        /// Adds or updates a line item using a <see ref="ProductVariant">ProductVariant </see>.
-        /// </summary>
-        /// <param name="variant"><see ref="ProductVariant">ProductVariant </see> whose id will be used to create or update a line item</param>
-        /// <param name="quantity">the number of items you'd like to order for variantId</param>
-        /// <param name="customAttributes">can be used to define extra information for this line item</param>
-        /// \code
-        /// // Example that updates the quantity of items to be purchased to 3.
-        /// // If no line item exists for `variantId`, then a new line item is created
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// cart.LineItems.AddOrUpdate(variant, 3);
-        /// \endcode
-        public void AddOrUpdate(ProductVariant variant, long? quantity = null, List<AttributeInput> customAttributes = null) {
-            AddOrUpdate(variant.id(), quantity, customAttributes);
-        }
-
-        /// <summary>
-        /// Adds a new line item using a <see ref="Product">Product </see> and selected options. If an existing line item exists for the
-        /// variant id, then that line item will be updated.
-        /// </summary>
-        /// <param name="product">product to check selected options against</param>
-        /// <param name="selectedOptions">a Dictionary used to define user selected options</param>
-        /// <param name="quantity">the number of items you'd like to order for variantId</param>
-        /// <param name="customAttributes">customAttributes can be used to define extra information for this line item</param>
-        /// <exception ref="NoMatchingVariantException">Throws when no matching variant could be found for selected options in product</exception>
-        /// \code
-        /// // Example that updates the quantity of items to be purchased to 3.
-        /// // If no line item exists for `variantId`, then a new line item is created
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Dictionary<string, string> selectedOptions = new Dictionary<string, string>() {
-        ///     {"Size", "Small"},
-        ///     {"Color", "Red"}
-        /// };
-        ///
-        /// cart.LineItems.AddOrUpdate(product, selectedOptions, 3);
-        /// \endcode
-        public void AddOrUpdate(Product product, Dictionary<string, string> selectedOptions, long? quantity = null, List<AttributeInput> customAttributes = null) {
-            string variantId = VariantIdFromSelectedOptions(product, selectedOptions);
-
-            if (variantId == null) {
-                throw new NoMatchingVariantException("Could not `AddOrUpdate` line item as no matching variant could be found for selected options");
-            }
-
-            AddOrUpdate(variantId, quantity, customAttributes);
-        }
-
-        /// <summary>
-        /// Returns all <see ref="CheckoutLineItemInput">Line Items </see> that have been created.
-        /// </summary>
-        /// \code
-        /// // Example that checks how many line items the cart contains
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Debug.Log("The cart has " + cart.LineItems.All().Count + " line items");
-        /// \endcode
-        public List<CheckoutLineItemInput> All() {
-            return LineItems;
-        }
-
-        /// <summary>
-        /// Returns one <see ref="CheckoutLineItemInput">Line Item </see> based on a variant id. If no line item exists for the variant id
-        /// <c>null</c> will be returned.
-        /// </summary>
-        /// <param name="variantId">variant id used to create a line item</param>
-        /// \code
-        /// // Example that checks the quantity of a line item based on variantId
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Debug.Log(cart.LineItems.Get(variantId).quantity);
-        /// \endcode
-        public CheckoutLineItemInput Get(string variantId) {
-            return LineItems.Find(item => item.variantId == variantId);
-        }
-
-        /// <summary>
-        /// Returns one <see ref="CheckoutLineItemInput">Line Item </see> based on a <see ref="ProductVariant">ProductVariant </see>. If no line item
-        /// exists for the variant, <c>null</c> will be returned.
-        /// </summary>
-        /// <param name="variant">variant whose variant id used to create a line item</param>
-        /// \code
-        /// // Example that checks the quantity of a line item based on a variant
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Debug.Log(cart.LineItems.Get(variant).quantity);
-        /// \endcode
-        public CheckoutLineItemInput Get(ProductVariant variant) {
-            return Get(variant.id());
-        }
-
-        /// <summary>
-        /// Returns one <see ref="CheckoutLineItemInput">Line Item </see> based on a <see ref="Product">product </see> and selected options.
-        /// If no line item exists for the matching variant, <c>null</c> will be returned.
-        /// </summary>
-        /// <param name="product">product whose options will be selected</param>
-        /// <param name="selectedOptions">a Dictionary used to define user selected options</param>
-        /// \code
-        /// // Example that checks the quantity of a line item based on a product and selected options
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Dictionary<string, string> selectedOptions = new Dictionary<string, string>() {
-        ///     {"Size", "Small"},
-        ///     {"Color", "Red"}
-        /// };
-        ///
-        /// Debug.Log(cart.LineItems.Get(product, selectedOptions).quantity);
-        /// \endcode
-        public CheckoutLineItemInput Get(Product product, Dictionary<string, string> selectedOptions) {
-            string variantId = VariantIdFromSelectedOptions(product, selectedOptions);
-
-            if (variantId == null) {
-                return null;
-            }
-
-            return Get(variantId);
-        }
-
-        /// <summary>
-        /// Deletes one <see ref="CheckoutLineItemInput">Line Item </see> based on a variant id. If a line item was deleted, <c>true</c>
-        /// will be returned. If no line items were deleted, <c>false</c> will be returned.
-        /// </summary>
-        /// <param name="variantId">variant id used to delete a line item</param>
-        /// \code
-        /// // Example that deletes a line item based on variantId
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Debug.Log("Did delete? " + cart.LineItems.Delete(variantId));
-        /// \endcode
-        public bool Delete(string variantId) {
-            int idxToDelete = LineItems.FindIndex(lineItem => lineItem.variantId == variantId);
-
-            if (idxToDelete == -1) {
-                return false;
-            } else {
-                LineItems.RemoveAt(idxToDelete);
-
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Deletes one <see ref="CheckoutLineItemInput">Line Item </see> based on a <see ref="ProductVariant">ProductVariant </see>. If a line
-        /// item was deleted, <c>true</c> will be returned. If no line items were deleted, <c>false</c> will be returned.
-        /// </summary>
-        /// <param name="variant"><see ref="ProductVariant">variant </see> to provide the ID to delete a line item</param>
-        /// \code
-        /// // Example that deletes a line item based on a product variant
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Debug.Log("Did delete? " + cart.LineItems.Delete(variant));
-        /// \endcode
-        public bool Delete(ProductVariant variant) {
-            return Delete(variant.id());
-        }
-
-        /// <summary>
-        /// Deletes one <see ref="CheckoutLineItemInput">Line Item </see> based on a <see ref="Product">Product </see> and selected options.
-        /// If a line item was deleted, <c>true</c> will be returned. If no line item was deleted, <c>false</c> will be returned.
-        /// </summary>
-        /// <param name="product"><see ref="Product">product </see> whose options will be used to determine which line item is deleted</param>
-        /// <param name="selectedOptions">a Dictionary used to define user selected options</param>
-        /// \code
-        /// // Example that deletes a line item based on a product and selected options
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// Dictionary<string, string> selectedOptions = new Dictionary<string, string>() {
-        ///     {"Size", "Small"},
-        ///     {"Color", "Red"}
-        /// };
-        ///
-        /// Debug.Log("Did delete? " + cart.LineItems.Delete(product, selectedOptions));
-        /// \endcode
-        public bool Delete(Product product, Dictionary<string, string> selectedOptions) {
-            string variantId = VariantIdFromSelectedOptions(product, selectedOptions);
-
-            if (variantId == null) {
-                return false;
-            }
-
-            return Delete(variantId);
-        }
-
-        private string VariantIdFromSelectedOptions(Product product, Dictionary<string, string> selectedOptions) {
-            List<ProductVariant> variants = (List<ProductVariant>) product.variants();
-            string variantId = null;
-
-            foreach(ProductVariant variant in variants) {
-                List<SelectedOption> variantSelectedOptions = variant.selectedOptions();
-                variantId = variant.id();
-
-                if (variantSelectedOptions.Count != selectedOptions.Keys.Count) {
-                    variantId = null;
-                } else {
-                    foreach(SelectedOption variantOption in variantSelectedOptions) {
-                        string optionName = variantOption.name();
-                        string optionValue = variantOption.value();
-
-                        if (!selectedOptions.ContainsKey(optionName) || selectedOptions[optionName] != optionValue) {
-                            variantId = null;
-
-                            break;
-                        }
-                    }
-                }
-
-                if (variantId != null) {
-                    break;
-                }
-            }
-
-            return variantId;
-        }
-    }
-
-    /// <summary>
     /// Manages line items for an order. Can also be used to generate a web checkout link to check out in browser.
     /// </summary>
     public class Cart {
@@ -327,7 +67,7 @@ namespace <%= namespace %> {
             url.Append(Client.Domain);
             url.Append("/cart/");
 
-            foreach(CheckoutLineItemInput lineItem in LineItems.All()) {
+            foreach(CartLineItem lineItem in LineItems.All()) {
                 if (hasLineItem) {
                     url.Append(",");
                 }
@@ -335,7 +75,7 @@ namespace <%= namespace %> {
                 hasLineItem = true;
 
                 string variantId = System.Text.Encoding.UTF8.GetString(
-                    Convert.FromBase64String(lineItem.variantId)
+                    Convert.FromBase64String(lineItem.VariantId)
                 );
 
                 // convert from variant gid to variant id
@@ -343,7 +83,7 @@ namespace <%= namespace %> {
 
                 url.Append(variandIdSplit[variandIdSplit.Length - 1]);
                 url.Append(":");
-                url.Append(lineItem.quantity);
+                url.Append(lineItem.Quantity);
             }
 
             url.Append("?access_token=");

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -1,0 +1,312 @@
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections.Generic;
+
+    public class CartLineItem {
+        public bool IsSaved {
+            get {
+                return _IsSaved;
+            }
+        }
+
+        public string VariantId {
+            get {
+                return _VariantId;
+            }
+        }
+
+        public long Quantity {
+            get {
+                return _Quantity;
+            }
+
+            set {
+                _IsSaved = false;
+                _Quantity = value;
+            }
+        }
+
+        public Dictionary<string, string> CustomAttributes {
+            get {
+                return _CustomAttributes;
+            }
+
+            set {
+                _IsSaved = false;
+                _CustomAttributes = value;
+            }
+        }
+
+        public string ID = null;
+        private bool _IsSaved;
+        private string _VariantId;
+        private long _Quantity;
+        private Dictionary<string, string> _CustomAttributes;
+        
+        public CartLineItem(string variantId, long quantity = 1, Dictionary<string, string> customAttributes = null) {
+            _VariantId = variantId;
+            _Quantity = quantity;
+            _CustomAttributes = customAttributes;
+        }
+    }
+
+    /// <summary>
+    /// Is used to add, update, or delete line items in a <see ref="Cart">Cart </see>.
+    /// </summary>
+    public class CartLineItems {
+        private List<CartLineItem> LineItems = new List<CartLineItem>();
+
+        /// <summary>
+        /// Adds or updates an existing line item using a variant id.
+        /// </summary>
+        /// <param name="variantId">variant id for a <see ref="ProductVariant">ProductVariant </see></param>
+        /// <param name="quantity">the number of items you'd like to order for variantId</param>
+        /// <param name="customAttributes">can be used to define extra information for this line item</param>
+        /// \code
+        /// // Example that updates the quantity of items to be purchased to 3.
+        /// // If no line item exists for `variantId`, then a new line item is created
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// cart.LineItems.AddOrUpdate(variantId, 3);
+        /// \endcode
+        public void AddOrUpdate(string variantId, long? quantity = null, Dictionary<string, string> customAttributes = null) {
+            CartLineItem input = Get(variantId);
+
+            if (input != null) {
+                if (quantity != null) {
+                    input.Quantity = (long) quantity;
+                }
+
+                if (customAttributes != null) {
+                    input.CustomAttributes = customAttributes;
+                }
+            } else {
+                if (quantity == null) {
+                    quantity = 1;
+                }
+
+                LineItems.Add(
+                    new CartLineItem(
+                        variantId: variantId,
+                        quantity: (long) quantity,
+                        customAttributes: customAttributes
+                    )
+                );
+            }
+        }
+
+        /// <summary>
+        /// Adds or updates a line item using a <see ref="ProductVariant">ProductVariant </see>.
+        /// </summary>
+        /// <param name="variant"><see ref="ProductVariant">ProductVariant </see> whose id will be used to create or update a line item</param>
+        /// <param name="quantity">the number of items you'd like to order for variantId</param>
+        /// <param name="customAttributes">can be used to define extra information for this line item</param>
+        /// \code
+        /// // Example that updates the quantity of items to be purchased to 3.
+        /// // If no line item exists for `variantId`, then a new line item is created
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// cart.LineItems.AddOrUpdate(variant, 3);
+        /// \endcode
+        public void AddOrUpdate(ProductVariant variant, long? quantity = null, Dictionary<string, string> customAttributes = null) {
+            AddOrUpdate(variant.id(), quantity, customAttributes);
+        }
+
+        /// <summary>
+        /// Adds a new line item using a <see ref="Product">Product </see> and selected options. If an existing line item exists for the
+        /// variant id, then that line item will be updated.
+        /// </summary>
+        /// <param name="product">product to check selected options against</param>
+        /// <param name="selectedOptions">a Dictionary used to define user selected options</param>
+        /// <param name="quantity">the number of items you'd like to order for variantId</param>
+        /// <param name="customAttributes">customAttributes can be used to define extra information for this line item</param>
+        /// <exception ref="NoMatchingVariantException">Throws when no matching variant could be found for selected options in product</exception>
+        /// \code
+        /// // Example that updates the quantity of items to be purchased to 3.
+        /// // If no line item exists for `variantId`, then a new line item is created
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Dictionary<string, string> selectedOptions = new Dictionary<string, string>() {
+        ///     {"Size", "Small"},
+        ///     {"Color", "Red"}
+        /// };
+        ///
+        /// cart.LineItems.AddOrUpdate(product, selectedOptions, 3);
+        /// \endcode
+        public void AddOrUpdate(Product product, Dictionary<string, string> selectedOptions, long? quantity = null, Dictionary<string, string> customAttributes = null) {
+            string variantId = VariantIdFromSelectedOptions(product, selectedOptions);
+
+            if (variantId == null) {
+                throw new NoMatchingVariantException("Could not `AddOrUpdate` line item as no matching variant could be found for selected options");
+            }
+
+            AddOrUpdate(variantId, quantity, customAttributes);
+        }
+
+        /// <summary>
+        /// Returns all <see ref="CartLineItem">Line Items </see> that have been created.
+        /// </summary>
+        /// \code
+        /// // Example that checks how many line items the cart contains
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Debug.Log("The cart has " + cart.LineItems.All().Count + " line items");
+        /// \endcode
+        public List<CartLineItem> All() {
+            return LineItems;
+        }
+
+        /// <summary>
+        /// Returns one <see ref="CartLineItem">Line Item </see> based on a variant id. If no line item exists for the variant id
+        /// <c>null</c> will be returned.
+        /// </summary>
+        /// <param name="variantId">variant id used to create a line item</param>
+        /// \code
+        /// // Example that checks the quantity of a line item based on variantId
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Debug.Log(cart.LineItems.Get(variantId).quantity);
+        /// \endcode
+        public CartLineItem Get(string variantId) {
+            return LineItems.Find(item => item.VariantId == variantId);
+        }
+
+        /// <summary>
+        /// Returns one <see ref="CartLineItem">Line Item </see> based on a <see ref="ProductVariant">ProductVariant </see>. If no line item
+        /// exists for the variant, <c>null</c> will be returned.
+        /// </summary>
+        /// <param name="variant">variant whose variant id used to create a line item</param>
+        /// \code
+        /// // Example that checks the quantity of a line item based on a variant
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Debug.Log(cart.LineItems.Get(variant).quantity);
+        /// \endcode
+        public CartLineItem Get(ProductVariant variant) {
+            return Get(variant.id());
+        }
+
+        /// <summary>
+        /// Returns one <see ref="CartLineItem">Line Item </see> based on a <see ref="Product">product </see> and selected options.
+        /// If no line item exists for the matching variant, <c>null</c> will be returned.
+        /// </summary>
+        /// <param name="product">product whose options will be selected</param>
+        /// <param name="selectedOptions">a Dictionary used to define user selected options</param>
+        /// \code
+        /// // Example that checks the quantity of a line item based on a product and selected options
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Dictionary<string, string> selectedOptions = new Dictionary<string, string>() {
+        ///     {"Size", "Small"},
+        ///     {"Color", "Red"}
+        /// };
+        ///
+        /// Debug.Log(cart.LineItems.Get(product, selectedOptions).quantity);
+        /// \endcode
+        public CartLineItem Get(Product product, Dictionary<string, string> selectedOptions) {
+            string variantId = VariantIdFromSelectedOptions(product, selectedOptions);
+
+            if (variantId == null) {
+                return null;
+            }
+
+            return Get(variantId);
+        }
+
+        /// <summary>
+        /// Deletes one <see ref="CartLineItem">Line Item </see> based on a variant id. If a line item was deleted, <c>true</c>
+        /// will be returned. If no line items were deleted, <c>false</c> will be returned.
+        /// </summary>
+        /// <param name="variantId">variant id used to delete a line item</param>
+        /// \code
+        /// // Example that deletes a line item based on variantId
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Debug.Log("Did delete? " + cart.LineItems.Delete(variantId));
+        /// \endcode
+        public bool Delete(string variantId) {
+            int idxToDelete = LineItems.FindIndex(lineItem => lineItem.VariantId == variantId);
+
+            if (idxToDelete == -1) {
+                return false;
+            } else {
+                LineItems.RemoveAt(idxToDelete);
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Deletes one <see ref="CartLineItem">Line Item </see> based on a <see ref="ProductVariant">ProductVariant </see>. If a line
+        /// item was deleted, <c>true</c> will be returned. If no line items were deleted, <c>false</c> will be returned.
+        /// </summary>
+        /// <param name="variant"><see ref="ProductVariant">variant </see> to provide the ID to delete a line item</param>
+        /// \code
+        /// // Example that deletes a line item based on a product variant
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Debug.Log("Did delete? " + cart.LineItems.Delete(variant));
+        /// \endcode
+        public bool Delete(ProductVariant variant) {
+            return Delete(variant.id());
+        }
+
+        /// <summary>
+        /// Deletes one <see ref="CartLineItem">Line Item </see> based on a <see ref="Product">Product </see> and selected options.
+        /// If a line item was deleted, <c>true</c> will be returned. If no line item was deleted, <c>false</c> will be returned.
+        /// </summary>
+        /// <param name="product"><see ref="Product">product </see> whose options will be used to determine which line item is deleted</param>
+        /// <param name="selectedOptions">a Dictionary used to define user selected options</param>
+        /// \code
+        /// // Example that deletes a line item based on a product and selected options
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// Dictionary<string, string> selectedOptions = new Dictionary<string, string>() {
+        ///     {"Size", "Small"},
+        ///     {"Color", "Red"}
+        /// };
+        ///
+        /// Debug.Log("Did delete? " + cart.LineItems.Delete(product, selectedOptions));
+        /// \endcode
+        public bool Delete(Product product, Dictionary<string, string> selectedOptions) {
+            string variantId = VariantIdFromSelectedOptions(product, selectedOptions);
+
+            if (variantId == null) {
+                return false;
+            }
+
+            return Delete(variantId);
+        }
+
+        private string VariantIdFromSelectedOptions(Product product, Dictionary<string, string> selectedOptions) {
+            List<ProductVariant> variants = (List<ProductVariant>) product.variants();
+            string variantId = null;
+
+            foreach(ProductVariant variant in variants) {
+                List<SelectedOption> variantSelectedOptions = variant.selectedOptions();
+                variantId = variant.id();
+
+                if (variantSelectedOptions.Count != selectedOptions.Keys.Count) {
+                    variantId = null;
+                } else {
+                    foreach(SelectedOption variantOption in variantSelectedOptions) {
+                        string optionName = variantOption.name();
+                        string optionValue = variantOption.value();
+
+                        if (!selectedOptions.ContainsKey(optionName) || selectedOptions[optionName] != optionValue) {
+                            variantId = null;
+
+                            break;
+                        }
+                    }
+                }
+
+                if (variantId != null) {
+                    break;
+                }
+            }
+
+            return variantId;
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -3,6 +3,14 @@ namespace <%= namespace %>.SDK {
     using System.Collections.Generic;
 
     public class CartLineItem {
+        public static explicit operator CheckoutLineItemInput(CartLineItem lineItem) {
+            return lineItem.GetCheckoutLineItemInput();
+        }
+
+        public static explicit operator CheckoutLineItemUpdateInput(CartLineItem lineItem) {
+            return lineItem.GetCheckoutLineItemUpdateInput();
+        }
+
         public bool IsSaved {
             get {
                 return _IsSaved;
@@ -47,6 +55,40 @@ namespace <%= namespace %>.SDK {
             _VariantId = variantId;
             _Quantity = quantity;
             _CustomAttributes = customAttributes;
+        }
+
+        public CheckoutLineItemInput GetCheckoutLineItemInput() {
+            return new CheckoutLineItemInput(
+                quantity: Quantity,
+                variantId: VariantId,
+                customAttributes: GetAttributeInputs()
+            );
+        }
+
+        public CheckoutLineItemUpdateInput GetCheckoutLineItemUpdateInput() {
+            return new CheckoutLineItemUpdateInput(
+                id: ID,
+                quantity: Quantity,
+                variantId: VariantId,
+                customAttributes: GetAttributeInputs()
+            );
+        }
+
+        private List<AttributeInput> GetAttributeInputs() {
+            List<AttributeInput> attributes = null;
+
+            if (CustomAttributes != null) {
+                attributes = new List<AttributeInput>();
+
+                foreach(string key in CustomAttributes.Keys) {
+                    attributes.Add(new AttributeInput(
+                        key: key,
+                        value: CustomAttributes[key]
+                    ));
+                }
+            }
+
+            return attributes;
         }
     }
 

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -333,11 +333,10 @@ namespace <%= namespace %>.SDK {
 
             foreach(ProductVariant variant in variants) {
                 List<SelectedOption> variantSelectedOptions = variant.selectedOptions();
-                variantId = variant.id();
 
-                if (variantSelectedOptions.Count != selectedOptions.Keys.Count) {
-                    variantId = null;
-                } else {
+                if (variantSelectedOptions.Count == selectedOptions.Keys.Count) {
+                    variantId = variant.id();
+
                     foreach(SelectedOption variantOption in variantSelectedOptions) {
                         string optionName = variantOption.name();
                         string optionValue = variantOption.value();

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -1,6 +1,7 @@
 namespace <%= namespace %>.SDK {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
 
     public class CartLineItem {
         public static explicit operator CheckoutLineItemInput(CartLineItem lineItem) {
@@ -34,14 +35,17 @@ namespace <%= namespace %>.SDK {
             }
         }
 
-        public Dictionary<string, string> CustomAttributes {
+        public IDictionary<string, string> CustomAttributes {
             get {
                 return _CustomAttributes;
             }
 
             set {
                 _IsSaved = false;
-                _CustomAttributes = value;
+
+                if (value != null) {
+                    _CustomAttributes = new ReadOnlyDictionary<string, string>(value);
+                }
             }
         }
 
@@ -49,12 +53,15 @@ namespace <%= namespace %>.SDK {
         private bool _IsSaved;
         private string _VariantId;
         private long _Quantity;
-        private Dictionary<string, string> _CustomAttributes;
+        private ReadOnlyDictionary<string, string> _CustomAttributes;
         
-        public CartLineItem(string variantId, long quantity = 1, Dictionary<string, string> customAttributes = null) {
+        public CartLineItem(string variantId, long quantity = 1, IDictionary<string, string> customAttributes = null) {
             _VariantId = variantId;
             _Quantity = quantity;
-            _CustomAttributes = customAttributes;
+
+            if (customAttributes != null) {
+                _CustomAttributes = new ReadOnlyDictionary<string, string>(customAttributes);
+            }
         }
 
         public CheckoutLineItemInput GetCheckoutLineItemInput() {

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -44,7 +44,7 @@ namespace <%= namespace %>.SDK {
                 _IsSaved = false;
 
                 if (value != null) {
-                    _CustomAttributes = new ReadOnlyDictionary<string, string>(value);
+                    _CustomAttributes = new ObservableDictionary<string, string>(value, OnCustomAttributesChange);
                 }
             }
         }
@@ -53,18 +53,20 @@ namespace <%= namespace %>.SDK {
         private bool _IsSaved;
         private string _VariantId;
         private long _Quantity;
-        private ReadOnlyDictionary<string, string> _CustomAttributes;
+        private ObservableDictionary<string, string> _CustomAttributes;
         
         public CartLineItem(string variantId, long quantity = 1, IDictionary<string, string> customAttributes = null) {
             _VariantId = variantId;
             _Quantity = quantity;
 
             if (customAttributes != null) {
-                _CustomAttributes = new ReadOnlyDictionary<string, string>(customAttributes);
+                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, OnCustomAttributesChange);
             }
         }
 
         public CheckoutLineItemInput GetCheckoutLineItemInput() {
+            _IsSaved = true;
+
             return new CheckoutLineItemInput(
                 quantity: Quantity,
                 variantId: VariantId,
@@ -73,6 +75,8 @@ namespace <%= namespace %>.SDK {
         }
 
         public CheckoutLineItemUpdateInput GetCheckoutLineItemUpdateInput() {
+            _IsSaved = true;
+
             return new CheckoutLineItemUpdateInput(
                 id: ID,
                 quantity: Quantity,
@@ -96,6 +100,10 @@ namespace <%= namespace %>.SDK {
             }
 
             return attributes;
+        }
+
+        private void OnCustomAttributesChange() {
+            _IsSaved = false;
         }
     }
 

--- a/scripts/generator/graphql_generator/csharp/SDK/ObservableDictionary.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ObservableDictionary.cs.erb
@@ -1,0 +1,119 @@
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public delegate void DictionaryChangeHandler();
+
+    public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue> {
+        private IDictionary<TKey, TValue> Data;
+        private DictionaryChangeHandler OnDictionaryChange;
+
+        public ObservableDictionary(DictionaryChangeHandler onDictionaryChange) {
+            Data = new Dictionary<TKey, TValue>();
+            OnDictionaryChange = onDictionaryChange;
+        }
+
+        public ObservableDictionary(IDictionary<TKey, TValue> data, DictionaryChangeHandler onDictionaryChange) {
+            Data = data;
+            OnDictionaryChange = onDictionaryChange;
+        }
+
+        public TValue this[TKey key] {
+            get {
+                if (Data.ContainsKey(key)) {
+                    return (TValue) Data[key];
+                } else {
+                    throw new KeyNotFoundException();
+                }
+            }
+            set {
+                Data[key] = value;
+
+                OnDictionaryChange();
+            }
+        }
+
+        public int Count {
+            get {
+                return Data.Count;
+            }
+        }
+
+        public bool IsReadOnly {
+            get {
+                return Data.IsReadOnly;
+            }
+        }
+
+        public ICollection<TKey> Keys {
+            get {
+                return Data.Keys;
+            }
+        }
+
+
+        public ICollection<TValue> Values {
+            get {
+                return Data.Values;
+            }
+        }
+        
+        public bool ContainsKey(TKey key) {
+            return Data.ContainsKey(key);
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> entry) {
+            return Data.ContainsKey(entry.Key) && EqualityComparer<TValue>.Default.Equals(Data[entry.Key], entry.Value);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value) {
+            return Data.TryGetValue(key, out value);
+        }
+
+        public void Add(TKey key, TValue value) {
+            Data.Add(key, value);
+
+            OnDictionaryChange();
+        }
+
+        public void Add(KeyValuePair<TKey,TValue> entry) {
+            Add(entry.Key, entry.Value);
+        }
+
+        public bool Remove(TKey key) {
+            bool shouldRemove = ContainsKey(key);
+            
+            if (shouldRemove) {
+                TValue value = Data[key];
+                Data.Remove(key);
+
+                OnDictionaryChange();
+            }
+            
+            return shouldRemove;
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> entry) {
+            return Remove(entry.Key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) {
+            Data.CopyTo(array, index);
+        }
+
+        public void Clear() {
+            Data.Clear();
+
+            OnDictionaryChange();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return Data.GetEnumerator();
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() {
+            return ((IEnumerable<KeyValuePair<TKey, TValue>>) Data).GetEnumerator();
+        }
+    }
+}

--- a/scripts/test_unity.sh
+++ b/scripts/test_unity.sh
@@ -20,6 +20,7 @@ $UNITY_PATH \
     -logFile $UNITY_LOG_PATH \
     -projectPath $PROJECT_ROOT \
     -runEditorTests \
+    -buildTarget osx \
     -quit
 
 if [ $? = 0 ] ; then

--- a/scripts/test_unity.sh
+++ b/scripts/test_unity.sh
@@ -8,7 +8,7 @@ which $UNITY_PATH &> /dev/null || die "Unity does not exist at $UNITY_PATH"
 
 convertNUnitToJUnit() {
     if [ ! -z "${UNITY_CIRCLE_XML_OUT_PATH}" ]; then
-        mkdir $UNITY_CIRCLE_XML_PATH
+        mkdir $UNITY_CIRCLE_XML_DIR
         xsltproc -o $UNITY_CIRCLE_XML_OUT_PATH $SCRIPTS_ROOT/nunit-to-junit.xsl EditorTestResults.xml
     fi
 }
@@ -33,7 +33,7 @@ else
     echo "------------------\n\n"
     if [ -e "EditorTestResults.xml" ]; then
         cat EditorTestResults.xml
-       convertNUnitToJUnit
+        convertNUnitToJUnit
     else
         cat $UNITY_LOG_PATH 
     fi

--- a/scripts/test_unity.sh
+++ b/scripts/test_unity.sh
@@ -3,13 +3,14 @@
 . $(dirname $0)/common.sh
 
 UNITY_LOG_PATH=$PROJECT_ROOT/test.log
+UNITY_TEST_RESULTS_PATH=$PROJECT_ROOT/EditorTestResults.xml
 
 which $UNITY_PATH &> /dev/null || die "Unity does not exist at $UNITY_PATH" 
 
 convertNUnitToJUnit() {
     if [ ! -z "${UNITY_CIRCLE_XML_OUT_PATH}" ]; then
         mkdir $UNITY_CIRCLE_XML_DIR
-        xsltproc -o $UNITY_CIRCLE_XML_OUT_PATH $SCRIPTS_ROOT/nunit-to-junit.xsl EditorTestResults.xml
+        xsltproc -o $UNITY_CIRCLE_XML_OUT_PATH $SCRIPTS_ROOT/nunit-to-junit.xsl $UNITY_TEST_RESULTS_PATH
     fi
 }
 
@@ -19,6 +20,7 @@ $UNITY_PATH \
     -silent-crashes \
     -logFile $UNITY_LOG_PATH \
     -projectPath $PROJECT_ROOT \
+    -editorTestsResultFile EditorTestResults.xml \
     -runEditorTests \
     -buildTarget osx \
     -quit
@@ -31,8 +33,8 @@ if [ $? = 0 ] ; then
 else
     echo "Tests failed. Exited with $?"
     echo "------------------\n\n"
-    if [ -e "EditorTestResults.xml" ]; then
-        cat EditorTestResults.xml
+    if [ -e $UNITY_TEST_RESULTS_PATH ]; then
+        cat $UNITY_TEST_RESULTS_PATH
         convertNUnitToJUnit
     else
         cat $UNITY_LOG_PATH 


### PR DESCRIPTION
This PR refactors cart line items to be a new generic type called `CartLineItem` from `CheckoutLineItemInput`.

At one time for checkouts `CheckoutLineItemInput` was the only input type for creating line items but now that we have `CheckoutLineItemUpdateInput` also I felt it's important to have a generic line item type type for the Cart from which we can create `CheckoutLineItemInput's` and `CheckoutLineItemUpdateInput's`.

The saved boolean will be used to determine when updates are done instead of creations.