### PR TITLE
[Feature] Input JSON Constructor

### DIFF
--- a/scripts/generator/graphql_generator/csharp/type.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type.cs.erb
@@ -146,6 +146,27 @@ namespace <%= namespace %>.GraphQL {
                     }
                 <% end %>
             }
+
+            <%= params_doc(type.input_fields) %>
+            public <%= type.classify_name %>(Dictionary<string, object> dataJSON) {
+                <%# handle adding required fields %>
+                <% if type.required_input_fields.length > 0 %>
+                try {
+                    <% type.required_input_fields.each do |field| %>
+                        Set("<%= field.name %>", dataJSON["<%= escape_reserved_word(field.name) %>"]);
+                    <% end %>
+                } catch {
+                    throw;
+                }
+                <% end %>
+
+                <%# handle adding optional fields %>
+                <% type.optional_input_fields.each do |field| %>
+                    if (dataJSON.ContainsKey("<%= escape_reserved_word(field.name) %>")) {
+                        Set("<%= field.name %>", dataJSON["<%= escape_reserved_word(field.name) %>"]);
+                    }
+                <% end %>
+            }
         }
     <% when 'ENUM' %>
         <%= docs_enum(type) %>


### PR DESCRIPTION
- Adds a constructor for Input types to be created from a JSON dictionary. 

#### Motivation
- By adding this constructor, Input types such as `MailingAddressInput` can be constructed from the serialized json objects sent from unmanaged functions

#### Decisions
- Decided to re-throw any exceptions. But at the call site we would probably not use a try and catch since a failure to initialize meant there is an error with our SDK