### PR TITLE
Ignore UnityEngine.dll-required files for Mono unit tests

### DIFF
--- a/Assets/Editor/TestDefaultQueriesCheckout.cs
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs
@@ -5,7 +5,6 @@ namespace Shopify.Tests
     using Shopify.Unity;
     using Shopify.Unity.SDK;
     using Shopify.Unity.GraphQL;
-    using UnityEngine;
 
     [TestFixture]
     public class TestDefaultQueries {

--- a/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
@@ -1,4 +1,5 @@
 namespace <%= namespace %>.SDK {
+#if !SHOPIFY_MONO_UNIT_TEST
     using System;
     using UnityEngine;
     using System.Runtime.InteropServices;
@@ -21,4 +22,5 @@ namespace <%= namespace %>.SDK {
             _RespondToNativeMessage(Identifier, message);
         }
     }
+#endif
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
@@ -1,4 +1,5 @@
 namespace <%= namespace %>.SDK {
+#if !SHOPIFY_MONO_UNIT_TEST
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -9,4 +10,5 @@ namespace <%= namespace %>.SDK {
             return JsonUtility.ToJson(this);
         }
     }
+#endif
 }


### PR DESCRIPTION
Wraps UnityEngine-required tests with #ifdef check and removes unused import.