### PR TITLE
[Feature] iOS Payment Session

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationController.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationController.swift
@@ -1,6 +1,6 @@
 //
-//  MockAuthorizationViewController.swift
-//  PayTests
+//  MockAuthorizationController.swift
+//  UnityBuySDK
 //
 //  Created by Shopify.
 //  Copyright (c) 2017 Shopify Inc. All rights reserved.
@@ -27,9 +27,10 @@
 import Foundation
 import PassKit
 
-final class MockAuthorizationViewController: PKPaymentAuthorizationViewController {
+@available(iOS 10.0, *)
+final class MockAuthorizationController: PKPaymentAuthorizationController {
     
-    static var instances: [MockAuthorizationViewController] = []
+    static var instances: [MockAuthorizationController] = []
     
     // ----------------------------------
     //  MARK: - Instance Management -
@@ -40,8 +41,15 @@ final class MockAuthorizationViewController: PKPaymentAuthorizationViewControlle
         type(of: self).instances.append(self)
     }
     
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+    // ----------------------------------
+    //  MARK: - Disable Defaults -
+    //
+    override func present(completion: ((Bool) -> Void)? = nil) {
+        completion?(true)
+    }
+    
+    override func dismiss(completion: (() -> Void)? = nil) {
+        completion?()
     }
     
     // ----------------------------------
@@ -49,35 +57,35 @@ final class MockAuthorizationViewController: PKPaymentAuthorizationViewControlle
     //
     static func invokeDidSelectShippingContact(_ contact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) {
         
-        self.instances.forEach { authorizationViewController in
-            authorizationViewController.delegate?.paymentAuthorizationViewController?(authorizationViewController, didSelectShippingContact: contact, completion: completion)
+        self.instances.forEach { authorizationController in
+            authorizationController.delegate?.paymentAuthorizationController?(authorizationController, didSelectShippingContact: contact, completion: completion)
         }
     }
     
     static func invokeDidAuthorizePayment(_ payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
         
-        self.instances.forEach { authorizationViewController in
-            authorizationViewController.delegate?.paymentAuthorizationViewController(authorizationViewController, didAuthorizePayment: payment, completion: completion)
+        self.instances.forEach { authorizationController in
+            authorizationController.delegate?.paymentAuthorizationController(authorizationController, didAuthorizePayment: payment, completion: completion)
         }
     }
     
     static func invokeDidFinish() {
-        self.instances.forEach { authorizationViewController in
-            authorizationViewController.delegate?.paymentAuthorizationViewControllerDidFinish(authorizationViewController)
+        self.instances.forEach { authorizationController in
+            authorizationController.delegate?.paymentAuthorizationControllerDidFinish(authorizationController)
         }
     }
     
     static func invokeDidSelectShippingMethod(_ shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
         
-        self.instances.forEach { authorizationViewController in
-            authorizationViewController.delegate?.paymentAuthorizationViewController?(authorizationViewController, didSelect: shippingMethod, completion: completion)
+        self.instances.forEach { authorizationController in
+            authorizationController.delegate?.paymentAuthorizationController?(authorizationController, didSelectShippingMethod: shippingMethod, completion: completion)
         }
     }
     
     static func invokeDidSelectPaymentMethod(_ paymentMethod: PKPaymentMethod, completion: @escaping ([PKPaymentSummaryItem]) -> Void) {
         
-        self.instances.forEach { authorizationViewController in
-            authorizationViewController.delegate?.paymentAuthorizationViewController?(authorizationViewController, didSelect: paymentMethod, completion: completion)
+        self.instances.forEach { authorizationController in
+            authorizationController.delegate?.paymentAuthorizationController?(authorizationController, didSelectPaymentMethod: paymentMethod, completion: completion)
         }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationController.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationController.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: ce55d7373cecf449a9d96e19d56baa33
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationViewController.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationViewController.swift
@@ -1,0 +1,83 @@
+//
+//  MockAuthorizationViewController.swift
+//  PayTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+final class MockAuthorizationViewController: PKPaymentAuthorizationViewController {
+    
+    static var instances: [MockAuthorizationViewController] = []
+    
+    // ----------------------------------
+    //  MARK: - Instance Management -
+    //
+    override init(paymentRequest request: PKPaymentRequest) {
+        super.init(paymentRequest: request)
+        
+        type(of: self).instances.append(self)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Invoke Delegate Calls -
+    //
+    static func invokeDidSelectShippingContact(_ contact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) {
+        
+        self.instances.forEach { authorizationViewController in
+            authorizationViewController.delegate?.paymentAuthorizationViewController?(authorizationViewController, didSelectShippingContact: contact, completion: completion)
+        }
+    }
+    
+    static func invokeDidAuthorizePayment(_ payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
+        
+        self.instances.forEach { authorizationViewController in
+            authorizationViewController.delegate?.paymentAuthorizationViewController(authorizationViewController, didAuthorizePayment: payment, completion: completion)
+        }
+    }
+    
+    static func invokeDidFinish() {
+        self.instances.forEach { authorizationViewController in
+            authorizationViewController.delegate?.paymentAuthorizationViewControllerDidFinish(authorizationViewController)
+        }
+    }
+    
+    static func invokeDidSelectShippingMethod(_ shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
+        
+        self.instances.forEach { authorizationViewController in
+            authorizationViewController.delegate?.paymentAuthorizationViewController?(authorizationViewController, didSelect: shippingMethod, completion: completion)
+        }
+    }
+    
+    static func invokeDidSelectPaymentMethod(_ paymentMethod: PKPaymentMethod, completion: @escaping ([PKPaymentSummaryItem]) -> Void) {
+        
+        self.instances.forEach { authorizationViewController in
+            authorizationViewController.delegate?.paymentAuthorizationViewController?(authorizationViewController, didSelect: paymentMethod, completion: completion)
+        }
+    }
+}

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentMethod.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentMethod.swift.meta
@@ -7,7 +7,6 @@ PluginImporter:
   iconMap: {}
   executionOrder: {}
   isPreloaded: 0
-  isOverridable: 0
   platformData:
     Any:
       enabled: 0

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentSessionDelegate.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentSessionDelegate.swift
@@ -1,6 +1,6 @@
 //
 //  MockPaymentSessionDelegate.swift
-//  Unity-iPhone
+//  UnityBuySDK
 //
 //  Created by Shopify.
 //

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentSessionDelegate.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentSessionDelegate.swift
@@ -1,0 +1,63 @@
+//
+//  MockPaymentSessionDelegate.swift
+//  Unity-iPhone
+//
+//  Created by Shopify.
+//
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+@testable import ProductName
+
+final class MockPaymentSessionDelegate: NSObject {
+    var onSessionDidFinish: ((PaymentSession, PaymentStatus) -> Void)?
+    
+    var onSessionDidSelectShippingMethod:
+        ((PaymentSession, PKShippingMethod, (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) -> Void)?
+    
+    var onSessionDidSelectShippingContact:
+        ((PaymentSession, PKContact, (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) -> Void)?
+    
+    var onSessionDidAuthorizePayment:
+        ((PaymentSession, PKPayment,  (PKPaymentAuthorizationStatus) -> Void) -> Void)?
+}
+
+// ----------------------------------
+//  MARK: - PaymentSessionDelegate -
+//
+extension MockPaymentSessionDelegate: PaymentSessionDelegate {
+    func paymentSessionDidFinish(session: PaymentSession, with status: PaymentStatus) {
+        onSessionDidFinish?(session, status)
+    }
+    
+    func paymentSession(_ session: PaymentSession, didSelect shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
+        onSessionDidSelectShippingMethod?(session, shippingMethod, completion)
+    }
+    
+    func paymentSession(_ session: PaymentSession, didSelectShippingContact shippingContact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) {
+        onSessionDidSelectShippingContact?(session, shippingContact, completion)
+    }
+    
+    func paymentSession(_ session: PaymentSession, didAuthorize payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
+        onSessionDidAuthorizePayment?(session, payment, completion)
+    }
+}

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentSessionDelegate.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentSessionDelegate.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: a41bf751d1b4146298271efb4ae9e20c
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentToken.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockPaymentToken.swift.meta
@@ -1,13 +1,12 @@
 fileFormatVersion: 2
 guid: 57b29869eafe7447c851b922fa4f6c4c
-timeCreated: 1495562514
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1
   iconMap: {}
   executionOrder: {}
   isPreloaded: 0
-  isOverridable: 0
   platformData:
     Any:
       enabled: 0

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Models.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Models.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: aa79a2bfad49141269d0a0f9597d655b
+folderAsset: yes
+timeCreated: 1496344093
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 import PassKit
-import ProductName
+@testable import ProductName
 
 struct Models {
     
@@ -42,6 +42,10 @@ struct Models {
     static let country      = "Canada"
     static let province     = "ON"
     static let zip          = "A1B 2C3"
+    
+    static let merchantId   = "com.merchant.id"
+    static let countryCode  = "US"
+    static let currencyCode = "USD"
     
     // ----------------------------------
     //  MARK: - PersonNameComponents -
@@ -109,5 +113,55 @@ struct Models {
                                 billingContact: createContact(with: createPostalAddress()),
                                 shippingContact: createContact(with: createPostalAddress()),
                                 shippingMethod: createShippingMethod())
+    }
+    
+    static func createSummaryItems() -> [PKPaymentSummaryItem] {
+        var summaryItems = [PKPaymentSummaryItem]()
+        summaryItems.append(PKPaymentSummaryItem.init(label: "SubTotal", amount: NSDecimalNumber.init(value: 1.00)))
+        summaryItems.append(PKPaymentSummaryItem.init(label: "Tax",      amount: NSDecimalNumber.init(value: 1.00)))
+        summaryItems.append(PKPaymentSummaryItem.init(label: "Shipping", amount: NSDecimalNumber.init(value: 1.00)))
+        summaryItems.append(PKPaymentSummaryItem.init(label: "Total",    amount: NSDecimalNumber.init(value: 3.00)))
+        return summaryItems
+    }
+    
+    static func createShippingMethods() -> [PKShippingMethod] {
+        var shippingMethods = [PKShippingMethod]()
+        shippingMethods.append(
+            PKShippingMethod.init(label: "Free",
+                                  amount: NSDecimalNumber.init(value: 0.0),
+                                  identifier: "Free",
+                                  detail: "10-15 Days"))
+        
+        shippingMethods.append(
+            PKShippingMethod.init(label: "Standard",
+                                  amount: NSDecimalNumber.init(value: 5.0),
+                                  identifier: "Standard",
+                                  detail: "10-15 Days"))
+        shippingMethods.append(
+            PKShippingMethod.init(label: "Express",
+                                  amount: NSDecimalNumber.init(value: 10.0),
+                                  identifier: "Express",
+                                  detail: "10-15 Days"))
+        return shippingMethods
+    }
+    
+    static func createPaymentSession(requiringShippingAddressFields: Bool, usingNonDefault controllerType: PaymentAuthorizationControlling.Type?) -> PaymentSession {
+        
+        if let controllerType = controllerType {
+            return PaymentSession.init(merchantId: merchantId,
+                                       countryCode: countryCode,
+                                       currencyCode: currencyCode,
+                                       requiringShippingAddressFields: requiringShippingAddressFields,
+                                       summaryItems: createSummaryItems(),
+                                       shippingMethods: createShippingMethods(),
+                                       controllerType: controllerType)
+        } else {
+            return PaymentSession.init(merchantId: merchantId,
+                                       countryCode: countryCode,
+                                       currencyCode: currencyCode,
+                                       requiringShippingAddressFields: requiringShippingAddressFields,
+                                       summaryItems: createSummaryItems(),
+                                       shippingMethods: createShippingMethods())
+        }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
@@ -1,9 +1,9 @@
 //
 //  Models.swift
-//  Unity-iPhone
+//  UnityBuySDK
 //
 //  Created by Shopify.
-//
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: 1f5208cf034dd4702a53682ee31c13d6
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift
@@ -1,0 +1,356 @@
+//
+//  PaymentSessionTests.swift
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+import PassKit
+
+@testable import ProductName
+
+class PaymentSessionTests: XCTestCase {
+
+    let expectTimeout = 10.0
+    
+    override func tearDown() {
+        if #available(iOS 10.0, *) {
+            MockAuthorizationController.instances.removeAll()
+        }
+    }
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    func testInit() {
+        
+        let summaryItems    = Models.createSummaryItems()
+        let shippingMethods = Models.createShippingMethods()
+        let session         = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: nil)
+    
+        XCTAssertEqual(session.request.merchantIdentifier,   Models.merchantId)
+        XCTAssertEqual(session.request.countryCode,          Models.countryCode)
+        XCTAssertEqual(session.request.currencyCode,         Models.currencyCode)
+        XCTAssertEqual(session.request.supportedNetworks,    PaymentSession.supportedNetworks)
+        XCTAssertEqual(session.request.paymentSummaryItems,  summaryItems)
+        XCTAssertEqual(session.request.shippingMethods!,     shippingMethods)
+        XCTAssertEqual(session.request.merchantCapabilities, .capability3DS)
+        XCTAssertEqual(session.request.requiredShippingAddressFields, .all)
+        XCTAssertEqual(session.request.requiredBillingAddressFields,  .all)
+        
+        let noShippingSession = Models.createPaymentSession(requiringShippingAddressFields: false, usingNonDefault: nil)
+        
+        XCTAssertEqual(noShippingSession.request.requiredShippingAddressFields, PKAddressField(rawValue: PKAddressField.email.rawValue | PKAddressField.phone.rawValue))
+    }
+    
+    // ----------------------------------
+    //  MARK: - Supported Networks -
+    //
+    func testSupportedNetworks() {
+        XCTAssertEqual(PaymentSession.supportedNetworks, [.amex, .masterCard, .visa, .discover])
+    }
+
+    // ----------------------------------
+    //  MARK: - Presenting and Dismissing -
+    //
+    /// Tests that the shouldResignActive is correctly set according to the state of the Payment view controller
+    @available(iOS 10.0, *)
+    func testPresentAndDismissViewController() {
+        
+        let session = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        
+        let unityController = UIApplication.shared.delegate as! UnityBuyAppController
+        print(unityController)
+        print(unityController.shouldResignActive)
+        
+        XCTAssertTrue(unityController.shouldResignActive)
+        
+        session.presentAuthorizationController()
+        XCTAssertFalse(unityController.shouldResignActive)
+
+        print(unityController)
+        print(unityController.shouldResignActive)
+        
+        MockAuthorizationController.invokeDidFinish()
+        print(unityController)
+        print(unityController.shouldResignActive)
+        
+        XCTAssertTrue(unityController.shouldResignActive)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Select Shipping Method -
+    //
+    @available(iOS 10.0, *)
+    func testSelectShippingMethod() {
+        let shippingMethods = Models.createShippingMethods()
+        var summaryItems    = Models.createSummaryItems()
+        let paymentSession  = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        
+        // Pretend that the user has chosen shipping method 2
+        let selectedMethod   = shippingMethods[1]
+        let completionStatus = PKPaymentAuthorizationStatus.success
+        summaryItems[2] = PKPaymentSummaryItem.init(label: "Shipping", amount: selectedMethod.amount)
+        
+        let delegate = MockPaymentSessionDelegate()
+        delegate.onSessionDidSelectShippingMethod = { session, method, completion in
+            
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(selectedMethod, method)
+            
+            completion(completionStatus, summaryItems)
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        let expectation = self.expectation(description: "MockAuthorizationController.invokeDidSelectShippingMethod failed to complete")
+        
+        MockAuthorizationController.invokeDidSelectShippingMethod(selectedMethod) { (status, items) in
+            XCTAssertEqual(completionStatus, status)
+            XCTAssertEqual(summaryItems, items)
+
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: expectTimeout)
+        
+        // Cleanup any Unity State that was changed from displaying MockAuthorizationController
+        MockAuthorizationController.invokeDidFinish();
+    }
+    
+    // ----------------------------------
+    //  MARK: - Select Shipping Contact -
+    //
+    @available(iOS 10.0, *)
+    func testSelectShippingContact() {
+        var shippingMethods = Models.createShippingMethods()
+        let summaryItems    = Models.createSummaryItems()
+        let paymentSession  = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        
+        // Pretend user has selected this contact, causing changes in shipping
+        let completionStatus = PKPaymentAuthorizationStatus.success
+        let selectedContact = PKContact.init()
+        selectedContact.emailAddress = "test@shopify.com"
+        shippingMethods.remove(at: 0)
+        
+        let delegate = MockPaymentSessionDelegate()
+        delegate.onSessionDidSelectShippingContact = { session, contact, completion in
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(selectedContact, contact)
+            completion(completionStatus, shippingMethods, summaryItems)
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        let expectation = self.expectation(description: "MockAuthorizationController.invokeDidSelectShippingContact failed to complete")
+
+        MockAuthorizationController.invokeDidSelectShippingContact(selectedContact) { (status, methods, items) in
+            XCTAssertEqual(completionStatus, status)
+            XCTAssertEqual(shippingMethods, methods)
+            XCTAssertEqual(summaryItems, items)
+            
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: expectTimeout)
+        
+        // Cleanup any Unity State that was changed
+        MockAuthorizationController.invokeDidFinish();
+    }
+    
+    // ----------------------------------
+    //  MARK: - Payment Authorization -
+    //
+    @available(iOS 10.0, *)
+    func testPaymentAuthorization() {
+        
+        let paymentSession   = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        let completionStatus = PKPaymentAuthorizationStatus.success
+        let expectedPayment  = Models.createPayment()
+        
+        let delegate = MockPaymentSessionDelegate()
+        delegate.onSessionDidAuthorizePayment = { session, payment, completion in
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(expectedPayment, payment)
+            completion(completionStatus)
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        let expectation = self.expectation(description: "MockAuthorizationController.invokeDidAuthorizePayment failed to complete")
+        
+        MockAuthorizationController.invokeDidAuthorizePayment(expectedPayment) { (status) in
+            XCTAssertEqual(completionStatus, status)
+            XCTAssertEqual(paymentSession.lastAuthStatus, completionStatus)
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: expectTimeout)
+        
+        // Cleanup any Unity State that was changed
+        MockAuthorizationController.invokeDidFinish();
+    }
+    
+    // ----------------------------------
+    //  MARK: - Payment Finishing -
+    //
+    
+    /// Tests that the correct states are passed to the PaymentSessionDelegate after authorizing and finishing
+    @available(iOS 10.0, *)
+    func testPaymentFinishSuccess() {
+        let paymentSession   = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        let completionStatus = PKPaymentAuthorizationStatus.success
+        let expectedPayment  = Models.createPayment()
+        let paymentStatus    = PaymentStatus.Success
+
+        let authorizeExpectation = self.expectation(description: "MockAuthorizationController.invokeDidAuthorizePayment failed to complete")
+        let finishExpectation    = self.expectation(description: "MockPaymentSessionDelegate.onSessionDidFinish failed to complete")
+        
+        let delegate = MockPaymentSessionDelegate()
+        
+        delegate.onSessionDidAuthorizePayment = { session, payment, completion in
+            completion(completionStatus)
+        }
+        
+        delegate.onSessionDidFinish = { session, status in
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(paymentStatus, status)
+            finishExpectation.fulfill()
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        MockAuthorizationController.invokeDidAuthorizePayment(expectedPayment) { (status) in
+            authorizeExpectation.fulfill()
+        }
+        
+        self.wait(for: [authorizeExpectation], timeout: expectTimeout)
+        
+        MockAuthorizationController.invokeDidFinish();
+        
+        self.wait(for: [finishExpectation], timeout: expectTimeout)
+    }
+    
+    /// Tests that the correct states are passed to the PaymentSessionDelegate after authorizing and finishing
+    @available(iOS 10.0, *)
+    func testPaymentFinishFailure() {
+        let paymentSession   = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        let completionStatus = PKPaymentAuthorizationStatus.failure
+        let expectedPayment  = Models.createPayment()
+        let paymentStatus    = PaymentStatus.Failed
+
+        let authorizeExpectation = self.expectation(description: "MockAuthorizationController.invokeDidAuthorizePayment failed to complete")
+        let finishExpectation    = self.expectation(description: "MockPaymentSessionDelegate.onSessionDidFinish failed to complete")
+        
+        let delegate = MockPaymentSessionDelegate()
+        
+        delegate.onSessionDidAuthorizePayment = { session, payment, completion in
+            completion(completionStatus)
+        }
+        
+        delegate.onSessionDidFinish = { session, status in
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(paymentStatus, status)
+            finishExpectation.fulfill()
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        MockAuthorizationController.invokeDidAuthorizePayment(expectedPayment) { (status) in
+            authorizeExpectation.fulfill()
+        }
+        
+        self.wait(for: [authorizeExpectation], timeout: expectTimeout)
+        
+        MockAuthorizationController.invokeDidFinish();
+        
+        self.wait(for: [finishExpectation], timeout: expectTimeout)
+    }
+    
+    /// Tests that the correct states are passed to the PaymentSessionDelegate after finishing without authorizing
+    @available(iOS 10.0, *)
+    func testPaymentFinishCancelled() {
+        let paymentSession    = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        let paymentStatus     = PaymentStatus.Cancelled
+        let finishExpectation = self.expectation(description: "MockPaymentSessionDelegate.onSessionDidFinish failed to complete")
+        
+        let delegate = MockPaymentSessionDelegate()
+        
+        delegate.onSessionDidFinish = { session, status in
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(paymentStatus, status)
+            XCTAssertNil(paymentSession.lastAuthStatus)
+            finishExpectation.fulfill()
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        MockAuthorizationController.invokeDidFinish();
+        
+        self.wait(for: [finishExpectation], timeout: expectTimeout)
+    }
+    
+    /// Tests that the correct states are passed to the PaymentSessionDelegate after authorizing and finishing
+    @available(iOS 10.0, *)
+    func testPaymentFinishAuthorizedCancelled() {
+        let paymentSession    = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
+        let expectedPayment   = Models.createPayment()
+        let paymentStatus     = PaymentStatus.Cancelled
+        let completionStatus  = PKPaymentAuthorizationStatus.invalidShippingPostalAddress
+        
+        let authorizeExpectation = self.expectation(description: "MockAuthorizationController.invokeDidAuthorizePayment failed to complete")
+        let finishExpectation    = self.expectation(description: "MockPaymentSessionDelegate.onSessionDidFinish failed to complete")
+        
+        let delegate = MockPaymentSessionDelegate()
+        
+        delegate.onSessionDidAuthorizePayment = { session, payment, completion in
+            completion(completionStatus)
+        }
+        
+        delegate.onSessionDidFinish = { session, status in
+            XCTAssertEqual(paymentSession, session)
+            XCTAssertEqual(paymentStatus, status)
+            XCTAssertEqual(paymentSession.lastAuthStatus, completionStatus)
+            finishExpectation.fulfill()
+        }
+        
+        paymentSession.delegate = delegate
+        paymentSession.presentAuthorizationController()
+        
+        MockAuthorizationController.invokeDidAuthorizePayment(expectedPayment) { (status) in
+            authorizeExpectation.fulfill()
+        }
+        
+        self.wait(for: [authorizeExpectation], timeout: expectTimeout)
+        
+        MockAuthorizationController.invokeDidFinish();
+        
+        self.wait(for: [finishExpectation], timeout: expectTimeout)
+    }
+}

--- a/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: 49ab90a1f65554b80a8d82b351638afe
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/BuyTests/SerializableTests.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/SerializableTests.swift.meta
@@ -1,13 +1,12 @@
 fileFormatVersion: 2
 guid: 6ca3b34bc28ac40e782bdee1bcdcb4a9
-timeCreated: 1495567347
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1
   iconMap: {}
   executionOrder: {}
   isPreloaded: 0
-  isOverridable: 0
   platformData:
     Any:
       enabled: 0

--- a/Assets/Plugins/iOS/Shopify/PKPaymentToken+Serializable.swift
+++ b/Assets/Plugins/iOS/Shopify/PKPaymentToken+Serializable.swift
@@ -36,7 +36,7 @@ extension PKPaymentToken: Serializable {
     
     func serializedJSON() -> JSON {
         var json = JSON()
-        json.insert(nullable: try! JSONSerialization.jsonObject(with: self.paymentData), forKey: PaymentTokenField.paymentData)
+        json.insert(nullable: try? JSONSerialization.jsonObject(with: self.paymentData), forKey: PaymentTokenField.paymentData)
         json.insert(nullable: self.transactionIdentifier, forKey: PaymentTokenField.transactionIdentifier)
         return json
     }

--- a/Assets/Plugins/iOS/Shopify/PKShippingMethod+Init.swift
+++ b/Assets/Plugins/iOS/Shopify/PKShippingMethod+Init.swift
@@ -1,9 +1,9 @@
 //
-//  MockToken.swift
+//  PKShippingMethod+Identifier.swift
 //  UnityBuySDK
 //
 //  Created by Shopify.
-//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,10 @@
 import Foundation
 import PassKit
 
-class MockPaymentToken: PKPaymentToken {
-    
-    override var paymentMethod: PKPaymentMethod {
-        return self._paymentMethod
-    }
-    
-    override var transactionIdentifier: String {
-        return self._transactionIdentifier
-    }
-    
-    override var paymentData: Data {
-        return self._paymentData
-    }
-    
-    private let _paymentMethod: MockPaymentMethod
-    private let _transactionIdentifier = UUID().uuidString
-    private let _paymentData           = try! JSONSerialization.data(withJSONObject: [String: Any]())
-    
-    // ----------------------------------
-    //  MARK: - Init -
-    //
-    init(paymentMethod: MockPaymentMethod) {
-        self._paymentMethod = paymentMethod
+extension PKShippingMethod {
+    convenience init(label: String, amount: NSDecimalNumber, identifier: String? = nil, detail: String? = nil) {
+        self.init(label: label, amount: amount)
+        self.identifier = identifier
+        self.detail     = detail
     }
 }

--- a/Assets/Plugins/iOS/Shopify/PKShippingMethod+Init.swift
+++ b/Assets/Plugins/iOS/Shopify/PKShippingMethod+Init.swift
@@ -3,7 +3,7 @@
 //  UnityBuySDK
 //
 //  Created by Shopify.
-//
+//  Copyright © 2017 Shopify Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Assets/Plugins/iOS/Shopify/PKShippingMethod+Init.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/PKShippingMethod+Init.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: df510a38efed8429797340886daa95d7
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling.meta
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6ac517c707ad149b2b7e93a3423135ca
+folderAsset: yes
+timeCreated: 1496344093
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationController+PaymentAuthorizationControlling.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationController+PaymentAuthorizationControlling.swift
@@ -1,9 +1,9 @@
 //
-//  MockToken.swift
+//  PKPaymentAuthorizationController+PaymentAuthorizationControlling.swift
 //  UnityBuySDK
 //
 //  Created by Shopify.
-//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,18 @@
 import Foundation
 import PassKit
 
-class MockPaymentToken: PKPaymentToken {
-    
-    override var paymentMethod: PKPaymentMethod {
-        return self._paymentMethod
-    }
-    
-    override var transactionIdentifier: String {
-        return self._transactionIdentifier
-    }
-    
-    override var paymentData: Data {
-        return self._paymentData
-    }
-    
-    private let _paymentMethod: MockPaymentMethod
-    private let _transactionIdentifier = UUID().uuidString
-    private let _paymentData           = try! JSONSerialization.data(withJSONObject: [String: Any]())
-    
-    // ----------------------------------
-    //  MARK: - Init -
-    //
-    init(paymentMethod: MockPaymentMethod) {
-        self._paymentMethod = paymentMethod
+@available(iOS 10.0, *)
+extension PKPaymentAuthorizationController: PaymentAuthorizationControlling {
+    var authorizationDelegate: NSObjectProtocol? {
+        get {
+            return delegate
+        }
+        set {
+            if let delegate = newValue as? PKPaymentAuthorizationControllerDelegate {
+                self.delegate = delegate
+            } else {
+                self.delegate = nil
+            }
+        }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationController+PaymentAuthorizationControlling.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationController+PaymentAuthorizationControlling.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: 811fa9c75093e44bd8098c168f68d297
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift
@@ -34,16 +34,13 @@ extension PKPaymentAuthorizationViewController: PaymentAuthorizationControlling 
             return delegate
         }
         set {
-            if let delegate = newValue as? PKPaymentAuthorizationViewControllerDelegate {
-                self.delegate = delegate
-            } else {
-                self.delegate = nil
-            }
+            self.delegate = newValue as? PKPaymentAuthorizationViewControllerDelegate
         }
     }
     
     func present(completion: ((Bool) -> Void)?) {
-        if let rootViewController = UIApplication.shared.delegate?.window??.rootViewController {
+        if let window = UIApplication.shared.delegate?.window,
+            let rootViewController = window?.rootViewController {
             rootViewController.present(self, animated: true) {
                 completion?(true)
             };

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift
@@ -1,9 +1,9 @@
 //
-//  MockToken.swift
+//  PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift
 //  UnityBuySDK
 //
 //  Created by Shopify.
-//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,38 @@
 import Foundation
 import PassKit
 
-class MockPaymentToken: PKPaymentToken {
+extension PKPaymentAuthorizationViewController: PaymentAuthorizationControlling {
     
-    override var paymentMethod: PKPaymentMethod {
-        return self._paymentMethod
+    var authorizationDelegate: NSObjectProtocol? {
+        get {
+            return delegate
+        }
+        set {
+            if let delegate = newValue as? PKPaymentAuthorizationViewControllerDelegate {
+                self.delegate = delegate
+            } else {
+                self.delegate = nil
+            }
+        }
     }
     
-    override var transactionIdentifier: String {
-        return self._transactionIdentifier
+    func present(completion: ((Bool) -> Void)?) {
+        if let rootViewController = UIApplication.shared.delegate?.window??.rootViewController {
+            rootViewController.present(self, animated: true) {
+                completion?(true)
+            };
+        } else {
+            completion?(false)
+        }
     }
     
-    override var paymentData: Data {
-        return self._paymentData
-    }
-    
-    private let _paymentMethod: MockPaymentMethod
-    private let _transactionIdentifier = UUID().uuidString
-    private let _paymentData           = try! JSONSerialization.data(withJSONObject: [String: Any]())
-    
-    // ----------------------------------
-    //  MARK: - Init -
-    //
-    init(paymentMethod: MockPaymentMethod) {
-        self._paymentMethod = paymentMethod
+    func dismiss(completion: (() -> Void)?) {
+        if let presentingViewController = self.presentingViewController {
+            presentingViewController.dismiss(animated: true) {
+                completion?()
+            }
+        } else {
+            completion?()
+        }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PKPaymentAuthorizationViewController+PaymentAuthorizationControlling.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: 9e31218cb22f9427fa9d6bed92ab4fee
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PaymentAuthorizationControlling.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PaymentAuthorizationControlling.swift
@@ -1,9 +1,9 @@
 //
-//  MockToken.swift
-//  UnityBuySDK
+//  PaymentAuthorizationControlling.swift
+//  Unity-iPhone
 //
 //  Created by Shopify.
-//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,11 @@
 import Foundation
 import PassKit
 
-class MockPaymentToken: PKPaymentToken {
+@objc protocol PaymentAuthorizationControlling {
     
-    override var paymentMethod: PKPaymentMethod {
-        return self._paymentMethod
-    }
+    var authorizationDelegate: NSObjectProtocol? { get set }
     
-    override var transactionIdentifier: String {
-        return self._transactionIdentifier
-    }
-    
-    override var paymentData: Data {
-        return self._paymentData
-    }
-    
-    private let _paymentMethod: MockPaymentMethod
-    private let _transactionIdentifier = UUID().uuidString
-    private let _paymentData           = try! JSONSerialization.data(withJSONObject: [String: Any]())
-    
-    // ----------------------------------
-    //  MARK: - Init -
-    //
-    init(paymentMethod: MockPaymentMethod) {
-        self._paymentMethod = paymentMethod
-    }
+    init(paymentRequest request: PKPaymentRequest)
+    func present(completion: ((Bool) -> Void)?)
+    func dismiss(completion: (() -> Void)?)
 }

--- a/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PaymentAuthorizationControlling.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PaymentAuthorizationControlling.swift.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: a88567d1553594f4bbfee38849cb8d26
-timeCreated: 1495551079
+guid: 926a242534af64c2a8b61099058c21b5
+timeCreated: 1496344108
 licenseType: Free
 PluginImporter:
   serializedVersion: 1

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -1,0 +1,171 @@
+//
+//  PaymentSession.swift
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+import PassKit
+
+@objc enum PaymentStatus: Int {
+    case Failed
+    case Cancelled
+    
+    func toString() -> String {
+        switch self {
+        case .Cancelled:
+            return "Cancelled"
+        case .Failed:
+            return "Failed"
+        }
+    }
+}
+
+@objc protocol PaymentSessionDelegate : class {
+    func paymentSessionDidFinish(session: PaymentSession,with status: PaymentStatus)
+    func paymentSession(_ session: PaymentSession, didSelect shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void)
+    func paymentSession(_ session: PaymentSession, didSelectShippingContact shippingContact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void)
+    func paymentSession(_ session: PaymentSession, didAuthorize payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void)
+}
+
+@objc class PaymentSession: NSObject {
+    
+    let request: PKPaymentRequest
+    var summaryItems: [PKPaymentSummaryItem]
+    /// The last status of the authorization received by passing the token data
+    /// to the payment server
+    var lastAuthStatus: PKPaymentAuthorizationStatus?
+    
+    weak var delegate: PaymentSessionDelegate?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    init(merchantId: String, countryCode: String, currencyCode: String, requiringShippingAddressFields: Bool, summaryItems: [PKPaymentSummaryItem], shippingMethods:[PKShippingMethod]?)
+    {
+        request = PKPaymentRequest.init()
+        request.countryCode                   = countryCode
+        request.currencyCode                  = currencyCode
+        request.merchantIdentifier            = merchantId
+        request.requiredBillingAddressFields  = .all
+        request.merchantCapabilities          = .capability3DS
+        request.supportedNetworks             = PaymentSession.supportedNetworks
+        request.requiredShippingAddressFields = requiringShippingAddressFields ?
+            .all : PKAddressField.init(rawValue: PKAddressField.email.rawValue | PKAddressField.phone.rawValue)
+        
+        request.paymentSummaryItems = summaryItems
+        request.shippingMethods     = shippingMethods
+        
+        self.summaryItems = summaryItems
+        
+        super.init()
+    }
+    
+    /// Presents the PKAuthorizationController with the current shipping methods
+    /// and summary items in this session.
+    /// UnityAppController is set to remain active until the authorization controller
+    /// is dismissed, to enable communication between managed and unmanaged functions
+    func presentAuthorizationController()  {
+        let authViewController = PKPaymentAuthorizationViewController.init(paymentRequest: request)
+        let unityController    = UIApplication.shared.delegate as! UnityBuyAppController
+        let topController      = unityController.topMostController()!
+
+        authViewController.delegate = self
+        unityController.shouldResignActive = false
+        topController.present(authViewController, animated: true)
+    }
+}
+
+// ----------------------------------
+//  MARK: - Static functions -
+//
+extension PaymentSession {
+    
+    static let supportedNetworks: [PKPaymentNetwork] = [.amex, .masterCard, .visa, .discover]
+    
+    static func canMakePayments() -> Bool {
+        return PKPaymentAuthorizationViewController.canMakePayments() &&
+            PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks)
+    }
+    
+    static func canShowSetup() -> Bool {
+        return PKPaymentAuthorizationViewController.canMakePayments() &&
+            !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks)
+    }
+    
+    static func showSetup() {
+        PKPassLibrary.init().openPaymentSetup()
+    }
+}
+
+// ----------------------------------
+//  MARK: - PKPaymentAuthorizationViewControllerDelegate -
+//
+extension PaymentSession: PKPaymentAuthorizationViewControllerDelegate {
+    
+    func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+        
+        let paymentStatus: PaymentStatus
+        let unityController = UIApplication.shared.delegate as! UnityBuyAppController
+        unityController.shouldResignActive = true
+        
+        if lastAuthStatus == .failure {
+            paymentStatus = .Failed
+        } else {
+            paymentStatus = .Cancelled
+        }
+        
+        controller.dismiss(animated: true) {
+            self.delegate?.paymentSessionDidFinish(session: self, with: paymentStatus)
+        }
+    }
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
+        
+        delegate?.paymentSession(self, didSelect: shippingMethod) { (status: PKPaymentAuthorizationStatus, items: [PKPaymentSummaryItem]) in
+            self.summaryItems = items
+            completion(status, items)
+        }
+    }
+
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect paymentMethod: PKPaymentMethod, completion: @escaping ([PKPaymentSummaryItem]) -> Void) {
+        completion(self.summaryItems)
+    }
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelectShippingContact contact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) {
+        
+        delegate?.paymentSession(self, didSelectShippingContact: contact) {
+            (status: PKPaymentAuthorizationStatus, shippingMethods: [PKShippingMethod], items: [PKPaymentSummaryItem]) in
+            self.summaryItems = items
+            completion(status, shippingMethods ,items)
+        }
+    }
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didAuthorizePayment payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
+        
+        delegate?.paymentSession(self, didAuthorize: payment) { (status: PKPaymentAuthorizationStatus) in
+            self.lastAuthStatus = status
+            completion(status)
+        }
+    }
+}

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -43,7 +43,12 @@ import PassKit
         }
     }
     
-    static func from(status: PKPaymentAuthorizationStatus) -> PaymentStatus{
+    static func from(status: PKPaymentAuthorizationStatus?) -> PaymentStatus {
+        
+        guard let status = status else {
+            return .Cancelled
+        }
+        
         switch status {
         case .failure:
             return .Failed
@@ -140,15 +145,9 @@ extension PaymentSession {
 extension PaymentSession {
     
     func paymentAuthorizationDidFinish() {
-        let paymentStatus: PaymentStatus;
+        let paymentStatus   = PaymentStatus.from(status: lastAuthStatus)
         let unityController = UIApplication.shared.delegate as! UnityBuyAppController
         unityController.shouldResignActive = true
-        
-        if let lastAuthStatus = lastAuthStatus {
-            paymentStatus = PaymentStatus.from(status: lastAuthStatus)
-        } else {
-            paymentStatus = .Cancelled
-        }
         
         self.controller.dismiss {
             self.delegate?.paymentSessionDidFinish(session: self, with: paymentStatus)

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: b3019f04b47ea433a9a587922876c87b
+timeCreated: 1496344108
+licenseType: Free
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+    iOS:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h
+++ b/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h
@@ -8,4 +8,3 @@
 
 #import "UnityBuyAppController.h"
 #import "UnityAppController+ViewHandling.h"
-#import "UnityInterfaceWrapper.h"

--- a/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h
+++ b/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h
@@ -1,0 +1,11 @@
+//
+//  Unity-iPhone-Bridging-Header.h
+//  Unity-iPhone
+//
+//  Created by Jeffrey Deng on 2017-05-02.
+//
+//
+
+#import "UnityBuyAppController.h"
+#import "UnityAppController+ViewHandling.h"
+#import "UnityInterfaceWrapper.h"

--- a/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h
+++ b/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h
@@ -1,9 +1,27 @@
 //
 //  Unity-iPhone-Bridging-Header.h
-//  Unity-iPhone
+//  UnityBuySDK
 //
-//  Created by Jeffrey Deng on 2017-05-02.
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 #import "UnityBuyAppController.h"

--- a/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h.meta
+++ b/Assets/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: f5a81f676946d46e996c7aea1c9fbac3
+timeCreated: 1496348345
+licenseType: Free
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+    iOS:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/UnityBuyAppController.h
+++ b/Assets/Plugins/iOS/Shopify/UnityBuyAppController.h
@@ -1,0 +1,34 @@
+//
+//  UnityBuyAppController.h
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+
+#import "UnityAppController.h"
+
+@interface UnityBuyAppController : UnityAppController
+
+@property (assign, nonatomic) bool shouldResignActive;
+
+@end

--- a/Assets/Plugins/iOS/Shopify/UnityBuyAppController.h.meta
+++ b/Assets/Plugins/iOS/Shopify/UnityBuyAppController.h.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 168564763f8b540428a388cf2915e6e4
+timeCreated: 1496344108
+licenseType: Free
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+    iOS:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/UnityBuyAppController.mm
+++ b/Assets/Plugins/iOS/Shopify/UnityBuyAppController.mm
@@ -1,0 +1,51 @@
+//
+//  UnityBuyAppController.m
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "UnityBuyAppController.h"
+
+extern bool _didResignActive;
+
+IMPL_APP_CONTROLLER_SUBCLASS(UnityBuyAppController)
+
+@implementation UnityBuyAppController
+
+- (id)init {
+    
+    if (self = [super init]) {
+        _shouldResignActive = true;
+    }
+    
+    return self;
+}
+
+- (void)applicationWillResignActive:(UIApplication*)application
+{
+    [super applicationWillResignActive:application];
+    if (!_shouldResignActive) {
+        _didResignActive = false;
+    }
+}
+@end

--- a/Assets/Plugins/iOS/Shopify/UnityBuyAppController.mm.meta
+++ b/Assets/Plugins/iOS/Shopify/UnityBuyAppController.mm.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 4d4357bbedeaa44fdb6c768ffbf3bd72
+timeCreated: 1496344108
+licenseType: Free
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+    iOS:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
+ Fixes PKPaymentToken+Serializable to handle cases where token data is nil. Testing Apple Pay on the simulator returns nil token data.
+ Adds `UnityBuyAppController`
    + A subclass of  `UnityAppController` that overrides the delegate method that is called when the app is about to resign active. This way we can control whether the app resigns active when the `PKPaymentAuthorizationViewController` is shown. By setting `didResignActive` to false Unity will continue to process messages sent via UnitySendMessage.
+ Adds a `PaymentSession` implementation
    + `PaymentSession` is responsible for creating the `PKPaymentRequest` and displaying a `PKPaymentAuthorizationViewController` on `iOS 9` or `PKPaymentAuthorizationController` on `iOS 10+`
    + I used the protocol `PaymentAuthorizationControlling` to generalize these two classes, so that PaymentSession can be modified to use either
   + On `PKPaymentAuthorizationViewControllerDelegate` notifications the `PaymentSession` will notify it's own `PaymentSessionDelegate` requesting for updated summary items and shipping info
        + There is no `PaymentSessionDelegate` method for
`paymentAuthorizationViewController(controller:, didSelect paymentMethod:, completion:`  because I do not see a use for the info provided in `PKPaymentMethod` for completing a checkout
+ What is different from the closed PR #82 ?
    + I removed the semaphore locks in this class. Instead as discussed the functionality for locking and retrieving updated info will be handled in another object. This keeps objects loosely coupled, and reduces the points of interaction between managed and unmanaged code.

+ Adds Tests and Mocks for PaymentSession
    + We use a subclass of `PKPaymentAuthorizationController`  as a mock to test the functionality for `PKPaymentAuthorizationControllerDelegate` and `PKPaymentAuthorizationViewControllerDelegate` methods. In `PaymentSession` we handle both delegate callbacks with a single method, thus testing with only the controller should be sufficient.

+ Step towards #65 