### PR TITLE
[Feature] Split line items into new, modified, and deleted

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -369,6 +369,8 @@ namespace Shopify.Tests
 
             cart.LineItems.AddOrUpdate(variantId1, 33);
             cart.LineItems.AddOrUpdate(variantId2, 2);
+
+            var lineItem1 = cart.LineItems.Get(variantId1);
         
             cart.LineItems.ClearNew();
 
@@ -389,6 +391,7 @@ namespace Shopify.Tests
 
             Assert.AreEqual(0, cart.LineItems.Deleted().Count, "Has 0 deleted line item after clear");
             Assert.AreEqual(1, cart.LineItems.All().Count, "Has 1 line item at end");
+            Assert.AreEqual(lineItem1, cart.LineItems.All()[0], "lineItem1 is the last remaining line item");
         } 
     }
 }

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -313,7 +313,49 @@ namespace Shopify.Tests
 
             Assert.AreEqual(0, cart.LineItems.Modified().Count, "After clear modified is 0");
             Assert.AreEqual(2, cart.LineItems.All().Count, "Has 2 line item at end");
-        } 
+        }
+
+        [Test]
+        public void TestModifyingLineItemsDirectly() {
+            ShopifyBuy.Init(new MockLoader());
+
+            Cart cart = ShopifyBuy.Client().Cart();
+
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
+
+            var lineItem1 = cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==");
+            var lineItem2 = cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==");
+
+            Assert.AreEqual(2, cart.LineItems.New().Count, "Has 2 new line items");
+
+            cart.LineItems.ClearNew();
+
+            Assert.AreEqual(0, cart.LineItems.New().Count, "Has 0 new line items");
+
+            Dictionary<string, string> newAttributes = new Dictionary<string, string>() {
+                {"zoo", "lion"}   
+            };
+
+            lineItem1.Quantity = 333333333333;
+
+            Assert.AreEqual(1, cart.LineItems.Modified().Count, "Has 1 modified line item");
+            Assert.AreEqual(lineItem1, cart.LineItems.Modified()[0], "lineItem1 is in modified list");
+
+            lineItem2.CustomAttributes = newAttributes;
+            
+            Assert.AreEqual(2, cart.LineItems.Modified().Count, "Has 2 modified line item");
+            Assert.AreEqual(lineItem2, cart.LineItems.Modified()[1], "lineItem2 is in modified list");
+
+            cart.LineItems.ClearModified();
+
+            Assert.AreEqual(0, cart.LineItems.Modified().Count, "Has 0 modified line items");
+
+            lineItem2.CustomAttributes["zoo"] = "zebra";
+
+            Assert.AreEqual(1, cart.LineItems.Modified().Count, "Has 1 modified line item after direct custom attribute change");
+            Assert.AreEqual(lineItem2, cart.LineItems.Modified()[0], "lineItem1 is in modified list after direct custom attribute change");
+        }
 
         [Test]
         public void TestDeletingLineItems() {

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -272,5 +272,81 @@ namespace Shopify.Tests
 
             Assert.AreEqual(null, cart.LineItems.Get(product, selectedOptions1), "Get retuned null after attempting access deleted line item");
         }
+
+        [Test]
+        public void TestNewLineItems() {
+            ShopifyBuy.Init(new MockLoader());
+
+            Cart cart = ShopifyBuy.Client().Cart();
+
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
+
+            Assert.AreEqual(2, cart.LineItems.New().Count, "Added 2 new line items");
+
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 3);
+
+            Assert.AreEqual(0, cart.LineItems.Modified().Count, "0 modified until new are cleared");
+            Assert.AreEqual(2, cart.LineItems.New().Count, "Still have 2 new after update");
+
+            cart.LineItems.ClearNew();
+            Assert.AreEqual(0, cart.LineItems.New().Count, "After clear new is 0");
+            Assert.AreEqual(2, cart.LineItems.All().Count, "Has 2 line item at end");
+        }
+
+        [Test]
+        public void TestModifyingLineItems() {
+            ShopifyBuy.Init(new MockLoader());
+
+            Cart cart = ShopifyBuy.Client().Cart();
+
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
+
+            cart.LineItems.ClearNew();
+
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 3);
+
+            Assert.AreEqual(1, cart.LineItems.Modified().Count, "Has 1 modified line item");  
+
+            cart.LineItems.ClearModified();
+
+            Assert.AreEqual(0, cart.LineItems.Modified().Count, "After clear modified is 0");
+            Assert.AreEqual(2, cart.LineItems.All().Count, "Has 2 line item at end");
+        } 
+
+        [Test]
+        public void TestDeletingLineItems() {
+            ShopifyBuy.Init(new MockLoader());
+
+            Cart cart = ShopifyBuy.Client().Cart();
+
+            string variantId1 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+            string variantId2 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==";
+            string variantId3 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTMTTT==";
+
+            cart.LineItems.AddOrUpdate(variantId1, 33);
+            cart.LineItems.AddOrUpdate(variantId2, 2);
+        
+            cart.LineItems.ClearNew();
+
+            cart.LineItems.AddOrUpdate(variantId2, 333);
+            cart.LineItems.AddOrUpdate(variantId3, 5);
+
+            Assert.AreEqual(1, cart.LineItems.New().Count, "Has one new line item");
+            Assert.AreEqual(1, cart.LineItems.Modified().Count, "Has one modified line item");
+
+            cart.LineItems.Delete(variantId2);
+            cart.LineItems.Delete(variantId3);
+
+            Assert.AreEqual(0, cart.LineItems.New().Count, "No new line items");
+            Assert.AreEqual(0, cart.LineItems.Modified().Count, "No modified line items");
+            Assert.AreEqual(1, cart.LineItems.Deleted().Count, "Has one deleted line item");
+
+            cart.LineItems.ClearDeleted();
+
+            Assert.AreEqual(0, cart.LineItems.Deleted().Count, "Has 0 deleted line item after clear");
+            Assert.AreEqual(1, cart.LineItems.All().Count, "Has 1 line item at end");
+        } 
     }
 }

--- a/Assets/Editor/TestDefaultQueriesCheckout.cs
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs
@@ -43,7 +43,7 @@ namespace Shopify.Tests
             DefaultQueries.checkout.LineItemsAdd(query, checkoutId, lineItems);
 
             Assert.AreEqual(
-                "mutation{checkoutLineItemsAdd (checkoutId:\"an-id\",lineItems:[]){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}", 
+                "mutation{checkoutLineItemsAdd (lineItems:[],checkoutId:\"an-id\"){checkout {id webUrl ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}", 
                 query.ToString()
             );
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -112,6 +112,9 @@ namespace <%= namespace %>.SDK {
     /// </summary>
     public class CartLineItems {
         private List<CartLineItem> LineItems = new List<CartLineItem>();
+        private List<CartLineItem> LineItemsNew = new List<CartLineItem>();
+        private List<CartLineItem> LineItemsModified = new List<CartLineItem>();
+        private List<CartLineItem> LineItemsDeleted = new List<CartLineItem>();
 
         /// <summary>
         /// Adds or updates an existing line item using a variant id.
@@ -127,28 +130,38 @@ namespace <%= namespace %>.SDK {
         /// cart.LineItems.AddOrUpdate(variantId, 3);
         /// \endcode
         public void AddOrUpdate(string variantId, long? quantity = null, Dictionary<string, string> customAttributes = null) {
-            CartLineItem input = Get(variantId);
+            CartLineItem modifiedLineItem = Get(variantId);
 
-            if (input != null) {
+            if (modifiedLineItem != null) {
+                bool didModify = false;
+
                 if (quantity != null) {
-                    input.Quantity = (long) quantity;
+                    modifiedLineItem.Quantity = (long) quantity;
+                    didModify = true;
                 }
 
                 if (customAttributes != null) {
-                    input.CustomAttributes = customAttributes;
+                    modifiedLineItem.CustomAttributes = customAttributes;
+                    didModify = false;
+                }
+
+                // if it's a new line item we don't want to add to the modified list but keep it in new
+                if (didModify && !LineItemsNew.Contains(modifiedLineItem)) {
+                    LineItemsModified.Add(modifiedLineItem);
                 }
             } else {
                 if (quantity == null) {
                     quantity = 1;
                 }
 
-                LineItems.Add(
-                    new CartLineItem(
-                        variantId: variantId,
-                        quantity: (long) quantity,
-                        customAttributes: customAttributes
-                    )
+                CartLineItem newLineItem = new CartLineItem(
+                    variantId: variantId,
+                    quantity: (long) quantity,
+                    customAttributes: customAttributes
                 );
+
+                LineItemsNew.Add(newLineItem);
+                LineItems.Add(newLineItem);
             }
         }
 
@@ -211,6 +224,30 @@ namespace <%= namespace %>.SDK {
         /// \endcode
         public List<CartLineItem> All() {
             return LineItems;
+        }
+
+        public List<CartLineItem> New() {
+            return LineItemsNew;
+        }
+
+        public void ClearNew() {
+            LineItemsNew.Clear();
+        }
+
+        public List<CartLineItem> Modified() {
+            return LineItemsModified;
+        }
+
+        public void ClearModified() {
+            LineItemsModified.Clear();
+        }
+
+        public List<CartLineItem> Deleted() {
+            return LineItemsDeleted;
+        }
+
+        public void ClearDeleted() {
+            LineItemsDeleted.Clear();
         }
 
         /// <summary>
@@ -282,12 +319,19 @@ namespace <%= namespace %>.SDK {
         /// Debug.Log("Did delete? " + cart.LineItems.Delete(variantId));
         /// \endcode
         public bool Delete(string variantId) {
-            int idxToDelete = LineItems.FindIndex(lineItem => lineItem.VariantId == variantId);
+            CartLineItem lineItemToDelete = LineItems.Find(lineItem => lineItem.VariantId == variantId);
 
-            if (idxToDelete == -1) {
+            if (lineItemToDelete == null) {
                 return false;
             } else {
-                LineItems.RemoveAt(idxToDelete);
+                bool wasInNew = LineItemsNew.Remove(lineItemToDelete);
+                LineItemsModified.Remove(lineItemToDelete);
+
+                if (!wasInNew) {
+                    LineItemsDeleted.Add(lineItemToDelete);
+                }
+
+                LineItems.Remove(lineItemToDelete);
 
                 return true;
             }

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -30,8 +30,9 @@ namespace <%= namespace %>.SDK {
             }
 
             set {
-                _IsSaved = false;
                 _Quantity = value;
+
+                OnAttributesChange();
             }
         }
 
@@ -41,11 +42,11 @@ namespace <%= namespace %>.SDK {
             }
 
             set {
-                _IsSaved = false;
-
                 if (value != null) {
-                    _CustomAttributes = new ObservableDictionary<string, string>(value, OnCustomAttributesChange);
+                    _CustomAttributes = new ObservableDictionary<string, string>(value, OnAttributesChange);
                 }
+
+                OnAttributesChange();
             }
         }
 
@@ -54,13 +55,15 @@ namespace <%= namespace %>.SDK {
         private string _VariantId;
         private long _Quantity;
         private ObservableDictionary<string, string> _CustomAttributes;
+        private Action<CartLineItem> OnChange;
         
-        public CartLineItem(string variantId, long quantity = 1, IDictionary<string, string> customAttributes = null) {
+        public CartLineItem(string variantId, Action<CartLineItem> onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
             _VariantId = variantId;
             _Quantity = quantity;
+            OnChange = onChange;
 
             if (customAttributes != null) {
-                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, OnCustomAttributesChange);
+                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, OnAttributesChange);
             }
         }
 
@@ -102,8 +105,10 @@ namespace <%= namespace %>.SDK {
             return attributes;
         }
 
-        private void OnCustomAttributesChange() {
+        private void OnAttributesChange() {
             _IsSaved = false;
+
+            OnChange(this);
         }
     }
 
@@ -133,21 +138,12 @@ namespace <%= namespace %>.SDK {
             CartLineItem modifiedLineItem = Get(variantId);
 
             if (modifiedLineItem != null) {
-                bool didModify = false;
-
                 if (quantity != null) {
                     modifiedLineItem.Quantity = (long) quantity;
-                    didModify = true;
                 }
 
                 if (customAttributes != null) {
                     modifiedLineItem.CustomAttributes = customAttributes;
-                    didModify = true;
-                }
-
-                // if it's a new line item we don't want to add to the modified list but keep it in new
-                if (didModify && !LineItemsNew.Contains(modifiedLineItem)) {
-                    LineItemsModified.Add(modifiedLineItem);
                 }
             } else {
                 if (quantity == null) {
@@ -156,6 +152,7 @@ namespace <%= namespace %>.SDK {
 
                 CartLineItem newLineItem = new CartLineItem(
                     variantId: variantId,
+                    onChange: OnCartLineItemChange,
                     quantity: (long) quantity,
                     customAttributes: customAttributes
                 );
@@ -377,6 +374,12 @@ namespace <%= namespace %>.SDK {
             }
 
             return Delete(variantId);
+        }
+
+        private void OnCartLineItemChange(CartLineItem modifiedLineItem) {
+            if (!LineItemsNew.Contains(modifiedLineItem) && !LineItemsModified.Contains(modifiedLineItem)) {
+                LineItemsModified.Add(modifiedLineItem);
+            }
         }
 
         private string VariantIdFromSelectedOptions(Product product, Dictionary<string, string> selectedOptions) {

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -142,7 +142,7 @@ namespace <%= namespace %>.SDK {
 
                 if (customAttributes != null) {
                     modifiedLineItem.CustomAttributes = customAttributes;
-                    didModify = false;
+                    didModify = true;
                 }
 
                 // if it's a new line item we don't want to add to the modified list but keep it in new


### PR DESCRIPTION
This PR creates 3 lists of line items on `CartLineItems`:

* New line items
* Modified line items
* Deleted line items

This will allow us build queries to create, modify, delete line items in the Storefront API.