### PR TITLE
[Feature] Merge utils

### DIFF
--- a/Assets/Editor/BaseMockLoader.cs.meta
+++ b/Assets/Editor/BaseMockLoader.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b3c51fa720eae404c84b36a88260f69f
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/IMockLoader.cs.meta
+++ b/Assets/Editor/IMockLoader.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 140e177a8e025437ebd4b87927041b39
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MockLoaderCollections.cs.meta
+++ b/Assets/Editor/MockLoaderCollections.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4374db1647a2841e8a99c563e3f871aa
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MockLoaderErrors.cs.meta
+++ b/Assets/Editor/MockLoaderErrors.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d5236e51d08884a23aa8b401e89f1d63
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MockLoaderGeneric.cs.meta
+++ b/Assets/Editor/MockLoaderGeneric.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 683963046119e4faea60ae5d3a25ebc2
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MockLoaderProducts.cs.meta
+++ b/Assets/Editor/MockLoaderProducts.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6473dda84810a4915817f32e6091e644
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/TestMockLoaders.cs.meta
+++ b/Assets/Editor/TestMockLoaders.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a49bc27afd4a644a69c508cf5f498cde
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -2,6 +2,7 @@ namespace Shopify.Tests
 {
     using NUnit.Framework;
     using Shopify.Unity.SDK;
+    using System.Collections;
     using System.Collections.Generic;
 
     [TestFixture]
@@ -39,6 +40,38 @@ namespace Shopify.Tests
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
             Assert.AreNotEqual(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]);
             Assert.AreNotEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]);
+        }
+
+        [Test]
+        public void CustomFieldMerger() {
+            Dictionary<string, object> responseA = GetResponseA();
+            Dictionary<string, object> responseB = GetResponseB();
+
+            ResponseMergeUtil merger = new ResponseMergeUtil();
+
+            merger.AddFieldMerger("fieldInBoth", (string field, IDictionary into, IDictionary dataA, IDictionary dataB) => {
+                into[field] = (string) dataA[field] + (string) dataB[field];
+            });
+
+            Dictionary<string, object> merged = merger.Merge(responseA, responseB);
+
+            Assert.AreEqual("i am ai am b", merged["fieldInBoth"], "Custom merger worked");
+        }
+
+        [Test]
+        public void MergeListsConcat() {
+            Dictionary<string, object> responseA = GetResponseA();
+            Dictionary<string, object> responseB = GetResponseB();
+
+            ResponseMergeUtil merger = new ResponseMergeUtil();
+
+            merger.AddFieldMerger("fieldHasList", ResponseMergeUtil.MergeListsConcat);
+
+            Dictionary<string, object> merged = merger.Merge(responseA, responseB);
+
+            Assert.AreEqual(2, ((List<object>) merged["fieldHasList"]).Count, "Has two elements");
+            Assert.AreEqual(0, ((List<object>) merged["fieldHasList"])[0], "First value was correct");
+            Assert.AreEqual(1, ((List<object>) merged["fieldHasList"])[1], "Second value was correct");
         }
 
         private Dictionary<string,object> GetResponseA() {

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -82,11 +82,12 @@ namespace Shopify.Tests
 
             ResponseMergeUtil merger = new ResponseMergeUtil();
 
-            merger.AddFieldMerger("fieldInBoth", ResponseMergeUtil.DoNotMerge);
+            merger.AddFieldMerger("fieldInBoth", ResponseMergeUtil.DoNotMergeIfExists);
 
             Dictionary<string, object> merged = merger.Merge(responseA, responseB);
 
-            Assert.AreEqual("i am a", merged["fieldInBoth"], "Custom merger worked");
+            Assert.AreEqual("i am a", merged["fieldInBoth"], "Did not merge when existed");
+            Assert.AreEqual(33, merged["fieldOnlyInB"], "Merged when did not exist");
         }
 
         private Dictionary<string,object> GetResponseA() {
@@ -103,6 +104,7 @@ namespace Shopify.Tests
 
         private Dictionary<string,object> GetResponseB() {
             return new Dictionary<string, object>() {
+                {"fieldOnlyInB", 33},
                 {"fieldInBoth", "i am b"},
                 {"fieldHasList", new List<int>() { 1 }},
                 {"fieldHasDictionary", new Dictionary<string, string>(){

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -38,8 +38,8 @@ namespace Shopify.Tests
 
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
-            Assert.AreNotEqual(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]);
-            Assert.AreNotEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]);
+            Assert.AreNotEqual(responseA["fieldHasDictionary"], merged["fieldHasDictionary"], "Creted a new nested object that was not responseA");
+            Assert.AreNotEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"], "Creted a new nested object that was not responseB");
         }
 
         [Test]

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -17,8 +17,8 @@ namespace Shopify.Tests
 
             Dictionary<string, object> merged = merger.Merge(responseA, responseB);
 
-            Assert.AreNotEqual(responseA, merged, "the merged dictionary is a dictionary. Is not responseA");
-            Assert.AreNotEqual(responseB, merged, "the merged dictionary is a dictionary. Is not responseB");
+            Assert.AreNotEqual(responseA, merged, "The merged dictionary is not responseA");
+            Assert.AreNotEqual(responseB, merged, "The merged dictionary is not responseB");
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
             Assert.AreEqual(1, ((List<int>) merged["fieldHasList"])[0], "Overwrote field in A from B that is a list");

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -17,6 +17,8 @@ namespace Shopify.Tests
 
             Dictionary<string, object> merged = merger.Merge(responseA, responseB);
 
+            Assert.IsTrue(!Object.ReferenceEquals(responseA, merged));
+            Assert.IsTrue(!Object.ReferenceEquals(responseB, merged));
             Assert.AreNotEqual(responseA, merged, "The merged dictionary is not responseA");
             Assert.AreNotEqual(responseB, merged, "The merged dictionary is not responseB");
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -22,7 +22,7 @@ namespace Shopify.Tests
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
             Assert.AreEqual(1, ((List<int>) merged["fieldHasList"])[0], "Overwrote field in A from B that is a list");
-            Assert.AreEqual("monkey", ((Dictionary<string, string>) merged["fieldHasDictionary"])["keyA"], "Overwrote field in A from B that is a list");
+            Assert.AreEqual("monkey", ((Dictionary<string, object>) merged["fieldHasDictionary"])["keyA"], "Overwrote field in A from B that is a list");
             Assert.IsTrue(Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]));
         }
 
@@ -50,7 +50,7 @@ namespace Shopify.Tests
 
             ResponseMergeUtil merger = new ResponseMergeUtil();
 
-            merger.AddFieldMerger("fieldInBoth", (string field, IDictionary into, IDictionary dataA, IDictionary dataB) => {
+            merger.AddFieldMerger("fieldInBoth", (string field, Dictionary<string, object> into, Dictionary<string, object> dataA, Dictionary<string, object> dataB) => {
                 into[field] = (string) dataA[field] + (string) dataB[field];
             });
 
@@ -95,7 +95,7 @@ namespace Shopify.Tests
                 {"fieldOnlyInA", 3},
                 {"fieldInBoth", "i am a"},
                 {"fieldHasList", new List<int>() { 0 }},
-                {"fieldHasDictionary", new Dictionary<string, string>(){
+                {"fieldHasDictionary", new Dictionary<string, object>(){
                     {"keyA", "valueA"},
                     {"keyB", "valueB"}
                 }}
@@ -107,7 +107,7 @@ namespace Shopify.Tests
                 {"fieldOnlyInB", 33},
                 {"fieldInBoth", "i am b"},
                 {"fieldHasList", new List<int>() { 1 }},
-                {"fieldHasDictionary", new Dictionary<string, string>(){
+                {"fieldHasDictionary", new Dictionary<string, object>(){
                     {"keyA", "monkey"},
                     {"keyB", "zebra"}
                 }}

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -39,8 +39,8 @@ namespace Shopify.Tests
 
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
-            Assert.IsTrue(!Object.ReferenceEquals(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]), "Creted a new nested object that was not responseA");
-            Assert.IsTrue(!Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]), "Creted a new nested object that was not responseB");
+            Assert.IsTrue(!Object.ReferenceEquals(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]), "Created a new nested object that was not responseA");
+            Assert.IsTrue(!Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]), "Created a new nested object that was not responseB");
         }
 
         [Test]

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -24,6 +24,23 @@ namespace Shopify.Tests
             Assert.AreEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]);
         }
 
+        [Test]
+        public void TestNestedMerge() {
+            Dictionary<string, object> responseA = GetResponseA();
+            Dictionary<string, object> responseB = GetResponseB();
+
+            ResponseMergeUtil merger = new ResponseMergeUtil();
+
+            merger.AddObjectMerger("fieldHasDictionary", new ResponseMergeUtil());
+
+            Dictionary<string, object> merged = merger.Merge(responseA, responseB);
+
+            Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
+            Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
+            Assert.AreNotEqual(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]);
+            Assert.AreNotEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]);
+        }
+
         private Dictionary<string,object> GetResponseA() {
             return new Dictionary<string, object>() {
                 {"fieldOnlyInA", 3},

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -1,5 +1,6 @@
 namespace Shopify.Tests
 {
+    using System;
     using NUnit.Framework;
     using Shopify.Unity.SDK;
     using System.Collections;
@@ -38,8 +39,8 @@ namespace Shopify.Tests
 
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
-            Assert.AreNotEqual(responseA["fieldHasDictionary"], merged["fieldHasDictionary"], "Creted a new nested object that was not responseA");
-            Assert.AreNotEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"], "Creted a new nested object that was not responseB");
+            Assert.IsTrue(!Object.ReferenceEquals(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]), "Creted a new nested object that was not responseA");
+            Assert.IsTrue(!Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]), "Creted a new nested object that was not responseB");
         }
 
         [Test]

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -75,6 +75,20 @@ namespace Shopify.Tests
             Assert.AreEqual(1, ((List<object>) merged["fieldHasList"])[1], "Second value was correct");
         }
 
+        [Test]
+        public void DoNotMerge() {
+            Dictionary<string, object> responseA = GetResponseA();
+            Dictionary<string, object> responseB = GetResponseB();
+
+            ResponseMergeUtil merger = new ResponseMergeUtil();
+
+            merger.AddFieldMerger("fieldInBoth", ResponseMergeUtil.DoNotMerge);
+
+            Dictionary<string, object> merged = merger.Merge(responseA, responseB);
+
+            Assert.AreEqual("i am a", merged["fieldInBoth"], "Custom merger worked");
+        }
+
         private Dictionary<string,object> GetResponseA() {
             return new Dictionary<string, object>() {
                 {"fieldOnlyInA", 3},

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -17,8 +17,8 @@ namespace Shopify.Tests
 
             Dictionary<string, object> merged = merger.Merge(responseA, responseB);
 
-            Assert.IsTrue(!Object.ReferenceEquals(responseA, merged));
-            Assert.IsTrue(!Object.ReferenceEquals(responseB, merged));
+            Assert.IsFalse(Object.ReferenceEquals(responseA, merged));
+            Assert.IsFalse(Object.ReferenceEquals(responseB, merged));
             Assert.AreNotEqual(responseA, merged, "The merged dictionary is not responseA");
             Assert.AreNotEqual(responseB, merged, "The merged dictionary is not responseB");
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
@@ -41,8 +41,8 @@ namespace Shopify.Tests
 
             Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
-            Assert.IsTrue(!Object.ReferenceEquals(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]), "Created a new nested object that was not responseA");
-            Assert.IsTrue(!Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]), "Created a new nested object that was not responseB");
+            Assert.IsFalse(Object.ReferenceEquals(responseA["fieldHasDictionary"], merged["fieldHasDictionary"]), "Created a new nested object that was not responseA");
+            Assert.IsFalse(Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]), "Created a new nested object that was not responseB");
         }
 
         [Test]

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -1,0 +1,50 @@
+namespace Shopify.Tests
+{
+    using NUnit.Framework;
+    using Shopify.Unity.SDK;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    public class TestResponseMergeUtil {
+        [Test]
+        public void TestDefaultMerge() {
+            Dictionary<string, object> responseA = GetResponseA();
+            Dictionary<string, object> responseB = GetResponseB();
+
+            ResponseMergeUtil merger = new ResponseMergeUtil();
+
+            Dictionary<string, object> merged = merger.Merge(responseA, responseB);
+
+            Assert.AreNotEqual(responseA, merged, "the merged dictionary is a dictionary. Is not responseA");
+            Assert.AreNotEqual(responseB, merged, "the merged dictionary is a dictionary. Is not responseB");
+            Assert.AreEqual(3, merged["fieldOnlyInA"], "Brought in field from A");
+            Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
+            Assert.AreEqual(1, ((List<int>) merged["fieldHasList"])[0], "Overwrote field in A from B that is a list");
+            Assert.AreEqual("monkey", ((Dictionary<string, string>) merged["fieldHasDictionary"])["keyA"], "Overwrote field in A from B that is a list");
+            Assert.AreEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]);
+        }
+
+        private Dictionary<string,object> GetResponseA() {
+            return new Dictionary<string, object>() {
+                {"fieldOnlyInA", 3},
+                {"fieldInBoth", "i am a"},
+                {"fieldHasList", new List<int>() { 0 }},
+                {"fieldHasDictionary", new Dictionary<string, string>(){
+                    {"keyA", "valueA"},
+                    {"keyB", "valueB"}
+                }}
+            };
+        }
+
+        private Dictionary<string,object> GetResponseB() {
+            return new Dictionary<string, object>() {
+                {"fieldInBoth", "i am b"},
+                {"fieldHasList", new List<int>() { 1 }},
+                {"fieldHasDictionary", new Dictionary<string, string>(){
+                    {"keyA", "monkey"},
+                    {"keyB", "zebra"}
+                }}
+            };
+        }
+    }
+}

--- a/Assets/Editor/TestResponeMergeUtil.cs
+++ b/Assets/Editor/TestResponeMergeUtil.cs
@@ -23,7 +23,7 @@ namespace Shopify.Tests
             Assert.AreEqual("i am b", merged["fieldInBoth"], "Overwrote field in A from B");
             Assert.AreEqual(1, ((List<int>) merged["fieldHasList"])[0], "Overwrote field in A from B that is a list");
             Assert.AreEqual("monkey", ((Dictionary<string, string>) merged["fieldHasDictionary"])["keyA"], "Overwrote field in A from B that is a list");
-            Assert.AreEqual(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]);
+            Assert.IsTrue(Object.ReferenceEquals(responseB["fieldHasDictionary"], merged["fieldHasDictionary"]));
         }
 
         [Test]

--- a/Assets/Editor/TestResponeMergeUtil.cs.meta
+++ b/Assets/Editor/TestResponeMergeUtil.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 14f55d88bb4534f15a2c16fa5d54b281
+timeCreated: 1497032874
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/UtilsMockLoader.cs.meta
+++ b/Assets/Editor/UtilsMockLoader.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 218b7a43a3ac245179b4a1a70ce4e377
+timeCreated: 1495746998
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/examples.txt.meta
+++ b/Assets/Shopify/examples.txt.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b1fc4f30cd4004d2b96294348edc5605
-timeCreated: 1495563369
-licenseType: Free
-TextScriptImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -106,6 +106,7 @@ module GraphQLGenerator
         SDK/UnityLoader
         SDK/TopLevelResponse
         SDK/MutationResponse
+        SDK/ResponseMergeUtil
         SDK/QueryResponse
         SDK/ILoader
         SDK/Log

--- a/scripts/generator/graphql_generator/csharp/SDK/AbstractResponse.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/AbstractResponse.cs.erb
@@ -4,9 +4,9 @@ namespace <%= namespace %>.SDK {
     using System.Collections.Generic;
 
     public abstract class AbstractResponse {
+        public Dictionary<string,object> DataJSON { get; protected set; }
         protected Dictionary<string,object> Data;
-        protected Dictionary<string,object> DataJSON;
-
+        
         protected T Get<T>(string field, string alias = null) {
             if (alias != null) {
                 ValidationUtils.ValidateAlias(alias);

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -6,7 +6,11 @@ namespace <%= namespace %>.SDK {
     public class ResponseMergeUtil {
         public delegate void MergeFieldDelegate(string field, IDictionary into, IDictionary responseA, IDictionary responseB);
 
-        public static void DoNotMerge(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {}
+        public static void DoNotMergeIfExists(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
+            if (!responseA.Contains(field)) {
+                into[field] = responseB[field];
+            }
+        }
 
         public static void MergeOverwrite(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
             into[field] = responseB[field];

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -10,6 +10,22 @@ namespace <%= namespace %>.SDK {
             into[field] = responseB[field];
         }
 
+        public static void MergeListsConcat(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
+            List<object> newList = new List<object>();
+            IList listA = (IList) responseA[field];
+            IList listB = (IList) responseB[field];
+
+            foreach(object item in listA) {
+                newList.Add(item);
+            }
+
+            foreach(object item in listB) {
+                newList.Add(item);
+            }
+
+            into[field] = newList;
+        }
+
         private Dictionary<string, MergeFieldDelegate> FieldMergers = new Dictionary<string, MergeFieldDelegate>();
         private Dictionary<string, ResponseMergeUtil> ObjectMergers = new Dictionary<string, ResponseMergeUtil>();
 
@@ -30,7 +46,7 @@ namespace <%= namespace %>.SDK {
 
             foreach(string field in responseB.Keys) {
                 if (FieldMergers.ContainsKey(field)) {
-
+                    FieldMergers[field](field, MergedResponse, responseA, responseB);
                 } else if (ObjectMergers.ContainsKey(field)) {
                     MergedResponse[field] = ObjectMergers[field].Merge(
                         (IDictionary) responseA[field], 

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -6,6 +6,8 @@ namespace <%= namespace %>.SDK {
     public class ResponseMergeUtil {
         public delegate void MergeFieldDelegate(string field, IDictionary into, IDictionary responseA, IDictionary responseB);
 
+        public static void DoNotMerge(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {}
+
         public static void MergeOverwrite(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
             into[field] = responseB[field];
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -40,10 +40,6 @@ namespace <%= namespace %>.SDK {
         public Dictionary<string, object> Merge(Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
             Dictionary<string, object> mergedResponse = new Dictionary<string, object>(responseA);
 
-            foreach(string field in responseA.Keys) {
-                mergedResponse[field] = responseA[field];
-            }
-
             foreach(string field in responseB.Keys) {
                 if (FieldMergers.ContainsKey(field)) {
                     FieldMergers[field](field, mergedResponse, responseA, responseB);

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -5,19 +5,19 @@ namespace <%= namespace %>.SDK {
     using System.Collections.Generic;
 
     public class ResponseMergeUtil {
-        public delegate void MergeFieldDelegate(string field, IDictionary into, IDictionary responseA, IDictionary responseB);
+        public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
 
-        public static void DoNotMergeIfExists(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
-            if (!responseA.Contains(field)) {
+        public static void DoNotMergeIfExists(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
+            if (!responseA.ContainsKey(field)) {
                 into[field] = responseB[field];
             }
         }
 
-        public static void MergeOverwrite(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
+        public static void MergeOverwrite(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
             into[field] = responseB[field];
         }
 
-        public static void MergeListsConcat(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
+        public static void MergeListsConcat(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
             List<object> newList = new List<object>();
             
             newList.AddRange(((IList) responseA[field]).Cast<object>());
@@ -37,8 +37,8 @@ namespace <%= namespace %>.SDK {
             ObjectMergers[field] = merger;
         }
 
-        public Dictionary<string, object> Merge(IDictionary responseA, IDictionary responseB) {
-            Dictionary<string, object> mergedResponse = new Dictionary<string, object>();
+        public Dictionary<string, object> Merge(Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
+            Dictionary<string, object> mergedResponse = new Dictionary<string, object>(responseA);
 
             foreach(string field in responseA.Keys) {
                 mergedResponse[field] = responseA[field];
@@ -49,8 +49,8 @@ namespace <%= namespace %>.SDK {
                     FieldMergers[field](field, mergedResponse, responseA, responseB);
                 } else if (ObjectMergers.ContainsKey(field)) {
                     mergedResponse[field] = ObjectMergers[field].Merge(
-                        (IDictionary) responseA[field], 
-                        (IDictionary) responseB[field]
+                        (Dictionary<string, object>) responseA[field], 
+                        (Dictionary<string, object>) responseB[field]
                     );
                 } else {
                     MergeOverwrite(field, mergedResponse, responseA, responseB);

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -1,5 +1,6 @@
 namespace <%= namespace %>.SDK {
     using System;
+    using System.Linq;
     using System.Collections;
     using System.Collections.Generic;
 
@@ -18,16 +19,9 @@ namespace <%= namespace %>.SDK {
 
         public static void MergeListsConcat(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
             List<object> newList = new List<object>();
-            IList listA = (IList) responseA[field];
-            IList listB = (IList) responseB[field];
-
-            foreach(object item in listA) {
-                newList.Add(item);
-            }
-
-            foreach(object item in listB) {
-                newList.Add(item);
-            }
+            
+            newList.AddRange(((IList) responseA[field]).Cast<object>());
+            newList.AddRange(((IList) responseB[field]).Cast<object>());
 
             into[field] = newList;
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -38,26 +38,26 @@ namespace <%= namespace %>.SDK {
         }
 
         public Dictionary<string, object> Merge(IDictionary responseA, IDictionary responseB) {
-            Dictionary<string, object> MergedResponse = new Dictionary<string, object>();
+            Dictionary<string, object> mergedResponse = new Dictionary<string, object>();
 
             foreach(string field in responseA.Keys) {
-                MergedResponse[field] = responseA[field];
+                mergedResponse[field] = responseA[field];
             }
 
             foreach(string field in responseB.Keys) {
                 if (FieldMergers.ContainsKey(field)) {
-                    FieldMergers[field](field, MergedResponse, responseA, responseB);
+                    FieldMergers[field](field, mergedResponse, responseA, responseB);
                 } else if (ObjectMergers.ContainsKey(field)) {
-                    MergedResponse[field] = ObjectMergers[field].Merge(
+                    mergedResponse[field] = ObjectMergers[field].Merge(
                         (IDictionary) responseA[field], 
                         (IDictionary) responseB[field]
                     );
                 } else {
-                    MergeOverwrite(field, MergedResponse, responseA, responseB);
+                    MergeOverwrite(field, mergedResponse, responseA, responseB);
                 }
             }
 
-            return MergedResponse;
+            return mergedResponse;
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -1,0 +1,44 @@
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public class ResponseMergeUtil {
+        public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
+
+        public static void MergeOverwrite(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
+            into[field] = responseB[field];
+        }
+
+        private Dictionary<string, MergeFieldDelegate> FieldMergers = new Dictionary<string, MergeFieldDelegate>();
+        private Dictionary<string, ResponseMergeUtil> ObjectMergers = new Dictionary<string, ResponseMergeUtil>();
+
+        public void AddFieldMerger(string field, MergeFieldDelegate merger) {
+            FieldMergers[field] = merger;
+        }
+
+        public void AddObjectMerger(string field, ResponseMergeUtil merger) {
+            ObjectMergers[field] = merger;
+        }
+
+        public Dictionary<string, object> Merge(Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
+            Dictionary<string, object> MergedResponse = new Dictionary<string, object>();
+
+            foreach(string field in responseA.Keys) {
+                MergedResponse[field] = responseA[field];
+            }
+
+            foreach(string field in responseB.Keys) {
+                if (FieldMergers.ContainsKey(field)) {
+
+                } else if (ObjectMergers.ContainsKey(field)) {
+
+                } else {
+                    MergeOverwrite(field, MergedResponse, responseA, responseB);
+                }
+            }
+
+            return MergedResponse;
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -4,9 +4,9 @@ namespace <%= namespace %>.SDK {
     using System.Collections.Generic;
 
     public class ResponseMergeUtil {
-        public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
+        public delegate void MergeFieldDelegate(string field, IDictionary into, IDictionary responseA, IDictionary responseB);
 
-        public static void MergeOverwrite(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
+        public static void MergeOverwrite(string field, IDictionary into, IDictionary responseA, IDictionary responseB) {
             into[field] = responseB[field];
         }
 
@@ -21,7 +21,7 @@ namespace <%= namespace %>.SDK {
             ObjectMergers[field] = merger;
         }
 
-        public Dictionary<string, object> Merge(Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
+        public Dictionary<string, object> Merge(IDictionary responseA, IDictionary responseB) {
             Dictionary<string, object> MergedResponse = new Dictionary<string, object>();
 
             foreach(string field in responseA.Keys) {
@@ -32,7 +32,10 @@ namespace <%= namespace %>.SDK {
                 if (FieldMergers.ContainsKey(field)) {
 
                 } else if (ObjectMergers.ContainsKey(field)) {
-
+                    MergedResponse[field] = ObjectMergers[field].Merge(
+                        (IDictionary) responseA[field], 
+                        (IDictionary) responseB[field]
+                    );
                 } else {
                     MergeOverwrite(field, MergedResponse, responseA, responseB);
                 }


### PR DESCRIPTION
This PR implements the ability to merge response json objects.

When working with checkouts we want the ability to update a previously queried `Checkout`. For instance let's say that we are polling we want to update `ready` on an existing `Checkout` we've previously queried.

One curious thing in this PR is `DoNotMergeIfExists`. There maybe cases where we do not want to merge one field but merge all other fields. This for instance could be used when you want to handle a field on a case by case basis. For instance with `Checkouts` sometimes we may want to merge in line items sometimes we may want to leave them be.