### PR TITLE
[Feature] Cart Apple Pay Shipping

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -123,6 +123,7 @@ module GraphQLGenerator
         SDK/iOS/ApplePayEventResponse
         SDK/iOS/ShippingMethod
         SDK/iOS/SummaryItem
+        SDK/iOS/CartApplePayEventReceiver
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -123,7 +123,7 @@ module GraphQLGenerator
         SDK/iOS/ApplePayEventResponse
         SDK/iOS/ShippingMethod
         SDK/iOS/SummaryItem
-        SDK/iOS/CartApplePayEventReceiver
+        SDK/iOS/Cart.ApplePayEventReceiver
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -151,22 +151,6 @@ namespace <%= namespace %> {
             } catch(NoQueryException exception) {}
         }
 
-        private void SetShippingAddress(MailingAddressInput mailingAddressInput, Action<ShopifyError> callback) {
-            MutationQuery query = new MutationQuery();
-
-            DefaultQueries.checkout.ShippingAddressUpdate(query, CurrentCheckout.id(), mailingAddressInput);
-
-            Client.Mutation(query, (Mutation response, ShopifyError error) => {
-                if (error != null) {
-                    callback(error);
-                    return;
-                }
-
-                UpdateCheckout(response.checkoutShippingAddressUpdate().checkout());
-                AvailableShippingRatesPoll(callback);
-            });
-        }
-
         private void SetShippingLine(string shippingRateHandle, Action<ShopifyError> callback) {
             MutationQuery query = new MutationQuery();
 
@@ -183,19 +167,19 @@ namespace <%= namespace %> {
             });
         }
 
-        private void SetEmail(string email, Action<ShopifyError> callback) {
+        private void SetShippingAddressAndEmail(MailingAddressInput mailingAddressInput, string email, Action<ShopifyError> callback) {
             MutationQuery query = new MutationQuery();
 
             DefaultQueries.checkout.EmailUpdate(query, CurrentCheckout.id(), email);
+            DefaultQueries.checkout.ShippingAddressUpdate(query, CurrentCheckout.id(), mailingAddressInput);
 
             Client.Mutation(query, (Mutation response, ShopifyError error) => {
                 if (error != null) {
                     callback(error);
-                    return;
+                } else {
+                    UpdateCheckout(response.checkoutEmailUpdate().checkout());
+                    AvailableShippingRatesPoll(callback);
                 }
-
-                UpdateCheckout(response.checkoutEmailUpdate().checkout());
-                CheckoutPoll(callback);
             });
         }
 

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -16,7 +16,7 @@ namespace <%= namespace %> {
     /// <summary>
     /// Manages line items for an order. Can also be used to generate a web checkout link to check out in browser.
     /// </summary>
-    public class Cart {
+    public partial class Cart {
         /// <summary>
         /// Current <see ref="CartLineItems">line items </see> for this <see ref="Cart">Cart </see>.
         /// </summary>

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/Cart.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/Cart.ApplePayEventReceiver.cs.erb
@@ -33,7 +33,7 @@ namespace <%= namespace %> {
             List<ShippingMethod> shippingMethods = null;
 
             SetShippingAddressAndEmail(mailingAddressInput, (String)contentDictionary["email"], (httpError, graphQLError) => {
-                if (httpError == null &&  graphQLError == null) {
+                if (httpError == null && graphQLError == null) {
                     summaryItems = GetSummaryItems();
                     shippingMethods = GetShippingMethods();
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/Cart.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/Cart.ApplePayEventReceiver.cs.erb
@@ -13,8 +13,8 @@ namespace <%= namespace %> {
 
             var message = NativeMessage.CreateFromJSON(serializedMessage);
 
-            SetShippingLine(message.Content, (httpError, graphQLError) => {
-                if (httpError == null && graphQLError == null) {
+            SetShippingLine(message.Content, (ShopifyError error) => {
+                if (error == null) {
                     var summaryItems = GetSummaryItems();
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems).ToJsonString());
                 } else {
@@ -32,8 +32,8 @@ namespace <%= namespace %> {
             List<SummaryItem> summaryItems = null;
             List<ShippingMethod> shippingMethods = null;
 
-            SetShippingAddressAndEmail(mailingAddressInput, (String)contentDictionary["email"], (httpError, graphQLError) => {
-                if (httpError == null && graphQLError == null) {
+            SetShippingAddressAndEmail(mailingAddressInput, (String)contentDictionary["email"], (ShopifyError error) => {
+                if (error == null) {
                     summaryItems = GetSummaryItems();
                     shippingMethods = GetShippingMethods();
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
@@ -10,6 +10,7 @@ namespace <%= namespace %> {
     public partial class Cart : IApplePayEventReceiver {
 
         public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
+
             var message = NativeMessage.CreateFromJSON(serializedMessage);
 
             SetShippingLine(message.Content, (httpError, graphQLError) => {
@@ -23,6 +24,7 @@ namespace <%= namespace %> {
         }
 
         public void UpdateSummaryItemsForShippingContact(string serializedMessage) {
+
             var message = NativeMessage.CreateFromJSON(serializedMessage);
             var contentDictionary = (Dictionary<string, object>)Json.Deserialize(message.Content);
             var mailingAddressInput = new MailingAddressInput(contentDictionary);
@@ -74,9 +76,8 @@ namespace <%= namespace %> {
                 foreach (var shippingRate in availableShippingRates) {
                     shippingMethods.Add(new ShippingMethod(shippingRate.title(), shippingRate.price().ToString(), shippingRate.handle()));
                 }
-
-            } catch {
-                throw;
+            } catch (Exception e) {
+                throw new Exception("Attempted to access AvailableShippingRates when CurrentCheckout has no property named AvailableShippingRates", e);
             }
 
             return shippingMethods;

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
@@ -8,20 +8,76 @@ namespace <%= namespace %> {
     using <%= namespace %>.MiniJSON;
 
     public partial class Cart : IApplePayEventReceiver {
-        public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
 
+        public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
+            var message = NativeMessage.CreateFromJSON(serializedMessage);
+
+            SetShippingLine(message.Content, (httpError, graphqlError) => {
+                 if (httpError == null && graphqlError == null) {
+                     var summaryItems = GetSummaryItems();
+                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems).ToJsonString());
+                 } else {
+                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                 }
+            });
         }
 
         public void UpdateSummaryItemsForShippingContact(string serializedMessage) {
 
+            var message = NativeMessage.CreateFromJSON(serializedMessage);
+            var contentDictionary = (Dictionary<string, object>)Json.Deserialize(message.Content);
+            var mailingAddressInput = new MailingAddressInput(contentDictionary);
+
+            SetShippingAddress(mailingAddressInput, (httpError, graphqlError) => {
+                if (httpError == null && graphqlError == null) {
+                    var summaryItems = GetSummaryItems();
+                    var shippingMethods = GetShippingMethods();
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());
+                } else {
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                }
+            });
         }
 
         public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {
-
+            //TODO
         }
 
         public void DidFinishCheckoutSession(string serializedMessage) {
+            //TODO
+        }
 
+        private List<SummaryItem> GetSummaryItems() {
+
+            var summaryItems = new List<SummaryItem>();
+            summaryItems.Add(new SummaryItem("SUBTOTAL", CurrentCheckout.subtotalPrice().ToString()));
+
+            if (CurrentCheckout.requiresShipping()) {
+                summaryItems.Add(new SummaryItem("SHIPPING", CurrentCheckout.subtotalPrice().ToString()));
+            }
+
+            summaryItems.Add(new SummaryItem("TAXES", CurrentCheckout.totalTax().ToString()));
+            summaryItems.Add(new SummaryItem("TOTAL", CurrentCheckout.totalPrice().ToString()));
+
+            return summaryItems;
+        }
+
+        private List<ShippingMethod> GetShippingMethods() {
+
+            var shippingMethods = new List<ShippingMethod>();
+
+            try {
+                var availableShippingRates = CurrentCheckout.availableShippingRates().shippingRates();
+
+                foreach (var shippingRate in availableShippingRates) {
+                    shippingMethods.Add(new ShippingMethod(shippingRate.title(), shippingRate.price().ToString(), shippingRate.handle()));
+                }
+
+            } catch {
+                throw;
+            }
+
+            return shippingMethods;
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
@@ -12,55 +12,29 @@ namespace <%= namespace %> {
         public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
             var message = NativeMessage.CreateFromJSON(serializedMessage);
 
-            SetShippingLine(message.Content, (httpError, graphqlError) => {
-                 if (httpError == null && graphqlError == null) {
-                     var summaryItems = GetSummaryItems();
-                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems).ToJsonString());
-                 } else {
-                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
-                 }
+            SetShippingLine(message.Content, (httpError, graphQLError) => {
+                if (httpError == null && graphQLError == null) {
+                    var summaryItems = GetSummaryItems();
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems).ToJsonString());
+                } else {
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                }
             });
         }
 
         public void UpdateSummaryItemsForShippingContact(string serializedMessage) {
-
             var message = NativeMessage.CreateFromJSON(serializedMessage);
             var contentDictionary = (Dictionary<string, object>)Json.Deserialize(message.Content);
             var mailingAddressInput = new MailingAddressInput(contentDictionary);
 
             List<SummaryItem> summaryItems = null;
             List<ShippingMethod> shippingMethods = null;
-            var updateShippingAddressSuccess = false;
-            var updateEmailSuccess = false;
 
-            Action respondWithSuccess = () => {
-                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());
-            };
-
-            SetEmail((String)contentDictionary["email"], (httpError, graphqlError) => {
-                if (httpError == null && graphqlError == null) {
-
-                    if (updateShippingAddressSuccess) {
-                        respondWithSuccess();
-                    } else {
-                        updateEmailSuccess = true;
-                    }
-                } else {
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
-                }
-            });
-
-            SetShippingAddress(mailingAddressInput, (httpError, graphqlError) => {
-                if (httpError == null &&  graphqlError == null) {
+            SetShippingAddressAndEmail(mailingAddressInput, (String)contentDictionary["email"], (httpError, graphQLError) => {
+                if (httpError == null &&  graphQLError == null) {
                     summaryItems = GetSummaryItems();
                     shippingMethods = GetShippingMethods();
-
-                    if (updateEmailSuccess) {
-                        respondWithSuccess();
-                    } else {
-                        updateShippingAddressSuccess = true;
-                    }
-
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());
                 } else {
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
                 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
@@ -1,0 +1,28 @@
+#if UNITY_IPHONE
+namespace <%= namespace %> {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using <%= namespace %>.SDK;
+    using <%= namespace %>.SDK.iOS;
+    using <%= namespace %>.MiniJSON;
+
+    public partial class Cart : IApplePayEventReceiver {
+        public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
+
+        }
+
+        public void UpdateSummaryItemsForShippingContact(string serializedMessage) {
+
+        }
+
+        public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {
+
+        }
+
+        public void DidFinishCheckoutSession(string serializedMessage) {
+
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/CartApplePayEventReceiver.cs.erb
@@ -28,11 +28,39 @@ namespace <%= namespace %> {
             var contentDictionary = (Dictionary<string, object>)Json.Deserialize(message.Content);
             var mailingAddressInput = new MailingAddressInput(contentDictionary);
 
-            SetShippingAddress(mailingAddressInput, (httpError, graphqlError) => {
+            List<SummaryItem> summaryItems = null;
+            List<ShippingMethod> shippingMethods = null;
+            var updateShippingAddressSuccess = false;
+            var updateEmailSuccess = false;
+
+            Action respondWithSuccess = () => {
+                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());
+            };
+
+            SetEmail((String)contentDictionary["email"], (httpError, graphqlError) => {
                 if (httpError == null && graphqlError == null) {
-                    var summaryItems = GetSummaryItems();
-                    var shippingMethods = GetShippingMethods();
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());
+
+                    if (updateShippingAddressSuccess) {
+                        respondWithSuccess();
+                    } else {
+                        updateEmailSuccess = true;
+                    }
+                } else {
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                }
+            });
+
+            SetShippingAddress(mailingAddressInput, (httpError, graphqlError) => {
+                if (httpError == null &&  graphqlError == null) {
+                    summaryItems = GetSummaryItems();
+                    shippingMethods = GetShippingMethods();
+
+                    if (updateEmailSuccess) {
+                        respondWithSuccess();
+                    } else {
+                        updateShippingAddressSuccess = true;
+                    }
+
                 } else {
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
                 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ShippingMethod.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ShippingMethod.cs.erb
@@ -11,7 +11,7 @@ namespace <%= namespace %>.SDK.iOS {
         public string Detail;
         #pragma warning restore 0414
 
-        public ShippingMethod(string label, string amount, string identifier, string detail) : base(label, amount) {
+        public ShippingMethod(string label, string amount, string identifier, string detail = null) : base(label, amount) {
             Identifier = identifier;
             Detail = detail;
         }


### PR DESCRIPTION
### What
+ Adds an Apple Pay Receiver to `Cart`
+ Received serialized Shipping and Email information from Apple Pay are deserialized and sent as GraphQL mutations
+ Combines email and shipping mutation queries, since they are not used separately 

### What is not included
+ Unit Tests
    + Will write the unit tests once we can create an apple pay session from Unity 
+ Error Refactors
    + Will leave the refactoring of Cart.cs later on to use Shopify Error