### PR TITLE
[Feature] Combines SetEmailUpdate/SetShippingAddress/SetShippingLine into SetFinalCheckoutFields method

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -23,6 +23,11 @@ namespace <%= namespace %> {
     public struct ShippingFields {
         public MailingAddressInput ShippingAddress;
         public string ShippingIdentifier; 
+
+        public ShippingFields(MailingAddressInput shippingAddress, string shippingIdentifier) {
+            ShippingIdentifier = shippingIdentifier;
+            ShippingAddress = shippingAddress;
+        }
     }
     
     /// <summary>

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -246,7 +246,7 @@ namespace <%= namespace %> {
                     }
 
                     if (UpdateState(response.checkoutEmailUpdate().checkout(), userErrors)) {
-                        PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
+                        PollCheckoutAndUpdate(PollCheckoutReady, callback);
                     } else {
                         HandleUserError(callback);
                     }

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -21,8 +21,8 @@ namespace <%= namespace %> {
     /// Wraps around a shipping address and shipping identifier. Used for sending the final checkout fields in one GraphQL query.
     /// </summary>
     public struct ShippingFields {
-        MailingAddressInput ShippingAddress;
-        string ShippingIdentifier; 
+        public MailingAddressInput ShippingAddress;
+        public string ShippingIdentifier; 
     }
     
     /// <summary>
@@ -221,7 +221,32 @@ namespace <%= namespace %> {
         }
 
         public void SetFinalCheckoutFields(string email, ShippingFields? shippingFields, CompletionCallback callback) {
-            throw new NotImplementedException("Implement Me.");
+            MutationQuery query = new MutationQuery();
+
+            DefaultQueries.checkout.EmailUpdate(query, CurrentCheckout.id(), email);
+
+            if (shippingFields.HasValue) {
+                DefaultQueries.checkout.ShippingAddressUpdate(query, CurrentCheckout.id(), shippingFields.Value.ShippingAddress);
+                DefaultQueries.checkout.ShippingLineUpdate(query, CurrentCheckout.id(), shippingFields.Value.ShippingIdentifier);
+            }
+
+            Client.Mutation(query, (Mutation response, ShopifyError error) => {
+                if (error != null) {
+                    callback(error);
+                } else {
+                    var userErrors = response.checkoutShippingAddressUpdate().userErrors();
+                    if (shippingFields.HasValue) {
+                        userErrors.AddRange(response.checkoutShippingLineUpdate().userErrors());
+                        userErrors.AddRange(response.checkoutEmailUpdate().userErrors());
+                    }
+
+                    if (UpdateState(response.checkoutEmailUpdate().checkout(), userErrors)) {
+                        PollCheckoutAndUpdate(PollCheckoutAvailableShippingRatesReady, callback);
+                    } else {
+                        HandleUserError(callback);
+                    }
+                }
+            });
         }
 
         private void CheckoutSave(CompletionCallback callback) {

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -16,6 +16,15 @@ namespace <%= namespace %> {
     public class NoMatchingVariantException : Exception {
         public NoMatchingVariantException(string message) : base(message) {}
     }
+
+    /// <summary>
+    /// Wraps around a shipping address and shipping identifier. Used for sending the final checkout fields in one GraphQL query.
+    /// </summary>
+    public struct ShippingFields {
+        MailingAddressInput ShippingAddress;
+        string ShippingIdentifier; 
+    }
+    
     /// <summary>
     /// Manages line items for an order. Can also be used to generate a web checkout link to check out in browser.
     /// </summary>
@@ -209,6 +218,10 @@ namespace <%= namespace %> {
                     }
                 }
             });
+        }
+
+        public void SetFinalCheckoutFields(string email, ShippingFields? shippingFields, CompletionCallback callback) {
+            throw new NotImplementedException("Implement Me.");
         }
 
         private void CheckoutSave(CompletionCallback callback) {


### PR DESCRIPTION
* Adds `SetFinalCheckoutFields` method for combining the 3 update query calls into one.
* Adds `ShippingFields` to enclose the shipping address and identifier since the update query either has both or none of those properties.

I'll follow this PR up with tests on TestCart.cs