### PR TITLE
[Feature] iOS Cart Apple Pay

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -1,0 +1,68 @@
+//
+//  CartTests.swift
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import ProductName
+
+class CartTests: XCTestCase {
+        
+    func testCreatePaymentSession() {
+        
+        let dataKey        = "Items"
+        let itemLabel      = "SubTotal"
+        let itemAmount     = "1.00"
+        let shippingLabel  = "Free Shipping"
+        let shippingAmount = "0"
+        let identifier     = "FreeShipping"
+        let detail         = "10-15 Days"
+        
+        let summaryItems        = [Models.createSummaryItemJson(amount: itemAmount, label: itemLabel)]
+        let shippingMethods     = [Models.createShippingMethodJson(amount: shippingAmount, label: shippingLabel, identifier: identifier, detail: detail)]
+        let summaryItemData     = try! JSONSerialization.data(withJSONObject: [dataKey: summaryItems])
+        let shippingMethodData  = try! JSONSerialization.data(withJSONObject: [dataKey: shippingMethods])
+        
+        let serializedSummaryItems  = String.init(data: summaryItemData,    encoding: .utf8)!.cString(using: .utf8)
+        let serializedShippingItems = String.init(data: shippingMethodData, encoding: .utf8)!.cString(using: .utf8)
+        
+        let merchantID        = "merchantID".cString(using: .utf8)
+        let countryCode       = "US".cString(using: .utf8)
+        let currencyCode      = "USD".cString(using: .utf8)
+        let requiringShipping = true
+        let unityObjectName   = "Tester".cString(using: .utf8)
+
+        _CreateApplePaySession(merchantID, countryCode, currencyCode, requiringShipping, unityObjectName, serializedSummaryItems, serializedShippingItems)
+        
+        XCTAssertEqual(_Session.request.paymentSummaryItems.count, 1)
+        XCTAssertEqual(_Session.request.paymentSummaryItems.first!.label, itemLabel)
+        XCTAssertEqual(_Session.request.paymentSummaryItems.first!.amount, NSDecimalNumber(string: itemAmount))
+        
+        XCTAssertEqual(_Session.request.shippingMethods!.count, 1)
+        XCTAssertEqual(_Session.request.shippingMethods!.first!.label,      shippingLabel)
+        XCTAssertEqual(_Session.request.shippingMethods!.first!.amount,     NSDecimalNumber(string: shippingAmount))
+        XCTAssertEqual(_Session.request.shippingMethods!.first!.identifier, identifier)
+        XCTAssertEqual(_Session.request.shippingMethods!.first!.detail,     detail)
+    }
+}

--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -28,11 +28,6 @@ import XCTest
 @testable import ProductName
 
 class CartTests: XCTestCase {
-    
-    override func tearDown() {
-        session = nil
-        super.tearDown()
-    }
         
     func testCreatePaymentSession() {
         
@@ -58,10 +53,11 @@ class CartTests: XCTestCase {
         let requiringShipping = true
         let unityObjectName   = "Tester".cString(using: .utf8)
 
-        XCTAssertNil(session)
+        XCTAssertNil(Cart.session)
+        _CreateApplePaySession(unityObjectName, merchantID, countryCode, currencyCode, serializedSummaryItems, serializedShippingItems, requiringShipping)
+        XCTAssertNotNil(Cart.session)
         
-        _CreateApplePaySession(merchantID, countryCode, currencyCode, requiringShipping, unityObjectName, serializedSummaryItems, serializedShippingItems)
-        
+        let session = Cart.session!
         XCTAssertEqual(session.request.paymentSummaryItems.count, 1)
         XCTAssertEqual(session.request.paymentSummaryItems.first!.label, itemLabel)
         XCTAssertEqual(session.request.paymentSummaryItems.first!.amount, NSDecimalNumber(string: itemAmount))

--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -28,6 +28,11 @@ import XCTest
 @testable import ProductName
 
 class CartTests: XCTestCase {
+    
+    override func tearDown() {
+        session = nil
+        super.tearDown()
+    }
         
     func testCreatePaymentSession() {
         
@@ -53,16 +58,18 @@ class CartTests: XCTestCase {
         let requiringShipping = true
         let unityObjectName   = "Tester".cString(using: .utf8)
 
+        XCTAssertNil(session)
+        
         _CreateApplePaySession(merchantID, countryCode, currencyCode, requiringShipping, unityObjectName, serializedSummaryItems, serializedShippingItems)
         
-        XCTAssertEqual(_Session.request.paymentSummaryItems.count, 1)
-        XCTAssertEqual(_Session.request.paymentSummaryItems.first!.label, itemLabel)
-        XCTAssertEqual(_Session.request.paymentSummaryItems.first!.amount, NSDecimalNumber(string: itemAmount))
+        XCTAssertEqual(session.request.paymentSummaryItems.count, 1)
+        XCTAssertEqual(session.request.paymentSummaryItems.first!.label, itemLabel)
+        XCTAssertEqual(session.request.paymentSummaryItems.first!.amount, NSDecimalNumber(string: itemAmount))
         
-        XCTAssertEqual(_Session.request.shippingMethods!.count, 1)
-        XCTAssertEqual(_Session.request.shippingMethods!.first!.label,      shippingLabel)
-        XCTAssertEqual(_Session.request.shippingMethods!.first!.amount,     NSDecimalNumber(string: shippingAmount))
-        XCTAssertEqual(_Session.request.shippingMethods!.first!.identifier, identifier)
-        XCTAssertEqual(_Session.request.shippingMethods!.first!.detail,     detail)
+        XCTAssertEqual(session.request.shippingMethods!.count, 1)
+        XCTAssertEqual(session.request.shippingMethods!.first!.label,      shippingLabel)
+        XCTAssertEqual(session.request.shippingMethods!.first!.amount,     NSDecimalNumber(string: shippingAmount))
+        XCTAssertEqual(session.request.shippingMethods!.first!.identifier, identifier)
+        XCTAssertEqual(session.request.shippingMethods!.first!.detail,     detail)
     }
 }

--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 0022f477219494906874f7efc19bd990
+timeCreated: 1497899512
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+    data:
+      first:
+        iPhone: iOS
+      second:
+        enabled: 1
+        settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
@@ -27,20 +27,14 @@
 #ifndef Cart_ApplePay_h
 #define Cart_ApplePay_h
 
-#import <PassKit/PassKit.h>
-#import "Cart+ApplePay.h"
-
-@class PaymentSession;
-PaymentSession *session;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-    bool _CreateApplePaySession(const char *merchantID, const char *countryCode, const char *currencyCode, bool requiringShipping, const char *unityDelegateObjectName, const char *serializedSummaryItems, const char *serializedShippingMethods);
+    bool _CreateApplePaySession(const char *unityDelegateObjectName, const char *merchantID, const char *countryCode, const char *currencyCode, const char *serializedSummaryItems, const char *serializedShippingMethods, bool requiringShipping);
     bool _CanCheckoutWithApplePay();
     bool _CanShowApplePaySetup();
     void _ShowApplePaySetup();
-    void _PresentApplePayAuthorization();
+    bool _PresentApplePayAuthorization();
 #ifdef __cplusplus
 }
 #endif

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
@@ -1,0 +1,49 @@
+//
+//  Cart+ApplePay.h
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#ifndef Cart_ApplePay_h
+#define Cart_ApplePay_h
+
+#import <PassKit/PassKit.h>
+#import "Cart+ApplePay.h"
+
+@class PaymentSession;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    PaymentSession *_Session;
+    
+    bool _CreateApplePaySession(const char *merchantID, const char *countryCode, const char *currencyCode, bool requiringShipping, const char *unityDelegateObjectName, const char *serializedSummaryItems, const char *serializedShippingMethods);
+    bool _CanCheckoutWithApplePay();
+    bool _CanShowApplePaySetup();
+    void _ShowApplePaySetup();
+    void _PresentApplePayAuthorization();
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* Cart_ApplePay_h */

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
@@ -31,12 +31,11 @@
 #import "Cart+ApplePay.h"
 
 @class PaymentSession;
+PaymentSession *session;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    PaymentSession *_Session;
-    
     bool _CreateApplePaySession(const char *merchantID, const char *countryCode, const char *currencyCode, bool requiringShipping, const char *unityDelegateObjectName, const char *serializedSummaryItems, const char *serializedShippingMethods);
     bool _CanCheckoutWithApplePay();
     bool _CanShowApplePaySetup();

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h.meta
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: ceb10e2b533e843c4ac3fea79afbb55e
+timeCreated: 1497899512
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+    data:
+      first:
+        iPhone: iOS
+      second:
+        enabled: 1
+        settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm
@@ -1,0 +1,97 @@
+//
+//  Cart+ApplePay.mm
+//  UnityBuySDK
+//
+//  Created by Shopify.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "Cart+ApplePay.h"
+#import "ProductName-Swift.h"
+
+ApplePayEventDispatcher *dispatcher;
+
+bool _CanCheckoutWithApplePay() {
+    return [PaymentSession canMakePayments];
+}
+
+bool _CanShowApplePaySetup() {
+    return [PaymentSession canShowSetup];
+}
+
+void _ShowApplePaySetup() {
+    [PaymentSession showSetup];
+}
+
+bool _CreateApplePaySession(const char *merchantID, const char *countryCode, const char *currencyCode, bool requiringShipping, const char *unityDelegateObjectName, const char *serializedSummaryItems, const char *serializedShippingMethods) {
+    
+    NSString *dataKey = @"Items";
+    NSString *itemsString = [NSString stringWithUTF8String:serializedSummaryItems];
+    NSString *shippingString = [NSString stringWithUTF8String:serializedShippingMethods];
+    
+    /// Parse Summary Items
+    NSError *error = nil;
+    NSDictionary *summaryItemsJson = [NSJSONSerialization JSONObjectWithData:[itemsString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                     options:kNilOptions
+                                                                       error:&error];
+    
+    NSArray *summaryItems;
+    if (error == nil && summaryItemsJson != nil && [summaryItemsJson objectForKey:dataKey] != nil) {
+        
+        NSArray *summaryItemsArray = summaryItemsJson[dataKey];
+        summaryItems = [PKPaymentSummaryItem deserializeWithSummaryItems:summaryItemsArray];
+        
+        if (summaryItems == nil) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    /// Parse Shipping Items
+    NSDictionary *shippingItemsJson = [NSJSONSerialization JSONObjectWithData:[shippingString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                      options:kNilOptions
+                                                                        error:&error];
+    
+    NSArray *shippingMethods;
+    if (error == nil && shippingItemsJson != nil && [shippingItemsJson objectForKey:dataKey] != nil) {
+        NSArray *shippingMethodsArray = shippingItemsJson[dataKey];
+        shippingMethods = [PKShippingMethod deserializedWithShippingMethods:shippingMethodsArray];
+    }
+
+    dispatcher = [[ApplePayEventDispatcher alloc] initWithReceiver:[NSString stringWithUTF8String:unityDelegateObjectName]];
+    
+    _Session = [[PaymentSession alloc] initWithMerchantId:[NSString stringWithUTF8String:merchantID]
+                                              countryCode:[NSString stringWithUTF8String:countryCode]
+                                             currencyCode:[NSString stringWithUTF8String:currencyCode]
+                           requiringShippingAddressFields:requiringShipping
+                                             summaryItems:summaryItems
+                                          shippingMethods:shippingMethods
+                                           controllerType:PKPaymentAuthorizationViewController.class];
+    
+    _Session.delegate = dispatcher;
+    
+    return true;
+}
+
+void _PresentApplePayAuthorization() {
+    [_Session presentAuthorizationController];
+}

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm.meta
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: d9d5438abab5147a08fed321c633a04a
+timeCreated: 1497899512
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+    data:
+      first:
+        iPhone: iOS
+      second:
+        enabled: 1
+        settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -1,0 +1,94 @@
+//
+//  Cart+ApplePay.swift
+//  Unity-iPhone
+//
+//  Created by Shopify.
+// 
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+@objc class Cart: NSObject {
+    
+    private(set) static var session: PaymentSession?
+    private static var dispatcher: ApplePayEventDispatcher?
+    
+    static func createApplePaySession(unityDelegateObjectName: String, merchantID: String, countryCode: String, currencyCode: String, serializedSummaryItems: String, serializedShippingMethods: String?, requiringShipping: Bool) -> Bool {
+        
+        guard
+            let summaryItemsJson = extractItems(from: serializedSummaryItems),
+            let summaryItems     = PKPaymentSummaryItem.deserialize(summaryItemsJson)
+        else {
+            return false
+        }
+        
+        var shippingMethods: [PKShippingMethod]?
+        if let serializedShippingMethods = serializedShippingMethods {
+            
+            guard
+                let shippingMethodsJson = extractItems(from: serializedShippingMethods),
+                let methods             = PKShippingMethod.deserialize(shippingMethodsJson)
+            else {
+                return false
+            }
+            
+            shippingMethods = methods
+        }
+
+        dispatcher = ApplePayEventDispatcher(receiver: unityDelegateObjectName)
+        session    = PaymentSession(
+                        merchantId: merchantID,
+                        countryCode: countryCode,
+                        currencyCode: currencyCode,
+                        requiringShippingAddressFields: requiringShipping,
+                        summaryItems: summaryItems,
+                        shippingMethods: shippingMethods)
+        
+        session!.delegate = dispatcher
+        
+        return true
+    }
+    
+    public static func presentAuthorizationController() -> Bool {
+        guard let session = session else {
+            return false
+        }
+        
+        session.presentAuthorizationController()
+        return true
+    }
+    
+    private static func extractItems(from jsonString: String) -> [JSON]? {
+        
+        let dataKey = "Items"
+        
+        guard
+            let data      = jsonString.data(using: .utf8),
+            let itemsJson = try? JSONSerialization.jsonObject(with: data) as? JSON,
+            let items     = itemsJson?[dataKey] as? [JSON]
+        else {
+            return nil
+        }
+        
+        return items
+    }
+}

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift.meta
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 2c10c7032f5144b23966ab0f4dd8dc40
+timeCreated: 1498066675
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+    data:
+      first:
+        iPhone: iOS
+      second:
+        enabled: 1
+        settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
+++ b/Assets/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
@@ -50,10 +50,4 @@ extension PKPaymentSummaryItem: Deserializable {
             return self.init(label: label, amount: NSDecimalNumber(string: amount))
         }
     }
-    
-    /// Needed re-declaration of static func deserialized(_ jsonCollection: [JSON]) -> [Self]?
-    /// Since methods defined in protocol extensions are not bridged to ObjC
-    class func deserialize(summaryItems: [JSON]) -> [PKPaymentSummaryItem]? {
-        return PKPaymentSummaryItem.deserialize(summaryItems)
-    }
 }

--- a/Assets/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift
+++ b/Assets/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift
@@ -56,10 +56,4 @@ extension PKShippingMethod {
         shippingMethod.identifier = json[Field.identifier.rawValue] as? String
         return shippingMethod
     }
-    
-    /// Needed re-declaration of static func deserialized(_ jsonCollection: [JSON]) -> [Self]?
-    /// Since methods defined in protocol extensions are not bridged to ObjC
-    class func deserialized(shippingMethods: [JSON]) -> [PKShippingMethod]? {
-        return PKShippingMethod.deserialize(shippingMethods)
-    }
 }


### PR DESCRIPTION
+ Defines the methods that managed code can access in order to interact with a `PaymentSession` 
+ Adds tests that check arguments are parsed into a `PaymentSession` correctly

##### Decisions
+ The serialized summary items and shipping items are stored in a `[String: String]` with a key of `Items` 
    + The built in serializable in `C#` for `List` must have it as a value of a `Dictionary`, hence the extra wrapping  