### PR TITLE
[Feature] iOS payment session

### DIFF
--- a/Assets/Plugins/iOS/Shopify/PKPaymentToken+Serializable.swift
+++ b/Assets/Plugins/iOS/Shopify/PKPaymentToken+Serializable.swift
@@ -36,7 +36,7 @@ extension PKPaymentToken: Serializable {
     
     func serializedJSON() -> JSON {
         var json = JSON()
-        json.insert(nullable: try! JSONSerialization.jsonObject(with: self.paymentData), forKey: PaymentTokenField.paymentData)
+        json.insert(nullable: try? JSONSerialization.jsonObject(with: self.paymentData), forKey: PaymentTokenField.paymentData)
         json.insert(nullable: self.transactionIdentifier, forKey: PaymentTokenField.transactionIdentifier)
         return json
     }

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -58,7 +58,7 @@ import PassKit
     
     /// The last status of the authorization received by passing the token data
     /// to the payment server
-    var lastAuthStatus: PKPaymentAuthorizationStatus!
+    var lastAuthStatus: PKPaymentAuthorizationStatus?
     
     var summaryItems: [PKPaymentSummaryItem]
     var shippingMethods: [PKShippingMethod]
@@ -215,7 +215,7 @@ extension PaymentSession: PKPaymentAuthorizationViewControllerDelegate {
         
         DispatchQueue.global(qos: .userInitiated).async {
             self.updateSemaphore.wait()
-            completion(self.lastAuthStatus);
+            completion(self.lastAuthStatus!);
         }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -1,0 +1,221 @@
+//
+//  PaymentSession.swift
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+import PassKit
+
+@objc enum PaymentStatus: Int {
+    case Failed
+    case Cancelled
+    
+    func toString() -> String {
+        switch self {
+        case .Cancelled:
+            return "Cancelled"
+        case .Failed:
+            return "Failed"
+        }
+    }
+}
+
+@objc protocol PaymentSessionDelegate : class {
+    func paymentSessionDidFinish(session: PaymentSession,with status: PaymentStatus)
+    func paymentSession(_ session: PaymentSession, didSelect shippingMethod: PKShippingMethod)
+    func paymentSession(_ session: PaymentSession, didSelectShippingContact shippingContact: PKContact)
+    func paymentSession(_ session: PaymentSession, didAuthorize payment: PKPayment)
+}
+
+@objc class PaymentSession: NSObject {
+
+    /// Semaphore that blocks the PKAuthorizationController till summary items
+    /// or shipping methods are updated based on the user's input
+    let updateSemaphore = DispatchSemaphore(value: 0)
+    
+    let request: PKPaymentRequest
+    
+    /// The last status of the authorization received by passing the token data
+    /// to the payment server
+    var lastAuthStatus: PKPaymentAuthorizationStatus!
+    
+    var summaryItems: [PKPaymentSummaryItem]
+    var shippingMethods: [PKShippingMethod]
+    weak var delegate: PaymentSessionDelegate?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    init(withMerchantIdentifier merchantId: String, countryCode: String, currencyCode: String, requiringShippingAddressFields: Bool)
+    {
+        summaryItems    = [PKPaymentSummaryItem]()
+        shippingMethods = [PKShippingMethod]()
+        
+        request = PKPaymentRequest.init()
+        request.countryCode                   = countryCode
+        request.currencyCode                  = currencyCode
+        request.merchantIdentifier            = merchantId
+        request.requiredBillingAddressFields  = .all
+        request.merchantCapabilities          = .capability3DS
+        request.supportedNetworks             = PaymentSession.supportedNetworks
+        request.requiredShippingAddressFields = requiringShippingAddressFields ?
+            .all : PKAddressField.init(rawValue: PKAddressField.email.rawValue | PKAddressField.phone.rawValue)
+        
+        super.init()
+    }
+    
+    func addSummaryItem(withLabel label : String, amount: NSDecimalNumber) {
+        let newItem = PKPaymentSummaryItem.init(label: label, amount: amount)
+        summaryItems.append(newItem)
+    }
+    
+    func removeAllSummaryItems() {
+        summaryItems.removeAll()
+    }
+    
+    func addShippingMethod(withLabel label : String, amount: NSDecimalNumber, identifier: String, detail: String) {
+        let newMethod        = PKShippingMethod.init(label: label, amount: amount)
+        newMethod.identifier = identifier
+        newMethod.detail     = detail
+        
+        shippingMethods.append(newMethod)
+    }
+    
+    func removeAllShippingMethods() {
+        shippingMethods.removeAll()
+    }
+    
+    /// Assigns the shipping methods and summary items in this session to the request
+    func populateRequest() {
+        request.shippingMethods     = shippingMethods;
+        request.paymentSummaryItems = summaryItems;
+    }
+    
+    /// Presents the PKAuthorizationController with the current shipping methods
+    /// and summary items in this session.
+    /// UnityAppController is set to remain active until the authorization controller
+    /// is dismissed, to enable communication between managed and unmanaged functions
+    func presentAuthorizationController()  {
+        populateRequest();
+        let authViewController = PKPaymentAuthorizationViewController.init(paymentRequest: request)
+        let unityController    = UIApplication.shared.delegate as! UnityBuyAppController
+        let topController      = unityController.topMostController()!
+
+        authViewController.delegate = self
+        unityController.shouldResignActive = false
+        topController.present(authViewController, animated: true)
+    }
+    
+    /// Signals the update semaphore that items updates have finalized
+    func didFinishUpdate() {
+        updateSemaphore.signal()
+    }
+    
+    /// Signal the update semaphore with the status returned from sending 
+    /// the token data
+    func didAuthorize(withStatus status: PKPaymentAuthorizationStatus) {
+        self.lastAuthStatus = status;
+        updateSemaphore.signal()
+    }
+}
+
+// ----------------------------------
+//  MARK: - Static functions -
+//
+extension PaymentSession {
+    
+    static let supportedNetworks: [PKPaymentNetwork] = [.amex, .masterCard, .visa, .discover]
+    
+    static func canMakePayments() -> Bool {
+        return PKPaymentAuthorizationViewController.canMakePayments() &&
+            PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks)
+    }
+    
+    static func canShowSetup() -> Bool {
+        return PKPaymentAuthorizationViewController.canMakePayments() &&
+            !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks)
+    }
+    
+    static func showSetup() {
+        PKPassLibrary.init().openPaymentSetup()
+    }
+}
+
+// ----------------------------------
+//  MARK: - PKPaymentAuthorizationViewControllerDelegate -
+//
+extension PaymentSession: PKPaymentAuthorizationViewControllerDelegate {
+    
+    func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+        
+        let paymentStatus: PaymentStatus
+        let unityController = UIApplication.shared.delegate as! UnityBuyAppController
+        unityController.shouldResignActive = true
+        
+        if lastAuthStatus == .failure {
+            paymentStatus = .Failed
+        }
+        else {
+            paymentStatus = .Cancelled
+        }
+        
+        controller.dismiss(animated: true) {
+            self.delegate?.paymentSessionDidFinish(session: self, with: paymentStatus)
+        }
+    }
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
+
+        delegate?.paymentSession(self, didSelect: shippingMethod)
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.updateSemaphore.wait()
+            completion(.success, self.summaryItems)
+        }
+    }
+
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect paymentMethod: PKPaymentMethod, completion: @escaping ([PKPaymentSummaryItem]) -> Void) {
+        completion(summaryItems)
+    }
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelectShippingContact contact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) {
+        
+        delegate?.paymentSession(self, didSelectShippingContact: contact)
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.updateSemaphore.wait()
+            completion(.success, self.shippingMethods, self.summaryItems);
+        }
+    }
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didAuthorizePayment payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
+        
+        delegate?.paymentSession(self, didAuthorize: payment)
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.updateSemaphore.wait()
+            completion(self.lastAuthStatus);
+        }
+    }
+}


### PR DESCRIPTION
### What 

I want to get some early feedback on this implementation while I write the tests. @mikkoh @dbart01 

+ Fixes PKPaymentToken+Serializable to handle cases where token data is nil. Testing Apple Pay on the simulator returns nil token data.
+ Adds a `PaymentSession` implementation
    + `PaymentSession` is responsible for creating the `PKPaymentRequest` and coordinating the mutations on that request such as adding summary items and shipping methods. 
   + `PaymentSession` is also responsible for displaying the `PKAuthorizationController`  
   + On `PKPaymentAuthorizationViewControllerDelegate` notifications the `PaymentSession` will notify it's own `PaymentSessionDelegate` and block till the `PaymentSession` is notified to unblock using `didAuthorize` or `didFinishUpdate ` 
       + There is no `PaymentSessionDelegate` method for
`paymentAuthorizationViewController(controller:, didSelect paymentMethod:, completion:`  because I do not see a use for the info provided in `PKPaymentMethod` for completing a checkout
       + We use a semaphore here so that we can block the before calling the completion closure on `PKPaymentAuthorizationDelegate`. Blocking before calling the completion, allows us to notify a managed function to update the session's summary items and shipping. Managed functions are asynchronous and have no return values so we must wait till we receive another function notifying that all mutations are finished. That is when we unlock the semaphore, and call the completion closure with the updated summary items.
       + `PaymentSession` will block an asynchronous queue that references the completion closure. The asynchronous queue is blocked until someone calls `didAuthorize` or `didFinishUpdate`. This does not block the main queue, so the user can still interact with the App. Other changes to the shipping address and billing address made by the user during this are put onto a queue by PKPaymentAuthorizationController, in effect other delegate methods are not called until the original completion closure is finished. With the exception of paymentAuthorizationViewControllerDidFinish
   + Step towards #65 