### PR TITLE
[FIX] CI compile parsing error

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -17,4 +17,6 @@ end() {
 
 PROJECT_ROOT=${PROJECT_ROOT:-$(pwd)}
 SCRIPTS_ROOT="$PROJECT_ROOT/scripts"
-UNITY_PATH="/Applications/Unity/Unity.app/Contents/MacOS/Unity"
+UNITY_APP_PATH="/Applications/Unity/Unity.app"
+UNITY_PATH="$UNITY_APP_PATH/Contents/MacOS/Unity"
+UNITY_PACKAGE_MANAGER_PATH="$UNITY_APP_PATH/Contents/PackageManager/Unity/PackageManager"

--- a/scripts/generator/graphql_generator/csharp/SDK/ObservableDictionary.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ObservableDictionary.cs.erb
@@ -5,8 +5,8 @@ namespace <%= namespace %>.SDK {
 
     public delegate void DictionaryChangeHandler();
 
-    public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue> {
-        private IDictionary<TKey, TValue> Data;
+    public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue> {
+        private IDictionary<TKey, TValue> Data;
         private DictionaryChangeHandler OnDictionaryChange;
 
         public ObservableDictionary(DictionaryChangeHandler onDictionaryChange) {
@@ -14,7 +14,7 @@ namespace <%= namespace %>.SDK {
             OnDictionaryChange = onDictionaryChange;
         }
 
-        public ObservableDictionary(IDictionary<TKey, TValue> data, DictionaryChangeHandler onDictionaryChange) {
+        public ObservableDictionary(IDictionary<TKey, TValue> data, DictionaryChangeHandler onDictionaryChange) {
             Data = data;
             OnDictionaryChange = onDictionaryChange;
         }

--- a/scripts/test_unity.sh
+++ b/scripts/test_unity.sh
@@ -20,10 +20,8 @@ $UNITY_PATH \
     -silent-crashes \
     -logFile $UNITY_LOG_PATH \
     -projectPath $PROJECT_ROOT \
-    -editorTestsResultFile EditorTestResults.xml \
-    -runEditorTests \
-    -buildTarget osx \
-    -quit
+    -editorTestsResultFile ./EditorTestResults.xml \
+    -runEditorTests
 
 if [ $? = 0 ] ; then
     echo "Tests passed"

--- a/scripts/test_unity.sh
+++ b/scripts/test_unity.sh
@@ -14,6 +14,9 @@ convertNUnitToJUnit() {
     fi
 }
 
+UNITY_VERSION=$(ls $UNITY_PACKAGE_MANAGER_PATH)
+echo "Testing with Unity Version: $UNITY_VERSION"
+
 $UNITY_PATH \
     -batchmode \
     -nographics \


### PR DESCRIPTION
+ Removes incorrect whitespace that caused older versions of Mono to have parsing issues
+ Adds ./ to correct test path errors
+ Adds Print statement to output the version of Unity
+ Removes -quit flag from build, -runEditorTests will quit upon failure or success