### PR TITLE
Move Delegates to Single File

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -102,6 +102,7 @@ module GraphQLGenerator
         SDK/DefaultQueriesProducts
         SDK/DefaultQueriesCollections
         SDK/DefaultQueriesCheckout
+        SDK/Delegates
         SDK/GlobalGameObject
         SDK/QueryLoader
         SDK/ConnectionLoader

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -49,9 +49,9 @@ namespace <%= namespace %>.SDK {
         private string _VariantId;
         private long _Quantity;
         private ObservableDictionary<string, string> _CustomAttributes;
-        private Action OnChange;
+        private OnCartLineItemChange OnChange;
         
-        public CartLineItem(string variantId, Action onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
+        public CartLineItem(string variantId, OnCartLineItemChange onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
             _VariantId = variantId;
             _Quantity = quantity;
             OnChange = onChange;

--- a/scripts/generator/graphql_generator/csharp/SDK/ConnectionLoader.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ConnectionLoader.cs.erb
@@ -5,12 +5,6 @@ namespace <%= namespace %>.SDK {
     using System.Collections.Generic;
     using <%= namespace %>.GraphQL;
 
-    public delegate <%= schema.query_root_name %>Query BuildQueryOnConnectionLoopDelegate(QueryResponse response = null);
-    public delegate object GetConnectionFromResponseDelegate(object response);
-    public delegate void BuildQueryOnNodeDelegate(QueryRootQuery query, List<ConnectionQueryInfo> connectionInfosToBuildQuery, string nodeId, string alias);
-    public delegate void BuildQueryOnEdgesNodeDelegate(object node, string after);
-    public delegate void ResponseNodeHandler(List<Node> nodes, List<string> errors, string httpError);
-    
     public struct ConnectionQueryInfo {
         public ConnectionQueryInfo(GetConnectionFromResponseDelegate getConnection, BuildQueryOnEdgesNodeDelegate query, string after = null) {
             GetConnection = getConnection;

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -27,5 +27,8 @@ namespace <%= namespace %>.SDK {
     public delegate void ResponseCollectionsHandler(List<Collection> collections, List<string> errors, string httpError);
     public delegate void ResponseQueryHandler(<%= schema.query_root_name %> response, List<string> errors, string httpError);
     public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, List<string> errors, string httpError);
+
+    // CartLineItems
+    public delegate void OnCartLineItemChange(CartLineItem item);
 }
 

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -1,0 +1,31 @@
+namespace <%= namespace %>.SDK {
+    using <%= namespace %>.GraphQL;
+    using System.Collections.Generic;
+    
+    // ConnectionLoader
+    public delegate <%= schema.query_root_name %>Query BuildQueryOnConnectionLoopDelegate(QueryResponse response = null);
+    public delegate object GetConnectionFromResponseDelegate(object response);
+    public delegate void BuildQueryOnNodeDelegate(QueryRootQuery query, List<ConnectionQueryInfo> connectionInfosToBuildQuery, string nodeId, string alias);
+    public delegate void BuildQueryOnEdgesNodeDelegate(object node, string after);
+    public delegate void ResponseNodeHandler(List<Node> nodes, List<string> errors, string httpError);
+
+    // ILoader
+    public delegate void LoaderResponseHandler(string response, string error);
+
+    // ObservableDictionary
+    public delegate void DictionaryChangeHandler();
+
+    // QueryLoader
+    public delegate void QueryResponseHandler(QueryResponse response);
+    public delegate void MutationResponseHandler(MutationResponse response);
+
+    // ResponseMergeUtil
+    public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
+
+    // ShopifyBuy
+    public delegate void ResponseProductsHandler(List<Product> products, List<string> errors, string httpError);
+    public delegate void ResponseCollectionsHandler(List<Collection> collections, List<string> errors, string httpError);
+    public delegate void ResponseQueryHandler(<%= schema.query_root_name %> response, List<string> errors, string httpError);
+    public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, List<string> errors, string httpError);
+}
+

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -1,34 +1,27 @@
 namespace <%= namespace %>.SDK {
     using <%= namespace %>.GraphQL;
     using System.Collections.Generic;
-    
-    // ConnectionLoader
+
     public delegate <%= schema.query_root_name %>Query BuildQueryOnConnectionLoopDelegate(QueryResponse response = null);
     public delegate object GetConnectionFromResponseDelegate(object response);
     public delegate void BuildQueryOnNodeDelegate(QueryRootQuery query, List<ConnectionQueryInfo> connectionInfosToBuildQuery, string nodeId, string alias);
     public delegate void BuildQueryOnEdgesNodeDelegate(object node, string after);
     public delegate void ResponseNodeHandler(List<Node> nodes, List<string> errors, string httpError);
 
-    // ILoader
     public delegate void LoaderResponseHandler(string response, string error);
 
-    // ObservableDictionary
     public delegate void DictionaryChangeHandler();
 
-    // QueryLoader
     public delegate void QueryResponseHandler(QueryResponse response);
     public delegate void MutationResponseHandler(MutationResponse response);
 
-    // ResponseMergeUtil
     public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
 
-    // ShopifyBuy
     public delegate void ResponseProductsHandler(List<Product> products, List<string> errors, string httpError);
     public delegate void ResponseCollectionsHandler(List<Collection> collections, List<string> errors, string httpError);
     public delegate void ResponseQueryHandler(<%= schema.query_root_name %> response, List<string> errors, string httpError);
     public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, List<string> errors, string httpError);
 
-    // CartLineItems
-    public delegate void OnCartLineItemChange(CartLineItem item);
+    public delegate void OnCartLineItemChange();
 }
 

--- a/scripts/generator/graphql_generator/csharp/SDK/ILoader.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ILoader.cs.erb
@@ -1,6 +1,4 @@
 namespace <%= namespace %>.SDK {
-    public delegate void LoaderResponseHandler(string response, string error);
-
     /// <summary>
     /// An interface that must be defined by classes that will perform network communication.
     /// </summary>

--- a/scripts/generator/graphql_generator/csharp/SDK/ObservableDictionary.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ObservableDictionary.cs.erb
@@ -3,8 +3,6 @@ namespace <%= namespace %>.SDK {
     using System.Collections;
     using System.Collections.Generic;
 
-    public delegate void DictionaryChangeHandler();
-
     public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue> {
         private IDictionary<TKey, TValue> Data;
         private DictionaryChangeHandler OnDictionaryChange;

--- a/scripts/generator/graphql_generator/csharp/SDK/QueryLoader.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/QueryLoader.cs.erb
@@ -5,9 +5,6 @@ namespace <%= namespace %>.SDK {
     using <%= namespace %>.GraphQL;
     using <%= namespace %>.MiniJSON;
 
-    public delegate void QueryResponseHandler(QueryResponse response);
-    public delegate void MutationResponseHandler(MutationResponse response);
-
     /// <summary>
     /// Abstracts creating and sending queries and mutations via an ILoader.
     /// </summary>

--- a/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ResponseMergeUtil.cs.erb
@@ -5,8 +5,6 @@ namespace <%= namespace %>.SDK {
     using System.Collections.Generic;
 
     public class ResponseMergeUtil {
-        public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
-
         public static void DoNotMergeIfExists(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB) {
             if (!responseA.ContainsKey(field)) {
                 into[field] = responseB[field];

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -131,11 +131,6 @@ namespace <%= namespace %> {
         private static Dictionary<string, ShopifyClient> ClientByDomain = new Dictionary<string, ShopifyClient>();
     }
 
-    public delegate void ResponseProductsHandler(List<Product> products, List<string> errors, string httpError);
-    public delegate void ResponseCollectionsHandler(List<Collection> collections, List<string> errors, string httpError);
-    public delegate void ResponseQueryHandler(<%= schema.query_root_name %> response, List<string> errors, string httpError);
-    public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, List<string> errors, string httpError);
-
     /// <summary>
     /// <see cref="ShopifyClient">ShopifyClient </see> is the entry point to communicate with the Shopify Storefront API.
     /// <see cref="ShopifyClient">ShopifyClient </see> also has functionality to easily generate and send queries to receive


### PR DESCRIPTION
Moves all of the delegates we use into a single SDK/Delegates.cs.erb file. Also changes the only Action<> we used for CartLineItems to be a delegate instead.