### PR TITLE
[Feature] Native checkout creation

### DIFF
--- a/Assets/Editor/MockLoaderCheckouts.cs
+++ b/Assets/Editor/MockLoaderCheckouts.cs
@@ -1,19 +1,19 @@
 namespace Shopify.Tests {
     public class MockLoaderCheckouts : BaseMockLoader {
         // The following query is for a straightforward checkout create
-        private const string CREATE_QUERY = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==""}]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
+        private const string CREATE_QUERY = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==""}]}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
 
         // The following two queries are used for a test where first a create is called and we return false for ready which forces a poll
         // then we return a result that ready is true and the new weburl is there
-        private const string CREATE_QUERY_THAT_POLLS = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTPOLL==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==""}]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
-        private const string POLL_QUERY_AFTER_CREATE = @"{node (id:""checkout-id-poll""){__typename ...on Checkout{id webUrl requiresShipping subtotalPrice totalTax totalPrice ready }}}";
+        private const string CREATE_QUERY_THAT_POLLS = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTPOLL==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==""}]}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
+        private const string POLL_QUERY_AFTER_CREATE = @"{node (id:""checkout-id-poll""){__typename ...on Checkout{id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready }}}";
 
         // The following queries are used to test creating a checkout, then modififying line items and getting a new url
-        private const string CREATE_QUERY_THAT_WILL_BE_UPDATED = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyUpdate==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyDelete==""}]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
-        private const string ADD_UPDATE_DELETE_AFTER_CREATE = @"mutation{checkoutLineItemsRemove (checkoutId:""checkout-id-poll"",lineItemIds:[""line-item-id1"",""line-item-id2""]){userErrors {field message }}checkoutLineItemsAdd (lineItems:[{quantity:10,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyUpdate==""},{quantity:3,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NTMNewItem==""}],checkoutId:""checkout-id-poll""){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
+        private const string CREATE_QUERY_THAT_WILL_BE_UPDATED = @"mutation{checkoutCreate (input:{lineItems:[{quantity:33,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyUpdate==""},{quantity:2,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyDelete==""}]}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
+        private const string ADD_UPDATE_DELETE_AFTER_CREATE = @"mutation{checkoutLineItemsRemove (checkoutId:""checkout-id-poll"",lineItemIds:[""line-item-id1"",""line-item-id2""]){userErrors {field message }}checkoutLineItemsAdd (lineItems:[{quantity:10,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyUpdate==""},{quantity:3,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NTMNewItem==""}],checkoutId:""checkout-id-poll""){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
 
         // The following query will return a user error
-        private const string CREATE_QUERY_SENDS_USERERROR = @"mutation{checkoutCreate (input:{lineItems:[{quantity:1,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError==""}]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
+        private const string CREATE_QUERY_SENDS_USERERROR = @"mutation{checkoutCreate (input:{lineItems:[{quantity:1,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError==""}]}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
 
         public MockLoaderCheckouts() {
             SetupCreateResponse();
@@ -31,6 +31,7 @@ namespace Shopify.Tests {
                             ""checkout"": {
                                 ""id"": ""checkout-id"", 
                                 ""webUrl"": ""http://shopify.com/checkout-no-poll"",
+                                ""currencyCode"": ""CAD"",
                                 ""requiresShipping"": true,
                                 ""subtotalPrice"": ""267.96"",
                                 ""totalTax"": ""34.83"",
@@ -78,6 +79,7 @@ namespace Shopify.Tests {
                             ""checkout"": {
                                 ""id"": ""checkout-id-poll"", 
                                 ""webUrl"": ""http://shopify.com/checkout-with-poll"",
+                                ""currencyCode"": ""CAD"",
                                 ""requiresShipping"": true,
                                 ""subtotalPrice"": ""267.96"",
                                 ""totalTax"": ""34.83"",
@@ -139,6 +141,7 @@ namespace Shopify.Tests {
                             ""checkout"": {
                                 ""id"": ""checkout-id-poll"", 
                                 ""webUrl"": ""http://shopify.com/checkout-create-before-update"",
+                                ""currencyCode"": ""CAD"",
                                 ""requiresShipping"": true,
                                 ""subtotalPrice"": ""267.96"",
                                 ""totalTax"": ""34.83"",
@@ -187,6 +190,7 @@ namespace Shopify.Tests {
                             ""checkout"": {
                                 ""id"": """",
                                 ""webUrl"": ""http://shopify.com/checkout-create-after-update"",
+                                ""currencyCode"": ""CAD"",
                                 ""requiresShipping"": true,
                                 ""subtotalPrice"": ""267.96"",
                                 ""totalTax"": ""34.83"",

--- a/Assets/Editor/TestDefaultQueriesCheckout.cs
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs
@@ -15,7 +15,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.Create(query, lineItems);
             Assert.AreEqual(
-                "mutation{checkoutCreate (input:{lineItems:[]}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}",
+                "mutation{checkoutCreate (input:{lineItems:[]}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}",
                 query.ToString()
             );
         }
@@ -27,7 +27,7 @@ namespace Shopify.Tests
             
             DefaultQueries.checkout.Poll(query, checkoutId);
             Assert.AreEqual(
-                "{node (id:\"an-id\"){__typename ...on Checkout{id webUrl requiresShipping subtotalPrice totalTax totalPrice ready }}}",
+                "{node (id:\"an-id\"){__typename ...on Checkout{id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready }}}",
                 query.ToString()
             );
         }
@@ -52,7 +52,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.LineItemsAdd(query, checkoutId, lineItems);
             Assert.AreEqual(
-                "mutation{checkoutLineItemsAdd (lineItems:[],checkoutId:\"an-id\"){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}",
+                "mutation{checkoutLineItemsAdd (lineItems:[],checkoutId:\"an-id\"){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}",
                 query.ToString()
             );
         }
@@ -90,7 +90,7 @@ namespace Shopify.Tests
             var addressInput = new MailingAddressInput("123 Test Street", "456", "Toronto", "Shopify", "Canada", "First", "Last", "1234567890", "Ontario", "A1B2C3");
             DefaultQueries.checkout.ShippingAddressUpdate(query, checkoutId, addressInput);
             Assert.AreEqual(
-                "mutation{checkoutShippingAddressUpdate (shippingAddress:{address1:\"123 Test Street\",address2:\"456\",city:\"Toronto\",company:\"Shopify\",country:\"Canada\",firstName:\"First\",lastName:\"Last\",phone:\"1234567890\",province:\"Ontario\",zip:\"A1B2C3\"},checkoutId:\"an-id\"){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready availableShippingRates {shippingRates {handle title price }ready }}userErrors {field message }}}",
+                "mutation{checkoutShippingAddressUpdate (shippingAddress:{address1:\"123 Test Street\",address2:\"456\",city:\"Toronto\",company:\"Shopify\",country:\"Canada\",firstName:\"First\",lastName:\"Last\",phone:\"1234567890\",province:\"Ontario\",zip:\"A1B2C3\"},checkoutId:\"an-id\"){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready availableShippingRates {shippingRates {handle title price }ready }}userErrors {field message }}}",
                 query.ToString()
             );
         }
@@ -114,7 +114,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.ShippingLineUpdate(query, checkoutId, "handle");
             Assert.AreEqual(
-                "mutation{checkoutShippingLineUpdate (checkoutId:\"an-id\",shippingRateHandle:\"handle\"){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready shippingLine {handle title price }}userErrors {field message }}}",
+                "mutation{checkoutShippingLineUpdate (checkoutId:\"an-id\",shippingRateHandle:\"handle\"){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready shippingLine {handle title price }}userErrors {field message }}}",
                 query.ToString()
             );
         }
@@ -129,7 +129,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.CheckoutCompleteWithTokenizedPayment(query, checkoutId, tokenizedPaymentInput);
             Assert.AreEqual(
-                "mutation{checkoutCompleteWithTokenizedPayment (checkoutId:\"an-id\",payment:{amount:1,billingAddress:{address1:\"123 Test Street\",address2:\"456\",city:\"Toronto\",company:\"Shopify\",country:\"Canada\",firstName:\"First\",lastName:\"Last\",phone:\"1234567890\",province:\"Ontario\",zip:\"A1B2C3\"},idempotencyKey:\"unique_id\",paymentData:\"some_utf8_data_string\",type:\"apple_pay\"}){checkout {id webUrl requiresShipping subtotalPrice totalTax totalPrice ready }payment {errorMessage id ready }userErrors {field message }}}",
+                "mutation{checkoutCompleteWithTokenizedPayment (checkoutId:\"an-id\",payment:{amount:1,billingAddress:{address1:\"123 Test Street\",address2:\"456\",city:\"Toronto\",company:\"Shopify\",country:\"Canada\",firstName:\"First\",lastName:\"Last\",phone:\"1234567890\",province:\"Ontario\",zip:\"A1B2C3\"},idempotencyKey:\"unique_id\",paymentData:\"some_utf8_data_string\",type:\"apple_pay\"}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready }payment {errorMessage id ready }userErrors {field message }}}",
                 query.ToString()
             );
         }

--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -31,7 +31,6 @@ class CartTests: XCTestCase {
         
     func testCreatePaymentSession() {
         
-        let dataKey        = "Items"
         let itemLabel      = "SubTotal"
         let itemAmount     = "1.00"
         let shippingLabel  = "Free Shipping"
@@ -41,8 +40,8 @@ class CartTests: XCTestCase {
         
         let summaryItems        = [Models.createSummaryItemJson(amount: itemAmount, label: itemLabel)]
         let shippingMethods     = [Models.createShippingMethodJson(amount: shippingAmount, label: shippingLabel, identifier: identifier, detail: detail)]
-        let summaryItemData     = try! JSONSerialization.data(withJSONObject: [dataKey: summaryItems])
-        let shippingMethodData  = try! JSONSerialization.data(withJSONObject: [dataKey: shippingMethods])
+        let summaryItemData     = try! JSONSerialization.data(withJSONObject: summaryItems)
+        let shippingMethodData  = try! JSONSerialization.data(withJSONObject: shippingMethods)
         
         let serializedSummaryItems  = String.init(data: summaryItemData,    encoding: .utf8)!.cString(using: .utf8)
         let serializedShippingItems = String.init(data: shippingMethodData, encoding: .utf8)!.cString(using: .utf8)

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm
@@ -42,12 +42,17 @@ void _ShowApplePaySetup() {
 
 bool _CreateApplePaySession(const char *unityDelegateObjectName, const char *merchantID, const char *countryCode, const char *currencyCode, const char *serializedSummaryItems, const char *serializedShippingMethods, bool requiringShipping) {
 
+    NSString *shippingMethodsString;
+    if (serializedShippingMethods != nil) {
+        shippingMethodsString = [NSString stringWithUTF8String:serializedShippingMethods];
+    }
+
     return [Cart createApplePaySessionWithUnityDelegateObjectName:[NSString stringWithUTF8String:unityDelegateObjectName]
                                                        merchantID:[NSString stringWithUTF8String:merchantID]
                                                       countryCode:[NSString stringWithUTF8String:countryCode]
                                                      currencyCode:[NSString stringWithUTF8String:currencyCode]
                                            serializedSummaryItems:[NSString stringWithUTF8String:serializedSummaryItems]
-                                        serializedShippingMethods:[NSString stringWithUTF8String:serializedShippingMethods]
+                                        serializedShippingMethods:shippingMethodsString
                                                 requiringShipping:requiringShipping];
 }
 

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -80,12 +80,26 @@ import PassKit
     private static func extractItems(from jsonString: String) -> [JSON]? {
         
         guard
-            let data  = jsonString.data(using: .utf8),
-            let items = try? JSONSerialization.jsonObject(with: data) as? [JSON]
-        else {
-            return nil
+            let data = jsonString.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let stringCollection = object as? [String]
+            else {
+                return nil
         }
         
-        return items
+        var itemCollection = [JSON]()
+        for string in stringCollection {
+            
+            if let stringData  = string.data(using: .utf8),
+                let itemObject = try? JSONSerialization.jsonObject(with: stringData),
+                let itemJson   = itemObject as? JSON {
+                
+                itemCollection.append(itemJson)
+            } else {
+                return nil
+            }
+        }
+        
+        return itemCollection
     }
 }

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -79,12 +79,9 @@ import PassKit
     
     private static func extractItems(from jsonString: String) -> [JSON]? {
         
-        let dataKey = "Items"
-        
         guard
-            let data      = jsonString.data(using: .utf8),
-            let itemsJson = try? JSONSerialization.jsonObject(with: data) as? JSON,
-            let items     = itemsJson?[dataKey] as? [JSON]
+            let data  = jsonString.data(using: .utf8),
+            let items = try? JSONSerialization.jsonObject(with: data) as? [JSON]
         else {
             return nil
         }

--- a/Assets/UnityTestTools/NativeTesting/iOS/ApplePayEventTester.cs
+++ b/Assets/UnityTestTools/NativeTesting/iOS/ApplePayEventTester.cs
@@ -10,19 +10,19 @@ namespace Shopify.Tests.iOS {
         public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
             var message = NativeMessageTester.CreateFromJSON(serializedMessage);
             var response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetExpectedSummaryItems());
-            message.Respond(response.ToJsonString());
+            message.Respond(response.ToString());
         }
 
         public void UpdateSummaryItemsForShippingContact(string serializedMessage) {
             var message = NativeMessageTester.CreateFromJSON(serializedMessage);
             var response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetExpectedSummaryItems(), GetExpectedShippingMethods());
-            message.Respond(response.ToJsonString());
+            message.Respond(response.ToString());
         }
 
         public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {
             var message = NativeMessageTester.CreateFromJSON(serializedMessage);
             var response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Success);
-            message.Respond(response.ToJsonString());
+            message.Respond(response.ToString());
         }
 
         public void DidFinishCheckoutSession(string serializedMessage) {

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -125,6 +125,7 @@ module GraphQLGenerator
         SDK/IWebCheckout
         SDK/iOS/ApplePayAuthorizationStatus
         SDK/iOS/ApplePayEventReceiver
+        SDK/iOS/ApplePayEventReceiverBridge
         SDK/iOS/ApplePayEventResponse
         SDK/iOS/ShippingMethod
         SDK/iOS/iOSWebCheckout

--- a/scripts/generator/graphql_generator/csharp/Cart.CheckoutAccessors.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.CheckoutAccessors.cs.erb
@@ -5,6 +5,19 @@ namespace <%= namespace %> {
     using <%= namespace %>.GraphQL;
 
     public partial class Cart {
+
+        /// <summary>
+        /// Retrieve the currency code for the current checkout.
+        /// </summary>
+        /// <exception cref="NoCheckoutException">Calling this accessor before a checkout was created for the Cart. See Cart.GetWebCheckoutLink</exception>
+        public CurrencyCode GetCurrencyCode() {
+            if (CurrentCheckout == null) {
+                throw new NoCheckoutException("There is no Checkout created from this Cart. See Cart.GetWebCheckoutLink");
+            } else {
+                return CurrentCheckout.currencyCode();
+            }
+        }
+
         /// <summary>
         /// Retrieve the shipping total for the current checkout.
         /// </summary>

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -170,17 +170,38 @@ namespace <%= namespace %> {
             }
         }
 
-        public void SetShippingAddressAndEmail(MailingAddressInput mailingAddressInput, string email, CompletionCallback callback) {
+        public void SetEmailAddress(string email, CompletionCallback callback) {
             MutationQuery query = new MutationQuery();
 
             DefaultQueries.checkout.EmailUpdate(query, CurrentCheckout.id(), email);
-            DefaultQueries.checkout.ShippingAddressUpdate(query, CurrentCheckout.id(), mailingAddressInput);
 
             Client.Mutation(query, (Mutation response, ShopifyError error) => {
                 if (error != null) {
                     callback(error);
                 } else {
                     if (UpdateState(response.checkoutEmailUpdate().checkout(), response.checkoutEmailUpdate().userErrors())) {
+                        if (CurrentCheckout.ready()) {
+                            callback(null);
+                        } else {
+                            PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
+                        }
+                    } else {
+                        HandleUserError(callback);
+                    }
+                }
+            });
+        }
+
+        public void SetShippingAddress(MailingAddressInput mailingAddressInput, CompletionCallback callback) {
+            MutationQuery query = new MutationQuery();
+
+            DefaultQueries.checkout.ShippingAddressUpdate(query, CurrentCheckout.id(), mailingAddressInput);
+
+            Client.Mutation(query, (Mutation response, ShopifyError error) => {
+                if (error != null) {
+                    callback(error);
+                } else {
+                    if (UpdateState(response.checkoutShippingAddressUpdate().checkout(), response.checkoutShippingAddressUpdate().userErrors())) {
                         if (CurrentCheckout.availableShippingRates().ready()) {
                             callback(null);
                         } else {

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
@@ -133,6 +133,7 @@ namespace <%= namespace %>.SDK {
             return checkout
                 .id()
                 .webUrl()
+                .currencyCode()
                 .requiresShipping()
                 .subtotalPrice()
                 .totalTax()

--- a/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Serializable.cs.erb
@@ -6,7 +6,7 @@ namespace <%= namespace %>.SDK {
     using UnityEngine;
 
     public class Serializable {
-        public string ToJsonString() {
+        override public string ToString() {
             return JsonUtility.ToJson(this);
         }
     }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayEventReceiverBridge.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayEventReceiverBridge.cs.erb
@@ -1,0 +1,32 @@
+#if UNITY_IPHONE
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+    using UnityEngine;
+
+    public class ApplePayEventReceiverBridge : MonoBehaviour, IApplePayEventReceiver {
+
+        public IApplePayEventReceiver Receiver;
+
+        public ApplePayEventReceiverBridge(IApplePayEventReceiver receiver) {
+            Receiver = receiver;
+        }
+
+        public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
+            Receiver.UpdateSummaryItemsForShippingIdentifier(serializedMessage);
+        }
+
+        public void UpdateSummaryItemsForShippingContact(string serializedMessage) {
+            Receiver.UpdateSummaryItemsForShippingContact(serializedMessage);
+        }
+
+        public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {
+            Receiver.FetchApplePayCheckoutStatusForToken(serializedMessage);
+        }
+
+        public void DidFinishCheckoutSession(string serializedMessage) {
+            Receiver.DidFinishCheckoutSession(serializedMessage);
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -33,7 +33,7 @@ namespace <%= namespace %>.SDK.iOS {
             };
 
             Action<ShopifyError, StatusForUserError> respondToError = (ShopifyError error, StatusForUserError statusForUserError) => {
-                switch(error.error) {
+                switch(error.Type) {
                 case ShopifyError.ErrorType.GraphQL:
                 case ShopifyError.ErrorType.HTTP:
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToString());
@@ -89,9 +89,7 @@ namespace <%= namespace %>.SDK.iOS {
 
                 if (lastField.Equals("firstName") ||
                     lastField.Equals("lastName") ||
-                    lastField.Equals("phone")) {
-                        return ApplePayAuthorizationStatus.InvalidShippingContact;
-                } else if (
+                    lastField.Equals("phone") ||
                     lastField.Equals("address1") ||
                     lastField.Equals("address2") ||
                     lastField.Equals("city") ||

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -7,6 +7,9 @@ namespace <%= namespace %>.SDK.iOS {
     using <%= namespace %>.MiniJSON;
 
     public partial class iOSNativeCheckout : IApplePayEventReceiver {
+
+        private delegate ApplePayAuthorizationStatus StatusForUserError(UserError error);
+
         public void UpdateSummaryItemsForShippingIdentifier(string serializedMessage) {
             var message = NativeMessage.CreateFromJSON(serializedMessage);
 
@@ -25,16 +28,46 @@ namespace <%= namespace %>.SDK.iOS {
             var contentDictionary = (Dictionary<string, object>)Json.Deserialize(message.Content);
             var mailingAddressInput = new MailingAddressInput(contentDictionary);
 
-            List<SummaryItem> summaryItems = null;
-            List<ShippingMethod> shippingMethods = null;
+            Action respondWithSuccess = () => {
+                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), GetShippingMethods()).ToString());
+            };
 
-            CurrentCart.SetShippingAddressAndEmail(mailingAddressInput, (String)contentDictionary["email"], (ShopifyError error) => {
-                if (error == null) {
-                    summaryItems = GetSummaryItems();
-                    shippingMethods = GetShippingMethods();
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToString());
-                } else {
+            Action<ShopifyError, StatusForUserError> respondToError = (ShopifyError error, StatusForUserError statusForUserError) => {
+                switch(error.error) {
+                case ShopifyError.ErrorType.GraphQL:
+                case ShopifyError.ErrorType.HTTP:
                     message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToString());
+                    break;
+                case ShopifyError.ErrorType.UserError:
+                    var userErrors = CurrentCart.UserErrors;
+
+                    if (userErrors.Count > 0) {
+                        var firstUserError = userErrors[0];
+                        var status = statusForUserError(firstUserError);
+                        message.Respond(new ApplePayEventResponse(status).ToString());
+                    } else {
+                        message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToString());
+                    }
+                    break;
+                }
+            };
+
+            CurrentCart.SetShippingAddress(mailingAddressInput, (ShopifyError error) => {
+                if (error == null) {
+
+                    if (contentDictionary.ContainsKey("email")) {
+                        CurrentCart.SetEmailAddress((String)contentDictionary["email"], (ShopifyError emailError) => {
+                            if (error == null) {
+                                respondWithSuccess();
+                            } else {
+                                respondToError(error, AuthorizationStatusForEmailUserError);
+                            }
+                        });
+                    } else {
+                        respondWithSuccess();
+                    }
+                } else {
+                    respondToError(error, AuthorizationStatusForShippingUserError);
                 }
             });
         }
@@ -45,6 +78,43 @@ namespace <%= namespace %>.SDK.iOS {
 
         public void DidFinishCheckoutSession(string serializedMessage) {
             //TODO
+        }
+
+        private ApplePayAuthorizationStatus AuthorizationStatusForShippingUserError(UserError error) {
+            var fields = error.field();
+            var lastIndex = fields.Count - 1;
+
+            if (lastIndex >= 0) {
+                var lastField = fields[lastIndex];
+
+                if (lastField.Equals("firstName") ||
+                    lastField.Equals("lastName") ||
+                    lastField.Equals("phone")) {
+                        return ApplePayAuthorizationStatus.InvalidShippingContact;
+                } else if (
+                    lastField.Equals("address1") ||
+                    lastField.Equals("address2") ||
+                    lastField.Equals("city") ||
+                    lastField.Equals("company") ||
+                    lastField.Equals("country") ||
+                    lastField.Equals("province") ||
+                    lastField.Equals("zip")) {
+                        return ApplePayAuthorizationStatus.InvalidShippingPostalAddress;
+                }
+            }
+
+            return ApplePayAuthorizationStatus.Failure;
+        }
+
+        private ApplePayAuthorizationStatus AuthorizationStatusForEmailUserError(UserError error) {
+            var fields = error.field();
+            var lastIndex = fields.Count - 1;
+
+            if (lastIndex >= 0 && fields[lastIndex].Equals("email")) {
+                return ApplePayAuthorizationStatus.InvalidShippingContact;
+            }
+
+            return ApplePayAuthorizationStatus.Failure;
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -13,9 +13,9 @@ namespace <%= namespace %>.SDK.iOS {
             CurrentCart.SetShippingLine(message.Content, (ShopifyError error) => {
                 if (error == null) {
                     var summaryItems = GetSummaryItems();
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems).ToJsonString());
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems).ToString());
                 } else {
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToString());
                 }
             });
         }
@@ -32,9 +32,9 @@ namespace <%= namespace %>.SDK.iOS {
                 if (error == null) {
                     summaryItems = GetSummaryItems();
                     shippingMethods = GetShippingMethods();
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToJsonString());
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, summaryItems, shippingMethods).ToString());
                 } else {
-                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                    message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToString());
                 }
             });
         }
@@ -45,36 +45,6 @@ namespace <%= namespace %>.SDK.iOS {
 
         public void DidFinishCheckoutSession(string serializedMessage) {
             //TODO
-        }
-
-        private List<SummaryItem> GetSummaryItems() {
-            var summaryItems = new List<SummaryItem>();
-            summaryItems.Add(new SummaryItem("SUBTOTAL", CurrentCart.GetSubtotal().ToString()));
-
-            if (CurrentCart.GetRequiresShipping()) {
-                summaryItems.Add(new SummaryItem("SHIPPING", CurrentCart.GetShippingTotal().ToString()));
-            }
-
-            summaryItems.Add(new SummaryItem("TAXES", CurrentCart.GetTotalTax().ToString()));
-            summaryItems.Add(new SummaryItem("TOTAL", CurrentCart.GetTotal().ToString()));
-
-            return summaryItems;
-        }
-
-        private List<ShippingMethod> GetShippingMethods() {
-            var shippingMethods = new List<ShippingMethod>();
-
-            try {
-                var availableShippingRates = CurrentCart.GetShippingRates();
-
-                foreach (var shippingRate in availableShippingRates) {
-                    shippingMethods.Add(new ShippingMethod(shippingRate.title(), shippingRate.price().ToString(), shippingRate.handle()));
-                }
-            } catch (Exception e) {
-                throw new Exception("Attempted to access AvailableShippingRates when CurrentCheckout has no property named AvailableShippingRates", e);
-            }
-
-            return shippingMethods;
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -5,6 +5,7 @@ namespace <%= namespace %>.SDK.iOS {
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
     using <%= namespace %>.SDK;
+    using <%= namespace %>.MiniJSON;
 
     partial class iOSNativeCheckout : INativeCheckout {
         [DllImport ("__Internal")]
@@ -23,6 +24,11 @@ namespace <%= namespace %>.SDK.iOS {
         private static extern void _PresentApplePayAuthorization();
 
         private Cart CurrentCart;
+        private ApplePayEventReceiverBridge ApplePayReceiver;
+
+        private CheckoutSuccessCallback Success;
+        private CheckoutFailureCallback Failure;
+        private CheckoutCancelCallback Cancelled;
 
         public iOSNativeCheckout(Cart cart) {
             CurrentCart = cart;
@@ -62,8 +68,55 @@ namespace <%= namespace %>.SDK.iOS {
         /// <param name="failure">Delegate method that will be notified upon a failure during the checkout process</param>
         /// <param name="cancelled">Delegate method that will be notified upon a cancellation during the checkout process</param>
         public void Checkout(string key, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
-            throw new NotImplementedException("Native checkout (Apple Pay) not implemented yet for iOS.");
+
+            Success = success;
+            Failure = failure;
+            Cancelled = cancelled;
+
+            var summaryItems = GetSummaryItems();
+            var summaryString = Json.Serialize(summaryItems);
+            var currencyCodeString = CurrentCart.GetCurrencyCode().ToString("G");
+
+            if (ApplePayReceiver == null) {
+                ApplePayReceiver = GlobalGameObject.AddComponent<ApplePayEventReceiverBridge>();
+                ApplePayReceiver.Receiver = this;
+            }
+
+            _CreateApplePaySession(key, "CA", CurrentCart.GetCurrencyCode().ToString("G"), GlobalGameObject.Name, summaryString, null, CurrentCart.GetRequiresShipping());
         }
+
+        private List<SummaryItem> GetSummaryItems() {
+            var summaryItems = new List<SummaryItem>();
+            summaryItems.Add(new SummaryItem("SUBTOTAL", CurrentCart.GetSubtotal().ToString()));
+
+            if (CurrentCart.GetRequiresShipping()) {
+                try {
+                    summaryItems.Add(new SummaryItem("SHIPPING", CurrentCart.GetShippingTotal().ToString()));
+                } catch {}
+            }
+
+            summaryItems.Add(new SummaryItem("TAXES", CurrentCart.GetTotalTax().ToString()));
+            summaryItems.Add(new SummaryItem("TOTAL", CurrentCart.GetTotal().ToString()));
+
+            return summaryItems;
+        }
+
+        private List<ShippingMethod> GetShippingMethods() {
+            var shippingMethods = new List<ShippingMethod>();
+
+            try {
+                var availableShippingRates = CurrentCart.GetShippingRates();
+
+                foreach (var shippingRate in availableShippingRates) {
+                    shippingMethods.Add(new ShippingMethod(shippingRate.title(), shippingRate.price().ToString(), shippingRate.handle()));
+                }
+            } catch (Exception e) {
+                throw new Exception("Attempted to access AvailableShippingRates when CurrentCheckout has no property named AvailableShippingRates", e);
+            }
+
+            return shippingMethods;
+        }
+
     }
 }
 #endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -18,7 +18,7 @@ namespace <%= namespace %>.SDK.iOS {
         private static extern void _ShowApplePaySetup();
 
         [DllImport ("__Internal")]
-        private static extern bool _CreateApplePaySession(string merchantID, string countryCode, string currencyCode, string unityDelegateObjectName, string serializedSummaryItems, string serializedShippingMethods, bool requiringShipping);
+        private static extern bool _CreateApplePaySession(string unityDelegateObjectName, string merchantID, string countryCode, string currencyCode, string serializedSummaryItems, string serializedShippingMethods, bool requiringShipping);
 
         [DllImport ("__Internal")]
         private static extern void _PresentApplePayAuthorization();
@@ -82,7 +82,11 @@ namespace <%= namespace %>.SDK.iOS {
                 ApplePayReceiver.Receiver = this;
             }
 
-            _CreateApplePaySession(key, "CA", CurrentCart.GetCurrencyCode().ToString("G"), GlobalGameObject.Name, summaryString, null, CurrentCart.GetRequiresShipping());
+            if (_CreateApplePaySession(GlobalGameObject.Name, key, "CA", CurrentCart.GetCurrencyCode().ToString("G"), summaryString, null, CurrentCart.GetRequiresShipping())) {
+                _PresentApplePayAuthorization();
+            } else {
+                //TODO call checkout failure
+            }
         }
 
         private List<SummaryItem> GetSummaryItems() {


### PR DESCRIPTION
+ Adds checkout creation
+ Adds Currency Code query
+ Changed Json serialization to override `ToString()`

#### Extras
+ Split up the email and shipping address query. 
    + Apple Pay can return a shipping address with no email, if it was an address that was set from other purchases the user has made
+ Set the `countryCode` of a request to `CAD` till I hear back from the Storefront API to see if we can get this from the API
    + https://github.com/Shopify/shopify/issues/120602