### PR TITLE
[Feature] User Error Handling

### DIFF
--- a/Assets/Editor/MockLoaderCheckouts.cs
+++ b/Assets/Editor/MockLoaderCheckouts.cs
@@ -12,10 +12,14 @@ namespace Shopify.Tests {
         private const string CREATE_QUERY_THAT_WILL_BE_UPDATED = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyUpdate==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyDelete==""}]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
         private const string ADD_UPDATE_DELETE_AFTER_CREATE = @"mutation{checkoutLineItemsRemove (checkoutId:""checkout-id-poll"",lineItemIds:[""line-item-id1"",""line-item-id2""]){userErrors {field message }}checkoutLineItemsAdd (lineItems:[{quantity:10,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyUpdate==""},{quantity:3,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NTMNewItem==""}],checkoutId:""checkout-id-poll""){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
 
+        // The following query will return a user error
+        private const string CREATE_QUERY_SENDS_USERERROR = @"mutation{checkoutCreate (input:{lineItems:[{quantity:1,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError==""}]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
+
         public MockLoaderCheckouts() {
             SetupCreateResponse();
             SetupCreateResponsesForPolling();
             SetupCreateThenUpdateResponse();
+            SetupUserErrorResponses();
         }
 
         private void SetupCreateResponse() {
@@ -215,6 +219,25 @@ namespace Shopify.Tests {
                                 }
                             },
                             ""userErrors"": []
+                        }
+                    }
+                }"
+            );
+        }
+
+        private void SetupUserErrorResponses() {
+            AddResponse(
+                CREATE_QUERY_SENDS_USERERROR,
+                @"{
+                    ""data"": {
+                        ""checkoutCreate"": {
+                            ""checkout"": null,
+                            ""userErrors"": [
+                                {
+                                    ""field"": [ ""someField"" ],
+                                    ""message"": ""bad things happened""
+                                }
+                            ]
                         }
                     }
                 }"

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -379,5 +379,33 @@ namespace Shopify.Tests
             Assert.AreEqual("line-item-id1", cart.LineItems.All()[0].ID, "Line item 1 has the correct ID set after update");
             Assert.AreEqual("line-item-id3", cart.LineItems.All()[1].ID, "Line item 2 has the correct ID set after update");
         }
+
+        [Test]
+        public void TestUserError() {
+            ShopifyBuy.Init(new MockLoader());
+
+            Cart cart = ShopifyBuy.Client().Cart();
+            string resultUrl = null;
+            ShopifyError resultError = null;
+
+            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError==", 1);
+            
+            cart.GetWebCheckoutLink(
+                success: (url) => {
+                    resultUrl = url;
+                },
+                failure: (shopError) => {
+                    resultError = shopError;
+                }
+            );
+
+            Assert.IsNull(resultUrl, "no url was returned");
+            Assert.IsNotNull(resultError, "returned an errror");
+            Assert.AreEqual(ShopifyError.ErrorType.UserError, resultError.error);
+            Assert.AreEqual("There were issues with some of the fields sent. Checkout `cart.UserErrors`", resultError.description);
+            Assert.AreEqual(1, cart.UserErrors.Count);
+            Assert.AreEqual("someField", cart.UserErrors[0].field()[0], "fields was correct");
+            Assert.AreEqual("bad things happened", cart.UserErrors[0].message(), "messaged was correct");
+        }
     }
 }

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -402,7 +402,7 @@ namespace Shopify.Tests
             Assert.IsNull(resultUrl, "no url was returned");
             Assert.IsNotNull(resultError, "returned an errror");
             Assert.AreEqual(ShopifyError.ErrorType.UserError, resultError.error);
-            Assert.AreEqual("There were issues with some of the fields sent. Checkout `cart.UserErrors`", resultError.description);
+            Assert.AreEqual("There were issues with some of the fields sent. See `cart.UserErrors`", resultError.description);
             Assert.AreEqual(1, cart.UserErrors.Count);
             Assert.AreEqual("someField", cart.UserErrors[0].field()[0], "fields was correct");
             Assert.AreEqual("bad things happened", cart.UserErrors[0].message(), "messaged was correct");

--- a/scripts/generator/graphql_generator/csharp/Cart.Poll.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.Poll.cs.erb
@@ -50,7 +50,7 @@ namespace <%= namespace %> {
         private void PollCheckoutAndUpdate(CheckoutPoll poll, Action<ShopifyError> callback) {
             poll((Checkout checkout, ShopifyError error) => {
                 if (error == null && checkout != null) {
-                    UpdateCheckout(checkout);
+                    UpdateState(checkout);
                 }
                 callback(error);
             });

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -177,14 +177,16 @@ namespace <%= namespace %> {
         }
 
         private void UpdateLineItemFromCheckout(Checkout checkout) {
-            if (checkout != null) {
-                // sometimes we may not query line items for instance when polling is being performed
-                try {
-                    List<CheckoutLineItem> lineItems = (List<CheckoutLineItem>) checkout.lineItems();
-
-                    LineItems.UpdateLineItemsFromCheckoutLineItems(lineItems);
-                } catch(NoQueryException exception) {}
+            if (checkout == null) {
+                return;
             }
+            
+            // sometimes we may not query line items for instance when polling is being performed
+            try {
+                List<CheckoutLineItem> lineItems = (List<CheckoutLineItem>) checkout.lineItems();
+
+                LineItems.UpdateLineItemsFromCheckoutLineItems(lineItems);
+            } catch(NoQueryException exception) {}
         }
 
         private void HandleUserError(Action<ShopifyError> callback) {

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -43,6 +43,7 @@ namespace <%= namespace %> {
         private List<String> DeletedLineItems = new List<string>();
         private ShopifyClient Client;
         private Checkout CurrentCheckout = null;
+        private List<UserError> CurrentUserErrors = null;
 
         /// <summary>
         /// Constructs a new cart using a <see ref="ShopifyClient">ShopifyClient </see>. Typically, carts won't be
@@ -100,12 +101,15 @@ namespace <%= namespace %> {
                     return;
                 }
 
-                UpdateCheckout(response.checkoutCreate().checkout());
-
-                if (CurrentCheckout.ready()) {
-                    callback(null);
+                if (UpdateState(response.checkoutCreate().checkout(), response.checkoutCreate().userErrors())) {
+                    if (CurrentCheckout.ready()) {
+                        callback(null);
+                    } else {
+                        PollCheckoutAndUpdate(PollCheckoutReady, callback);
+                    }
                 } else {
-                    PollCheckoutAndUpdate(PollCheckoutReady, callback);
+                    // HANDLE USER ERROR
+                    throw new NotImplementedException("Mikko implement handling user error");
                 }
             });
         }
@@ -129,17 +133,25 @@ namespace <%= namespace %> {
                 }
 
                 DeletedLineItems.Clear();
-                UpdateCheckout(response.checkoutLineItemsAdd().checkout());
 
-                if (CurrentCheckout.ready()) {
-                    callback(null);
+                if (UpdateState(response.checkoutLineItemsAdd().checkout(), response.checkoutLineItemsAdd().userErrors())) {
+                    if (CurrentCheckout.ready()) {
+                        callback(null);
+                    } else {
+                        PollCheckoutAndUpdate(PollCheckoutReady, callback);
+                    }
                 } else {
-                    PollCheckoutAndUpdate(PollCheckoutReady, callback);
+                    // HANDLE USER ERROR
+                    throw new NotImplementedException("Mikko implement handling user error");
                 }
             });
         }
 
-        private void UpdateCheckout(Checkout checkout) {
+        private bool UpdateState(Checkout checkout) {
+            return UpdateState(checkout, new List<UserError>());
+        }
+
+        private bool UpdateState(Checkout checkout, List<UserError> userErrors) {
             if (CurrentCheckout == null) {
                 CurrentCheckout = checkout;
             } else {
@@ -148,7 +160,15 @@ namespace <%= namespace %> {
                 CurrentCheckout = merger.Merge(CurrentCheckout, checkout);    
             }
 
+            if (userErrors.Count > 0) {
+                CurrentUserErrors = userErrors;
+            } else {
+                CurrentUserErrors = null;
+            }
+
             UpdateLineItemFromCheckout(CurrentCheckout);
+
+            return CurrentUserErrors == null;
         }
 
         private void UpdateLineItemFromCheckout(Checkout checkout) {
@@ -171,12 +191,15 @@ namespace <%= namespace %> {
                     return;
                 }
 
-                UpdateCheckout(response.checkoutShippingLineUpdate().checkout());
-
-                if (CurrentCheckout.ready()) {
-                    callback(null);
+                if (UpdateState(response.checkoutShippingLineUpdate().checkout(), response.checkoutShippingLineUpdate().userErrors())) {
+                    if (CurrentCheckout.ready()) {
+                        callback(null);
+                    } else {
+                        PollCheckoutAndUpdate(PollCheckoutReady, callback);
+                    }
                 } else {
-                    PollCheckoutAndUpdate(PollCheckoutReady, callback);
+                    // HANDLE USER ERROR
+                    throw new NotImplementedException("Mikko implement handling user error");
                 }
             });
         }
@@ -191,12 +214,15 @@ namespace <%= namespace %> {
                 if (error != null) {
                     callback(error);
                 } else {
-                    UpdateCheckout(response.checkoutEmailUpdate().checkout());
-
-                    if (CurrentCheckout.availableShippingRates().ready()) {
-                        callback(null);
+                    if (UpdateState(response.checkoutEmailUpdate().checkout(), response.checkoutEmailUpdate().userErrors())) {
+                        if (CurrentCheckout.availableShippingRates().ready()) {
+                            callback(null);
+                        } else {
+                            PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
+                        }
                     } else {
-                        PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
+                        // HANDLE USER ERROR
+                        throw new NotImplementedException("Mikko implement handling user error");
                     }
                 }
             });

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -115,8 +115,7 @@ namespace <%= namespace %> {
                         PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     }
                 } else {
-                    // HANDLE USER ERROR
-                    throw new NotImplementedException("Mikko implement handling user error");
+                    HandleUserError(response.checkoutCreate().userErrors(), callback);
                 }
             });
         }
@@ -148,8 +147,7 @@ namespace <%= namespace %> {
                         PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     }
                 } else {
-                    // HANDLE USER ERROR
-                    throw new NotImplementedException("Mikko implement handling user error");
+                    HandleUserError(response.checkoutLineItemsAdd().userErrors(), callback);
                 }
             });
         }
@@ -179,12 +177,23 @@ namespace <%= namespace %> {
         }
 
         private void UpdateLineItemFromCheckout(Checkout checkout) {
-            // sometimes we may not query line items for instance when polling is being performed
-            try {
-                List<CheckoutLineItem> lineItems = (List<CheckoutLineItem>) checkout.lineItems();
+            if (checkout != null) {
+                // sometimes we may not query line items for instance when polling is being performed
+                try {
+                    List<CheckoutLineItem> lineItems = (List<CheckoutLineItem>) checkout.lineItems();
 
-                LineItems.UpdateLineItemsFromCheckoutLineItems(lineItems);
-            } catch(NoQueryException exception) {}
+                    LineItems.UpdateLineItemsFromCheckoutLineItems(lineItems);
+                } catch(NoQueryException exception) {}
+            }
+        }
+
+        private void HandleUserError(List<UserError> userErrors, Action<ShopifyError> callback) {
+            ShopifyError error = new ShopifyError(
+                ShopifyError.ErrorType.UserError,
+                "There were issues with some of the fields sent. Checkout `cart.UserErrors`"
+            );
+
+            callback(error);
         }
 
         private void SetShippingLine(string shippingRateHandle, Action<ShopifyError> callback) {
@@ -205,8 +214,7 @@ namespace <%= namespace %> {
                         PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     }
                 } else {
-                    // HANDLE USER ERROR
-                    throw new NotImplementedException("Mikko implement handling user error");
+                    HandleUserError(response.checkoutShippingLineUpdate().userErrors(), callback);
                 }
             });
         }
@@ -228,8 +236,7 @@ namespace <%= namespace %> {
                             PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
                         }
                     } else {
-                        // HANDLE USER ERROR
-                        throw new NotImplementedException("Mikko implement handling user error");
+                        HandleUserError(response.checkoutEmailUpdate().userErrors(), callback);
                     }
                 }
             });

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -26,6 +26,12 @@ namespace <%= namespace %> {
             }
         }
 
+        public List<UserError> UserErrors {
+            get {
+                return _UserErrors;
+            }
+        }
+
         private bool IsSaved {
             get {
                 return IsCreated && LineItems.IsSaved;
@@ -40,10 +46,11 @@ namespace <%= namespace %> {
 
         private const float POLL_DELAY_SECONDS = 0.5f;
         private CartLineItems _LineItems;
+        private List<UserError> _UserErrors = null;
         private List<String> DeletedLineItems = new List<string>();
         private ShopifyClient Client;
         private Checkout CurrentCheckout = null;
-        private List<UserError> CurrentUserErrors = null;
+        
 
         /// <summary>
         /// Constructs a new cart using a <see ref="ShopifyClient">ShopifyClient </see>. Typically, carts won't be
@@ -161,14 +168,14 @@ namespace <%= namespace %> {
             }
 
             if (userErrors.Count > 0) {
-                CurrentUserErrors = userErrors;
+                _UserErrors = userErrors;
             } else {
-                CurrentUserErrors = null;
+                _UserErrors = null;
             }
 
             UpdateLineItemFromCheckout(CurrentCheckout);
 
-            return CurrentUserErrors == null;
+            return _UserErrors == null;
         }
 
         private void UpdateLineItemFromCheckout(Checkout checkout) {

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -115,7 +115,7 @@ namespace <%= namespace %> {
                         PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     }
                 } else {
-                    HandleUserError(response.checkoutCreate().userErrors(), callback);
+                    HandleUserError(callback);
                 }
             });
         }
@@ -147,7 +147,7 @@ namespace <%= namespace %> {
                         PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     }
                 } else {
-                    HandleUserError(response.checkoutLineItemsAdd().userErrors(), callback);
+                    HandleUserError(callback);
                 }
             });
         }
@@ -187,7 +187,7 @@ namespace <%= namespace %> {
             }
         }
 
-        private void HandleUserError(List<UserError> userErrors, Action<ShopifyError> callback) {
+        private void HandleUserError(Action<ShopifyError> callback) {
             ShopifyError error = new ShopifyError(
                 ShopifyError.ErrorType.UserError,
                 "There were issues with some of the fields sent. Checkout `cart.UserErrors`"
@@ -214,7 +214,7 @@ namespace <%= namespace %> {
                         PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     }
                 } else {
-                    HandleUserError(response.checkoutShippingLineUpdate().userErrors(), callback);
+                    HandleUserError(callback);
                 }
             });
         }
@@ -236,7 +236,7 @@ namespace <%= namespace %> {
                             PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
                         }
                     } else {
-                        HandleUserError(response.checkoutEmailUpdate().userErrors(), callback);
+                        HandleUserError(callback);
                     }
                 }
             });

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -180,7 +180,7 @@ namespace <%= namespace %> {
             if (checkout == null) {
                 return;
             }
-            
+
             // sometimes we may not query line items for instance when polling is being performed
             try {
                 List<CheckoutLineItem> lineItems = (List<CheckoutLineItem>) checkout.lineItems();
@@ -192,7 +192,7 @@ namespace <%= namespace %> {
         private void HandleUserError(Action<ShopifyError> callback) {
             ShopifyError error = new ShopifyError(
                 ShopifyError.ErrorType.UserError,
-                "There were issues with some of the fields sent. Checkout `cart.UserErrors`"
+                "There were issues with some of the fields sent. See `cart.UserErrors`"
             );
 
             callback(error);

--- a/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
 #if !SHOPIFY_MONO_UNIT_TEST
     using System;
@@ -24,3 +25,4 @@ namespace <%= namespace %>.SDK {
     }
 #endif
 }
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
@@ -1,6 +1,5 @@
 #if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
-#if !SHOPIFY_MONO_UNIT_TEST
     using System;
     using UnityEngine;
     using System.Runtime.InteropServices;
@@ -23,6 +22,5 @@ namespace <%= namespace %>.SDK {
             _RespondToNativeMessage(Identifier, message);
         }
     }
-#endif
 }
 #endif

--- a/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
 #if !SHOPIFY_MONO_UNIT_TEST
     using System;
@@ -12,3 +13,4 @@ namespace <%= namespace %>.SDK {
     }
 #endif
 }
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
@@ -1,6 +1,5 @@
 #if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
-#if !SHOPIFY_MONO_UNIT_TEST
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -11,6 +10,5 @@ namespace <%= namespace %>.SDK {
             return JsonUtility.ToJson(this);
         }
     }
-#endif
 }
 #endif

--- a/scripts/generator/graphql_generator/csharp/SDK/ShopifyError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/ShopifyError.cs.erb
@@ -16,7 +16,7 @@ namespace <%= namespace %>.SDK {
         }
 
         public enum ErrorType {
-            HTTP, GraphQL
+            HTTP, GraphQL, UserError
         }
 
         public readonly ErrorType error;
@@ -27,4 +27,4 @@ namespace <%= namespace %>.SDK {
             this.description = description;
         }
     }
-    }
+}


### PR DESCRIPTION
I was working on an example of how we could handle user errors.

Really user errors describe one of the states of the checkout that is not defined in `Checkout`. This state is that the `Checkout` can be in erroneous state. So my thought was to add the list of user errors to the `Cart` beside `CurrentCheckout`.

This list should be exposed to the user. I think with the work that @sleroux has been doing on refactoring errors we could send an error that is of type user error and in documentation we tell the user to check user errors on cart.

Thoughts? This PR should be finished after #107.