### PR TITLE
[Feature] Global GameObject

### DIFF
--- a/Assets/Editor/TestDefaultQueriesCheckout.cs.meta
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a27ed36d539284421be934686a0fcdbb
+timeCreated: 1495216019
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -102,6 +102,7 @@ module GraphQLGenerator
         SDK/DefaultQueriesProducts
         SDK/DefaultQueriesCollections
         SDK/DefaultQueriesCheckout
+        SDK/GlobalGameObject
         SDK/QueryLoader
         SDK/ConnectionLoader
         SDK/UnityLoader

--- a/scripts/generator/graphql_generator/csharp/SDK/GlobalGameObject.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/GlobalGameObject.cs.erb
@@ -1,0 +1,17 @@
+#if !SHOPIFY_MONO_UNIT_TEST
+namespace <%= namespace %>.SDK {
+    using UnityEngine;
+
+    public class GlobalGameObject {
+        private static GameObject GameObject;
+
+        public static T AddComponent<T>() where T: Component {
+            if (GameObject == null) {
+                GameObject = new GameObject("Shopify");
+            }
+
+            return GameObject.AddComponent<T>();
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/UnityLoader.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/UnityLoader.cs.erb
@@ -58,8 +58,6 @@ namespace <%= namespace %>.SDK {
     /// Performs network communication to send GraphQL queries between Unity and a Shopify GraphQL endpoint.
     /// </summary>
     public class UnityLoader : ILoader {
-        static GameObject LoaderGameObject;
-
         /// <summary>
         /// Shopify store domain where the GraphQL endpoint lives.
         /// </summary>
@@ -94,11 +92,7 @@ namespace <%= namespace %>.SDK {
         /// <param name="query">Query that will be sent to the Storefront API</param>
         /// <param name="callback">callback that receives a response</param>
         public void Load(string query, LoaderResponseHandler callback) {
-            if (LoaderGameObject == null) {
-                LoaderGameObject = new GameObject();
-            }
-
-            LoaderGameObject.AddComponent<LoaderComponent>()
+            GlobalGameObject.AddComponent<LoaderComponent>()
             .SetURL("https://" + Domain + "/api/graphql.json")
             .SetAccessToken(AccessToken)
             .Load(query, callback);


### PR DESCRIPTION
This PR allows you to add components to a global `GameObject`. Previously the `UnityLoader` had it's own `GameObject`. Now for checkouts we need to add the ability to poll on an interval we we need to have `GameObject` to add a script to. Instead of all these scripts creating their own `GameObjects` it's probably better we just have one global game object.