### PR TITLE
Link with UnityEngine.dll for testing

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,8 +3,10 @@
 which mcs &> /dev/null || die "Mono is not installed"
 which nunit-console &> /dev/null || die "nunit-console is not installed"
 
+UNITY_MONO_DIR="/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current"
+
 # we're defining SHOPIFY_TEST here so that source can check whether we're running assertions/tests
-mcs -debug -define:SHOPIFY_TEST -define:SHOPIFY_MONO_UNIT_TEST -recurse:'Assets/Shopify/*.cs' -recurse:'Assets/Editor/*.cs' -reference:nunit.framework.dll -target:library -out:test.dll
+"$UNITY_MONO_DIR/bin/mcs" -debug -define:SHOPIFY_TEST -define:SHOPIFY_MONO_UNIT_TEST -recurse:'Assets/Shopify/*.cs' -recurse:'Assets/Editor/*.cs' -reference:nunit.framework.dll -target:library -out:test.dll
 
 if [ $? = 0 ] ; then
     nunit-console test.dll

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,8 @@ UNITY_MONO_DIR="/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.fra
     -recurse:'Assets/Editor/*.cs' \
     -reference:nunit.framework.dll \
     -reference:'/Applications/Unity/Unity.app/Contents/Managed/UnityEngine.dll' \
-    -target:library -out:test.dll
+    -target:library \
+    -out:test.dll
 
 if [ $? = 0 ] ; then
     nunit-console test.dll

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,10 +3,8 @@
 which mcs &> /dev/null || die "Mono is not installed"
 which nunit-console &> /dev/null || die "nunit-console is not installed"
 
-UNITY_MONO_DIR="/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current"
-
 # we're defining SHOPIFY_TEST here so that source can check whether we're running assertions/tests
-"$UNITY_MONO_DIR/bin/mcs" \
+mcs \
     -debug \
     -define:SHOPIFY_TEST \
     -define:SHOPIFY_MONO_UNIT_TEST \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,15 @@ which nunit-console &> /dev/null || die "nunit-console is not installed"
 UNITY_MONO_DIR="/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current"
 
 # we're defining SHOPIFY_TEST here so that source can check whether we're running assertions/tests
-"$UNITY_MONO_DIR/bin/mcs" -debug -define:SHOPIFY_TEST -define:SHOPIFY_MONO_UNIT_TEST -recurse:'Assets/Shopify/*.cs' -recurse:'Assets/Editor/*.cs' -reference:nunit.framework.dll -target:library -out:test.dll
+"$UNITY_MONO_DIR/bin/mcs" \
+    -debug \
+    -define:SHOPIFY_TEST \
+    -define:SHOPIFY_MONO_UNIT_TEST \
+    -recurse:'Assets/Shopify/*.cs' \
+    -recurse:'Assets/Editor/*.cs' \
+    -reference:nunit.framework.dll \
+    -reference:'/Applications/Unity/Unity.app/Contents/Managed/UnityEngine.dll' \
+    -target:library -out:test.dll
 
 if [ $? = 0 ] ; then
     nunit-console test.dll


### PR DESCRIPTION
Since NUnit is obsolete for newer versions of Mono, the developer would need to install an older version to run the ./scripts/test.sh script properly. This patch uses the
Mono installation bundled with Unity which is older (4.0.5.0).