### PR TITLE
[Fix] Testing in mono

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Editor/ExtendedPBXProject.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ExtendedPBXProject.cs.erb
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
     using UnityEngine;
     using UnityEditor.iOS.Xcode;
@@ -79,3 +80,4 @@ namespace <%= namespace %>.SDK {
         }
     }
 }
+#endif

--- a/scripts/generator/graphql_generator/csharp/Editor/ExtendedPBXProject.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ExtendedPBXProject.cs.erb
@@ -1,4 +1,4 @@
-#if !SHOPIFY_MONO_UNIT_TEST
+#if UNITY_EDITOR
 namespace <%= namespace %>.SDK {
     using UnityEngine;
     using UnityEditor.iOS.Xcode;

--- a/scripts/generator/graphql_generator/csharp/Editor/PostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/PostProcessor.cs.erb
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
     using UnityEngine;
     using UnityEditor;
@@ -17,3 +18,4 @@ namespace <%= namespace %>.SDK {
         }
     }
 }
+#endif

--- a/scripts/generator/graphql_generator/csharp/Editor/PostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/PostProcessor.cs.erb
@@ -1,4 +1,4 @@
-#if !SHOPIFY_MONO_UNIT_TEST
+#if UNITY_EDITOR
 namespace <%= namespace %>.SDK {
     using UnityEngine;
     using UnityEditor;

--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyIosPostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyIosPostProcessor.cs.erb
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
     using UnityEngine;
     using UnityEditor;
@@ -42,3 +43,4 @@ namespace <%= namespace %>.SDK {
         }
     }
 }
+#endif

--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyIosPostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyIosPostProcessor.cs.erb
@@ -1,4 +1,4 @@
-#if !SHOPIFY_MONO_UNIT_TEST
+#if UNITY_EDITOR
 namespace <%= namespace %>.SDK {
     using UnityEngine;
     using UnityEditor;


### PR DESCRIPTION
Some of the files added require Unity specific classes the following adds preprocessor conditionals to ensure we can run tests in mono via `scripts/test.sh`