### PR TITLE
[FIX] Created a `unity-buy-sdk` test store

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,8 +17,8 @@ Before you can start using the Unity Buy SDK, you need:
 This code example initializes the SDK. The `ShopifyBuy.Init` method takes two arguments. The first is a storefront access token to communicate with the Storefront API. The second is the domain name of your shop.
 
 ```cs
-string accessToken = "351c122017d0f2a957d32ae728ad749c";
-string shopDomain = "graphql.myshopify.com";
+string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+string shopDomain = "unity-buy-sdk.myshopify.com";
 
 ShopifyBuy.Init(accessToken, shopDomain);
 ```
@@ -33,8 +33,8 @@ The following example shows how to query all products in your Shopify store:
 using Shopify.Unity;
 
 void Start () {
-    string accessToken = "351c122017d0f2a957d32ae728ad749c";
-    string shopDomain = "graphql.myshopify.com";
+    string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+    string shopDomain = "unity-buy-sdk.myshopify.com";
 
     // Init only needs to be called once
     ShopifyBuy.Init(accessToken, shopDomain);
@@ -72,8 +72,8 @@ The following example shows how to query all collections in your Shopify store:
 using Shopify.Unity;
 
 void Start () {
-    string accessToken = "351c122017d0f2a957d32ae728ad749c";
-    string shopDomain = "graphql.myshopify.com";
+    string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+    string shopDomain = "unity-buy-sdk.myshopify.com";
 
     ShopifyBuy.Init(accessToken, shopDomain);
 
@@ -117,8 +117,8 @@ The following example shows how to create a cart, add line items to the cart usi
 using Shopify.Unity;
 
 void Start () {
-    string accessToken = "351c122017d0f2a957d32ae728ad749c";
-    string shopDomain = "graphql.myshopify.com";
+    string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+    string shopDomain = "unity-buy-sdk.myshopify.com";
 
     ShopifyBuy.Init(accessToken, shopDomain);
 
@@ -169,8 +169,8 @@ In Shopify, a product can have many options. These options map to **variants** o
 using Shopify.Unity;
 
 void Start () {
-    string accessToken = "351c122017d0f2a957d32ae728ad749c";
-    string shopDomain = "graphql.myshopify.com";
+    string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+    string shopDomain = "unity-buy-sdk.myshopify.com";
 
     ShopifyBuy.Init(accessToken, shopDomain);
 
@@ -266,8 +266,8 @@ The following example shows how to build a custom query in C# that matches the G
 using Shopify.Unity;
 
 void Start () {
-    string accessToken = "351c122017d0f2a957d32ae728ad749c";
-    string shopDomain = "graphql.myshopify.com";
+    string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+    string shopDomain = "unity-buy-sdk.myshopify.com";
 
     ShopifyBuy.Init(accessToken, shopDomain);
 

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -53,7 +53,7 @@ namespace <%= namespace %> {
         /// <param name="domain">the domain associated to a client</param>
         /// \code
         /// // Example usage querying all products using `Client` and a domain
-        /// ShopifyBuy.Client("graphql.myshopify.com").products((products, errors, httpError) => {
+        /// ShopifyBuy.Client("unity-buy-sdk.myshopify.com").products((products, errors, httpError) => {
         /// 	Debug.Log(products[0].title()); // "Snare Boot"
         /// 	Debug.Log(products[1].title()); // "Neptune Boot"
         /// 	Debug.Log(products.Count); // 38 products returned
@@ -77,8 +77,8 @@ namespace <%= namespace %> {
         /// <param name="domain">domain of your Shopify store</param>
         /// \code
         /// // Example that initializes the Unity Buy SDK
-        /// string accessToken = "351c122017d0f2a957d32ae728ad749c";
-        /// string shopDomain = "graphql.myshopify.com";
+        /// string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+        /// string shopDomain = "unity-buy-sdk.myshopify.com";
         ///
         /// // Init only needs to be called once
         /// ShopifyBuy.Init(accessToken, shopDomain);
@@ -105,8 +105,8 @@ namespace <%= namespace %> {
         /// <param name="loader">a loader which will handle network communicationication with the Storefront API</param>
         /// \code
         /// // Mock example using a custom loader for another C# platform
-        /// string accessToken = "351c122017d0f2a957d32ae728ad749c";
-        /// string shopDomain = "graphql.myshopify.com";
+        /// string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+        /// string shopDomain = "unity-buy-sdk.myshopify.com";
         ///
         /// CustomLoaderForNonUnityPlatform loader = new CustomLoaderForNonUnityPlatform(accessToken, shopDomain);
         ///
@@ -202,8 +202,8 @@ namespace <%= namespace %> {
         /// <param name="domain">domain for the Shopify store</param>
         /// \code
         /// // Example that initializes a new ShopifyClient which will query all products
-        /// string accessToken = "351c122017d0f2a957d32ae728ad749c";
-        /// string shopDomain = "graphql.myshopify.com";
+        /// string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+        /// string shopDomain = "unity-buy-sdk.myshopify.com";
         ///
         /// ShopifyClient client = new ShopifyClient(accessToken, shopDomain);
         ///
@@ -231,8 +231,8 @@ namespace <%= namespace %> {
         /// <param name="loader">a loader which will handle network communicationication with the Storefront API</param>
         /// \code
         /// // Example that initializes a new ShopifyClient using a custom loader for another C# platform
-        /// string accessToken = "351c122017d0f2a957d32ae728ad749c";
-        /// string shopDomain = "graphql.myshopify.com";
+        /// string accessToken = "b8d417759a62f7b342f3735dbe86b322";
+        /// string shopDomain = "unity-buy-sdk.myshopify.com";
         ///
         /// CustomLoaderForNonUnityPlatform loader = new CustomLoaderForNonUnityPlatform(accessToken, shopDomain);
         ///

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -36,9 +36,9 @@ namespace <%= namespace %> {
         /// \code
         /// // Example usage querying all products using `Client`
         /// ShopifyBuy.Client().products((products, errors, httpError) => {
-        /// 	Debug.Log(products[0].title()); // "Snare Boot"
-        /// 	Debug.Log(products[1].title()); // "Neptune Boot"
-        /// 	Debug.Log(products.Count); // 38 products returned
+        /// 	Debug.Log(products[0].title());
+        /// 	Debug.Log(products[1].title());
+        /// 	Debug.Log(products.Count);
         /// });
         /// \endcode
         public static ShopifyClient Client() {
@@ -54,9 +54,9 @@ namespace <%= namespace %> {
         /// \code
         /// // Example usage querying all products using `Client` and a domain
         /// ShopifyBuy.Client("unity-buy-sdk.myshopify.com").products((products, errors, httpError) => {
-        /// 	Debug.Log(products[0].title()); // "Snare Boot"
-        /// 	Debug.Log(products[1].title()); // "Neptune Boot"
-        /// 	Debug.Log(products.Count); // 38 products returned
+        /// 	Debug.Log(products[0].title());
+        /// 	Debug.Log(products[1].title());
+        /// 	Debug.Log(products.Count);
         /// });
         /// \endcode
         public static ShopifyClient Client(string domain) {
@@ -208,8 +208,8 @@ namespace <%= namespace %> {
         /// ShopifyClient client = new ShopifyClient(accessToken, shopDomain);
         ///
         /// client.products((products, errors, httpError) => {
-        ///     Debug.Log(products[0].title()); // "Snare Boot"
-        ///     Debug.Log(products[1].title()); // "Neptune Boot"
+        ///     Debug.Log(products[0].title());
+        ///     Debug.Log(products[1].title());
         /// });
         /// \endcode
         public ShopifyClient(string accessToken, string domain) {
@@ -239,8 +239,8 @@ namespace <%= namespace %> {
         /// ShopifyClient client = new ShopifyClient(loader);
         ///
         /// client.products((products, errors, httpError) => {
-        ///     Debug.Log(products[0].title()); // "Snare Boot"
-        ///     Debug.Log(products[1].title()); // "Neptune Boot"
+        ///     Debug.Log(products[0].title());
+        ///     Debug.Log(products[1].title());
         /// });
         /// \endcode
         public ShopifyClient(ILoader loader) {
@@ -294,9 +294,9 @@ namespace <%= namespace %> {
         /// \code
         /// // Example usage querying all products
         /// ShopifyBuy.Client().products((products, errors, httpError) => {
-        /// 	Debug.Log(products[0].title()); // "Snare Boot"
-        /// 	Debug.Log(products[1].title()); // "Neptune Boot"
-        /// 	Debug.Log(products.Count); // 38 products returned
+        /// 	Debug.Log(products[0].title());
+        /// 	Debug.Log(products[1].title());
+        /// 	Debug.Log(products.Count);
         /// });
         /// \endcode
         public void products(ResponseProductsHandler callback, int? first = null, string after = null) {
@@ -351,8 +351,8 @@ namespace <%= namespace %> {
         /// \code
         /// // Example usage querying two product ids
         /// ShopifyBuy.Client().products((products, errors, httpError) => {
-        ///     Debug.Log(products[0].title()); // "Snare Boot"
-        ///     Debug.Log(products[1].title()); // "Neptune Boot"
+        ///     Debug.Log(products[0].title());
+        ///     Debug.Log(products[1].title());
         /// }, "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyNzYwOTk=", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0Lzk4OTUyNzkwNDM=");
         /// \endcode
         public void products(ResponseProductsHandler callback, string firstProductId, params string[] otherProductIds) {
@@ -405,8 +405,8 @@ namespace <%= namespace %> {
         /// };
         ///
         /// ShopifyBuy.Client().products((products, errors, httpError) => {
-        ///     Debug.Log(products[0].title()); // "Snare Boot"
-        ///     Debug.Log(products[1].title()); // "Neptune Boot"
+        ///     Debug.Log(products[0].title());
+        ///     Debug.Log(products[1].title());
         /// }, productIds);
         /// \endcode
         public void products(ResponseProductsHandler callback, List<string> productIds) {
@@ -468,8 +468,8 @@ namespace <%= namespace %> {
         /// \code
         /// // Example that queries all collections on a shop
         /// ShopifyBuy.Client().collections((collections, errors, httpError) => {
-        /// 	Debug.Log(collections[0].title()); // "Home page"
-        /// 	Debug.Log(collections.Count); // 1 collection
+        /// 	Debug.Log(collections[0].title());
+        /// 	Debug.Log(collections.Count);
         /// });
         /// \endcode
         public void collections(ResponseCollectionsHandler callback, int? first = null, string after = null) {


### PR DESCRIPTION
We have an issue right now where it's hard for us to tell in Splunk whether queries are coming from people testing the SDK or if it's from Integration tests. This PR updates the store url and access token to use a test shop `unity-buy-sdk.myshopify.com`.

This update will allow us to differentiate better in Splunk whether developers are testing the sdk based on the SDK documentation or if it's queries are coming from internal development.
