### PR TITLE
[FEATURE] Added default queries for checkout

### DIFF
--- a/Assets/Editor/TestDefaultQueriesCheckout.cs
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs
@@ -16,7 +16,7 @@ namespace Shopify.Tests
             DefaultQueries.checkout.Create(query, lineItems);
 
             Assert.AreEqual(
-                "mutation{checkoutCreate (input:{lineItems:[]}){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                "mutation{checkoutCreate (input:{lineItems:[]}){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}", 
                 query.ToString()
             );
         }
@@ -43,7 +43,7 @@ namespace Shopify.Tests
             DefaultQueries.checkout.LineItemsAdd(query, checkoutId, lineItems);
 
             Assert.AreEqual(
-                "mutation{checkoutLineItemsAdd (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                "mutation{checkoutLineItemsAdd (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}", 
                 query.ToString()
             );
         }
@@ -57,7 +57,7 @@ namespace Shopify.Tests
             DefaultQueries.checkout.LineItemsRemove(query, checkoutId, lineItemIds);
 
             Assert.AreEqual(
-                "mutation{checkoutLineItemsRemove (checkoutId:\"an-id\",lineItemIds:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                "mutation{checkoutLineItemsRemove (checkoutId:\"an-id\",lineItemIds:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}", 
                 query.ToString()
             );
         }
@@ -71,7 +71,20 @@ namespace Shopify.Tests
             DefaultQueries.checkout.LineItemsUpdate(query, checkoutId, lineItems);
 
             Assert.AreEqual(
-                "mutation{checkoutLineItemsUpdate (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                "mutation{checkoutLineItemsUpdate (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}", 
+                query.ToString()
+            );
+        }
+
+        [Test]
+        public void TestCheckoutLineItemsPage() {
+            QueryRootQuery query = new QueryRootQuery();
+            string checkoutId = "an-id";
+
+            DefaultQueries.checkout.CheckoutLineItemsPage(query, checkoutId, 210, "after-something");
+
+            Assert.AreEqual(
+                "{node (id:\"an-id\"){__typename ...on Checkout{lineItems (first:210,after:\"after-something\"){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}}}", 
                 query.ToString()
             );
         }

--- a/Assets/Editor/TestDefaultQueriesCheckout.cs
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs
@@ -1,0 +1,79 @@
+namespace Shopify.Tests
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Shopify.Unity;
+    using Shopify.Unity.SDK;
+    using Shopify.Unity.GraphQL;
+
+    [TestFixture]
+    public class TestDefaultQueries {
+        [Test]
+        public void TestCheckoutCreate() {
+            MutationQuery query = new MutationQuery();
+            List<CheckoutLineItemInput> lineItems = new List<CheckoutLineItemInput>();
+
+            DefaultQueries.checkout.Create(query, lineItems);
+
+            Assert.AreEqual(
+                "mutation{checkoutCreate (input:{lineItems:[]}){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                query.ToString()
+            );
+        }
+
+        [Test]
+        public void TestCheckoutPoll() {
+            QueryRootQuery query = new QueryRootQuery();
+            string checkoutId = "an-id";
+            
+            DefaultQueries.checkout.Poll(query, checkoutId);
+
+            Assert.AreEqual(
+                "{node (id:\"an-id\"){__typename ...on Checkout{id webUrl ready }}}", 
+                query.ToString()
+            );
+        }
+
+        [Test]
+        public void TestCheckoutLineItemsAdd() {
+            MutationQuery query = new MutationQuery();
+            string checkoutId = "an-id";
+            List<CheckoutLineItemInput> lineItems = new List<CheckoutLineItemInput>();
+
+            DefaultQueries.checkout.LineItemsAdd(query, checkoutId, lineItems);
+
+            Assert.AreEqual(
+                "mutation{checkoutLineItemsAdd (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                query.ToString()
+            );
+        }
+
+        [Test]
+        public void TestCheckoutLineItemsRemove() {
+            MutationQuery query = new MutationQuery();
+            string checkoutId = "an-id";
+            List<string> lineItemIds = new List<string>();
+
+            DefaultQueries.checkout.LineItemsRemove(query, checkoutId, lineItemIds);
+
+            Assert.AreEqual(
+                "mutation{checkoutLineItemsRemove (checkoutId:\"an-id\",lineItemIds:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                query.ToString()
+            );
+        }
+
+        [Test]
+        public void TestCheckoutLineItemsUpdate() {
+            MutationQuery query = new MutationQuery();
+            string checkoutId = "an-id";
+            List<CheckoutLineItemUpdateInput> lineItems = new List<CheckoutLineItemUpdateInput>();
+
+            DefaultQueries.checkout.LineItemsUpdate(query, checkoutId, lineItems);
+
+            Assert.AreEqual(
+                "mutation{checkoutLineItemsUpdate (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }}}userErrors {field message }}}", 
+                query.ToString()
+            );
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -101,6 +101,7 @@ module GraphQLGenerator
         SDK/DefaultQueries
         SDK/DefaultQueriesProducts
         SDK/DefaultQueriesCollections
+        SDK/DefaultQueriesCheckout
         SDK/QueryLoader
         SDK/ConnectionLoader
         SDK/UnityLoader

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
@@ -11,6 +11,7 @@ namespace <%= namespace %>.SDK {
 
         public static DefaultProductsQueries products = new DefaultProductsQueries();
         public static DefaultCollectionsQueries collections = new DefaultCollectionsQueries();
+        public static DefaultQueriesCheckout checkout = new DefaultQueriesCheckout();
 
         public static string GetAliasFromIndex(int idx) {
             return String.Format("a{0}", idx);

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
@@ -1,0 +1,112 @@
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections.Generic;
+    using <%= namespace %>.GraphQL;
+
+    public class DefaultQueriesCheckout {
+        public void Create(MutationQuery query, List<CheckoutLineItemInput> lineItems) {
+            query.checkoutCreate(
+                buildQuery: checkoutCreate => checkoutCreate
+                    .checkout(checkout => 
+                        Checkout(checkout)
+                        .lineItems(
+                            buildQuery: li => CheckoutLineItems(li),
+                            first: DefaultQueries.MaxPageSize
+                        )
+                    )
+                    .userErrors(userErrors => userErrors
+                        .field()
+                        .message()
+                    ),
+                input: new CheckoutCreateInput(
+                    lineItems: lineItems
+                )
+            );
+        }
+
+        public void Poll(QueryRootQuery query, string checkoutID) {
+            query.node(
+                buildQuery: node => node
+                    .onCheckout(checkout => Checkout(checkout)),
+                id: checkoutID
+            );
+        }
+
+        public void LineItemsAdd(MutationQuery query, string checkoutID, List<CheckoutLineItemInput> lineItems) {
+            query.checkoutLineItemsAdd(
+                buildQuery: lineItemAdd => lineItemAdd
+                    .checkout(checkout => 
+                        Checkout(checkout)
+                        .lineItems(
+                            buildQuery: li => CheckoutLineItems(li),
+                            first: DefaultQueries.MaxPageSize
+                        )
+                    )
+                    .userErrors(userErrors => userErrors
+                        .field()
+                        .message()
+                    ),
+                checkoutId: checkoutID,
+                lineItems: lineItems
+            );
+        }
+
+        public void LineItemsRemove(MutationQuery query, string checkoutID, List<string> lineItemIds) {
+            query.checkoutLineItemsRemove(
+                buildQuery: lineItemRemove => lineItemRemove
+                    .checkout(checkout => 
+                        Checkout(checkout)
+                        .lineItems(
+                            buildQuery: li => CheckoutLineItems(li),
+                            first: DefaultQueries.MaxPageSize
+                        )
+                    )
+                    .userErrors(userErrors => userErrors
+                        .field()
+                        .message()
+                    ),
+                checkoutId: checkoutID,
+                lineItemIds: lineItemIds
+            );
+        }
+
+        public void LineItemsUpdate(MutationQuery query, string checkoutID, List<CheckoutLineItemUpdateInput> lineItems) {
+            query.checkoutLineItemsUpdate(
+                buildQuery: lineItemUpdate => lineItemUpdate
+                    .checkout(checkout => 
+                        Checkout(checkout)
+                        .lineItems(
+                            buildQuery: li => CheckoutLineItems(li),
+                            first: DefaultQueries.MaxPageSize
+                        )
+                    )
+                    .userErrors(userErrors => userErrors
+                        .field()
+                        .message()
+                    ),
+                checkoutId: checkoutID,
+                lineItems: lineItems
+            );
+        }
+
+        private CheckoutQuery Checkout(CheckoutQuery checkout) {
+            return checkout
+                .id()
+                .webUrl()
+                .ready();
+        }
+
+        private CheckoutLineItemConnectionQuery CheckoutLineItems(CheckoutLineItemConnectionQuery lineItems) {
+            return lineItems
+                .edges(edge => edge
+                    .node(node => node
+                        .id()
+                        .variant(variant => variant
+                            .id()
+                        )
+                    )
+                    .cursor()
+                );
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
@@ -7,13 +7,10 @@ namespace <%= namespace %>.SDK {
         public void Create(MutationQuery query, List<CheckoutLineItemInput> lineItems) {
             query.checkoutCreate(
                 buildQuery: checkoutCreate => checkoutCreate
-                    .checkout(checkout => 
-                        Checkout(checkout)
-                        .lineItems(
-                            buildQuery: li => CheckoutLineItems(li),
-                            first: DefaultQueries.MaxPageSize
-                        )
-                    )
+                    .checkout(checkout => {
+                        Checkout(checkout);
+                        CheckoutLineItems(checkout);
+                    })
                     .userErrors(userErrors => userErrors
                         .field()
                         .message()
@@ -24,68 +21,66 @@ namespace <%= namespace %>.SDK {
             );
         }
 
-        public void Poll(QueryRootQuery query, string checkoutID) {
+        public void Poll(QueryRootQuery query, string checkoutId) {
             query.node(
                 buildQuery: node => node
                     .onCheckout(checkout => Checkout(checkout)),
-                id: checkoutID
+                id: checkoutId
             );
         }
 
-        public void LineItemsAdd(MutationQuery query, string checkoutID, List<CheckoutLineItemInput> lineItems) {
+        public void LineItemsAdd(MutationQuery query, string checkoutId, List<CheckoutLineItemInput> lineItems) {
             query.checkoutLineItemsAdd(
                 buildQuery: lineItemAdd => lineItemAdd
-                    .checkout(checkout => 
-                        Checkout(checkout)
-                        .lineItems(
-                            buildQuery: li => CheckoutLineItems(li),
-                            first: DefaultQueries.MaxPageSize
-                        )
-                    )
+                    .checkout(checkout => {
+                        Checkout(checkout);
+                        CheckoutLineItems(checkout);
+                    })
                     .userErrors(userErrors => userErrors
                         .field()
                         .message()
                     ),
-                checkoutId: checkoutID,
+                checkoutId: checkoutId,
                 lineItems: lineItems
             );
         }
 
-        public void LineItemsRemove(MutationQuery query, string checkoutID, List<string> lineItemIds) {
+        public void LineItemsRemove(MutationQuery query, string checkoutId, List<string> lineItemIds) {
             query.checkoutLineItemsRemove(
                 buildQuery: lineItemRemove => lineItemRemove
-                    .checkout(checkout => 
-                        Checkout(checkout)
-                        .lineItems(
-                            buildQuery: li => CheckoutLineItems(li),
-                            first: DefaultQueries.MaxPageSize
-                        )
-                    )
+                    .checkout(checkout => {
+                        Checkout(checkout);
+                        CheckoutLineItems(checkout);
+                    })
                     .userErrors(userErrors => userErrors
                         .field()
                         .message()
                     ),
-                checkoutId: checkoutID,
+                checkoutId: checkoutId,
                 lineItemIds: lineItemIds
             );
         }
 
-        public void LineItemsUpdate(MutationQuery query, string checkoutID, List<CheckoutLineItemUpdateInput> lineItems) {
+        public void LineItemsUpdate(MutationQuery query, string checkoutId, List<CheckoutLineItemUpdateInput> lineItems) {
             query.checkoutLineItemsUpdate(
                 buildQuery: lineItemUpdate => lineItemUpdate
-                    .checkout(checkout => 
-                        Checkout(checkout)
-                        .lineItems(
-                            buildQuery: li => CheckoutLineItems(li),
-                            first: DefaultQueries.MaxPageSize
-                        )
-                    )
+                    .checkout(checkout => {
+                        Checkout(checkout);
+                        CheckoutLineItems(checkout);
+                    })
                     .userErrors(userErrors => userErrors
                         .field()
                         .message()
                     ),
-                checkoutId: checkoutID,
+                checkoutId: checkoutId,
                 lineItems: lineItems
+            );
+        }
+
+        public void CheckoutLineItemsPage(QueryRootQuery query, string checkoutId, int first = 250, string after = null) {
+            query.node(
+                buildQuery: node => node.onCheckout(checkout => CheckoutLineItems(checkout, first, after)),
+                id: checkoutId
             );
         }
 
@@ -96,17 +91,24 @@ namespace <%= namespace %>.SDK {
                 .ready();
         }
 
-        private CheckoutLineItemConnectionQuery CheckoutLineItems(CheckoutLineItemConnectionQuery lineItems) {
-            return lineItems
-                .edges(edge => edge
-                    .node(node => node
-                        .id()
-                        .variant(variant => variant
+        private CheckoutQuery CheckoutLineItems(CheckoutQuery checkout, int first = 250, string after = null) {
+            return checkout.lineItems(
+                buildQuery: lineItems => lineItems
+                    .edges(edge => edge
+                        .node(node => node
                             .id()
+                            .variant(variant => variant
+                                .id()
+                            )
                         )
+                        .cursor()
                     )
-                    .cursor()
-                );
+                    .pageInfo(pageInfo => pageInfo
+                        .hasNextPage()
+                    ),
+                first: first,
+                after: after
+            );
         }
     }
 }


### PR DESCRIPTION
This PR adds default queries we'll need to start to build checkouts via weblink.

The following queries are included:
* creating checkouts
* updating checkouts
  + Add line items
  + Remove line items
  + Update line items
* Poll to wait for `ready`

The following queries are not included:
* Setting up shipping information
* Discounts
* Completing checkouts