### PR TITLE
[Feature] Apple Pay checkout token

### DIFF
--- a/Assets/Editor/BuildPipeline/ShopifyBuildPipeline.cs
+++ b/Assets/Editor/BuildPipeline/ShopifyBuildPipeline.cs
@@ -30,10 +30,11 @@ namespace Shopify.BuildPipeline {
         {
             string path = PlayerPath;
             string[] scenes = {"Assets/Scenes/iOSTestScene.unity"};
-
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS, "IOS_SIMULATOR_SDK");
             PlayerSettings.iOS.sdkVersion = iOSSdkVersion.SimulatorSDK;
             BuildPipeline.BuildPlayer(scenes, path, BuildTarget.iOS, BuildOptions.Development);
             ShopifyIosPostProcessor.ProcessForTests(path);
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS, "");
         }
 
         private static string PlayerPathFromArguments(string[] arguments) {

--- a/Assets/Editor/BuildPipeline/ShopifyBuildPipeline.cs
+++ b/Assets/Editor/BuildPipeline/ShopifyBuildPipeline.cs
@@ -30,11 +30,9 @@ namespace Shopify.BuildPipeline {
         {
             string path = PlayerPath;
             string[] scenes = {"Assets/Scenes/iOSTestScene.unity"};
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS, "IOS_SIMULATOR_SDK");
             PlayerSettings.iOS.sdkVersion = iOSSdkVersion.SimulatorSDK;
             BuildPipeline.BuildPlayer(scenes, path, BuildTarget.iOS, BuildOptions.Development);
             ShopifyIosPostProcessor.ProcessForTests(path);
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS, "");
         }
 
         private static string PlayerPathFromArguments(string[] arguments) {

--- a/Assets/Editor/TestDefaultQueriesCheckout.cs
+++ b/Assets/Editor/TestDefaultQueriesCheckout.cs
@@ -39,7 +39,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.PaymentPoll(query, paymentId);
             Assert.AreEqual(
-                "{node (id:\"an-id\"){__typename ...on Payment{errorMessage id ready }}}",
+                "{node (id:\"an-id\"){__typename ...on Payment{checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready completedAt }errorMessage id ready }}}",
                 query.ToString()
             );
         }
@@ -142,7 +142,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.CheckoutCompleteWithTokenizedPayment(query, checkoutId, tokenizedPaymentInput);
             Assert.AreEqual(
-                "mutation{checkoutCompleteWithTokenizedPayment (checkoutId:\"an-id\",payment:{amount:1,billingAddress:{address1:\"123 Test Street\",address2:\"456\",city:\"Toronto\",company:\"Shopify\",country:\"Canada\",firstName:\"First\",lastName:\"Last\",phone:\"1234567890\",province:\"Ontario\",zip:\"A1B2C3\"},idempotencyKey:\"unique_id\",paymentData:\"some_utf8_data_string\",type:\"apple_pay\"}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready }payment {errorMessage id ready }userErrors {field message }}}",
+                "mutation{checkoutCompleteWithTokenizedPayment (checkoutId:\"an-id\",payment:{amount:1,billingAddress:{address1:\"123 Test Street\",address2:\"456\",city:\"Toronto\",company:\"Shopify\",country:\"Canada\",firstName:\"First\",lastName:\"Last\",phone:\"1234567890\",province:\"Ontario\",zip:\"A1B2C3\"},idempotencyKey:\"unique_id\",paymentData:\"some_utf8_data_string\",type:\"apple_pay\"}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready }payment {checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready completedAt }errorMessage id ready }userErrors {field message }}}",
                 query.ToString()
             );
         }

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -130,7 +130,7 @@ module GraphQLGenerator
         SDK/iOS/SummaryItem
         SDK/iOS/iOSNativeCheckout
         SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver
-        SDK/iOS/PaymentDeserializer
+        SDK/iOS/ApplePayPayment
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -289,7 +289,7 @@ namespace <%= namespace %> {
             });
         }
 
-        private void CheckoutWithTokenizedPayment(TokenizedPaymentInput tokenizedPaymentInput, CompletionCallback callback) {
+        public void CheckoutWithTokenizedPayment(TokenizedPaymentInput tokenizedPaymentInput, CompletionCallback callback) {
             Action<Payment> pollPayment = (payment) => {
                 PollPaymentReady(payment.id(), (Payment newPayment, ShopifyError error) => {
                     if (error != null) {

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueriesCheckout.cs.erb
@@ -152,6 +152,9 @@ namespace <%= namespace %>.SDK {
 
         private PaymentQuery Payment(PaymentQuery payment) {
             return payment
+                .checkout(checkout => Checkout(checkout)
+                    .completedAt()
+                )
                 .errorMessage()
                 .id()
                 .ready();

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayPayment.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayPayment.cs.erb
@@ -5,7 +5,7 @@ namespace <%= namespace %>.SDK.iOS {
     using <%= namespace %>;
     using <%= namespace %>.MiniJSON;
 
-    public class PaymentDeserializer {
+    public class ApplePayPayment {
 
         private enum PaymentField {
             BillingContact,
@@ -26,7 +26,7 @@ namespace <%= namespace %>.SDK.iOS {
         readonly public string TransactionIdentifier;
         readonly public string PaymentData;
 
-        public PaymentDeserializer(string stringJson) {
+        public ApplePayPayment(string stringJson) {
             var dictionary = (Dictionary<string, object>)Json.Deserialize(stringJson);
 
             // Billing Address

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayPayment.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayPayment.cs.erb
@@ -55,7 +55,9 @@ namespace <%= namespace %>.SDK.iOS {
                 var paymentDictionary = tokenDictionary[TokenField.PaymentData.ToString("G")];
                 PaymentData = Json.Serialize(paymentDictionary);
             } else {
+                #if IOS_SIMULATOR_SDK
                 PaymentData = "";
+                #endif
             }
         }
     }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayPayment.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayPayment.cs.erb
@@ -55,9 +55,7 @@ namespace <%= namespace %>.SDK.iOS {
                 var paymentDictionary = tokenDictionary[TokenField.PaymentData.ToString("G")];
                 PaymentData = Json.Serialize(paymentDictionary);
             } else {
-                #if IOS_SIMULATOR_SDK
                 PaymentData = "";
-                #endif
             }
         }
     }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/PaymentDeserializer.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/PaymentDeserializer.cs.erb
@@ -54,6 +54,8 @@ namespace <%= namespace %>.SDK.iOS {
             if (tokenDictionary.ContainsKey(TokenField.PaymentData.ToString("G"))) {
                 var paymentDictionary = tokenDictionary[TokenField.PaymentData.ToString("G")];
                 PaymentData = Json.Serialize(paymentDictionary);
+            } else {
+                PaymentData = "";
             }
         }
     }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/PaymentDeserializer.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/PaymentDeserializer.cs.erb
@@ -1,4 +1,4 @@
-#if UNITY_iPHONE
+#if UNITY_IOS
 namespace <%= namespace %>.SDK.iOS {
     using System.Collections;
     using System.Collections.Generic;
@@ -21,6 +21,7 @@ namespace <%= namespace %>.SDK.iOS {
 
         readonly public MailingAddressInput BillingAddress;
         readonly public MailingAddressInput ShippingAddress;
+        readonly public string Email;
         readonly public string ShippingIdentifier;
         readonly public string TransactionIdentifier;
         readonly public string PaymentData;
@@ -35,6 +36,9 @@ namespace <%= namespace %>.SDK.iOS {
             // Shipping Address
             var shippingContactDictionary = (Dictionary<string, object>)dictionary[PaymentField.ShippingContact.ToString("G")];
             ShippingAddress = new MailingAddressInput(shippingContactDictionary);
+
+            // Email
+            Email = (string)shippingContactDictionary["email"];
 
             // Shipping Identifier
             ShippingIdentifier = (string)dictionary[PaymentField.ShippingIdentifier.ToString("G")];

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/PaymentDeserializer.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/PaymentDeserializer.cs.erb
@@ -41,15 +41,20 @@ namespace <%= namespace %>.SDK.iOS {
             Email = (string)shippingContactDictionary["email"];
 
             // Shipping Identifier
-            ShippingIdentifier = (string)dictionary[PaymentField.ShippingIdentifier.ToString("G")];
+            if (dictionary.ContainsKey(PaymentField.ShippingIdentifier.ToString("G"))) {
+                ShippingIdentifier = (string)dictionary[PaymentField.ShippingIdentifier.ToString("G")];
+            }
 
             // Transaction Identifier
             var tokenDictionary = (Dictionary<string, object>)dictionary[PaymentField.TokenData.ToString("G")];
             TransactionIdentifier = (string)tokenDictionary[TokenField.TransactionIdentifier.ToString("G")];
 
             // Payment Data
-            var paymentDictionary = tokenDictionary[TokenField.PaymentData.ToString("G")];
-            PaymentData = Json.Serialize(paymentDictionary);
+            // Payment Data can be null when running on a simulator
+            if (tokenDictionary.ContainsKey(TokenField.PaymentData.ToString("G"))) {
+                var paymentDictionary = tokenDictionary[TokenField.PaymentData.ToString("G")];
+                PaymentData = Json.Serialize(paymentDictionary);
+            }
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -71,7 +71,7 @@ namespace <%= namespace %>.SDK.iOS {
             if (payment.PaymentData == null) {
                 message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
             } else {
-                var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
+                var tokenizedPaymentInput = new TokenizedPaymentInput(amount: amount, billingAddress: payment.BillingAddress, idempotencyKey: payment.TransactionIdentifier, paymentData: payment.PaymentData, type: "apple_pay");
 
                 Action performCheckout = () => {
                     CheckoutWithTokenizedPayment(tokenizedPaymentInput, checkout, (ApplePayEventResponse errorResponse) => {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -60,7 +60,71 @@ namespace <%= namespace %>.SDK.iOS {
         }
 
         public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {
-            //TODO
+            var checkout = CurrentCart.CurrentCheckout;
+            var message = NativeMessage.CreateFromJSON(serializedMessage);
+            var amount  = checkout.totalPrice();
+            var payment = new PaymentDeserializer(message.Content);
+            var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
+
+
+            Action<ShopifyError> respondToSetFinalCheckoutFieldsError = (ShopifyError error) => {
+                ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
+
+                // Check to see if this is a recoverable user error
+                if (error.Type == ShopifyError.ErrorType.UserError) {
+                    var userErrors = CurrentCart.UserErrors;
+                    var status = GetAuthorizationStatusFromShippingUserErrors(userErrors);
+
+                    if (status == ApplePayAuthorizationStatus.InvalidShippingPostalAddress) {
+                        response = new ApplePayEventResponse(status, GetSummaryItems());
+                    } else if (status == ApplePayAuthorizationStatus.InvalidShippingContact) {
+                        response = new ApplePayEventResponse(status, GetSummaryItems(), GetShippingMethods());
+                    }
+                }
+
+                message.Respond(response.ToJsonString());
+            };
+
+            Action<ShopifyError> respondToCheckoutError = (ShopifyError error) => {
+                ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
+
+                // Check to see if this is a recoverable user error
+                if (error.Type == ShopifyError.ErrorType.UserError) {
+                    var userErrors = CurrentCart.UserErrors;
+                    var status = GetAuthorizationStatusFromCheckoutUserErrors(userErrors);
+
+                    if (status != ApplePayAuthorizationStatus.Failure) {
+                        response = new ApplePayEventResponse(status, GetSummaryItems(), GetShippingMethods());
+                    } else {
+                        response = new ApplePayEventResponse(status);
+                    }
+                }
+
+                message.Respond(response.ToJsonString());
+            };
+
+            Action performCheckout = () => {
+                CurrentCart.CheckoutWithTokenizedPayment(tokenizedPaymentInput, (ShopifyError error) => {
+                    if (error == null) {
+                        message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success).ToJsonString());
+                    } else {
+                        respondToCheckoutError(error);
+                    }
+                });
+            };
+
+            ShippingFields? shippingFields = null;
+            if (checkout.requiresShipping()) {
+                shippingFields = new ShippingFields(payment.ShippingAddress, payment.ShippingIdentifier);
+            }
+
+            CurrentCart.SetFinalCheckoutFields(payment.Email, shippingFields, (ShopifyError error) => {
+                if (error == null) {
+                    performCheckout();
+                } else {
+                    respondToSetFinalCheckoutFieldsError(error);
+                }
+            });
         }
 
         public void DidFinishCheckoutSession(string serializedMessage) {
@@ -80,16 +144,67 @@ namespace <%= namespace %>.SDK.iOS {
             }
         }
 
+         private ApplePayAuthorizationStatus GetAuthorizationStatusFromCheckoutUserErrors(List<UserError> errors) {
+
+            ApplePayAuthorizationStatus statusToReturn = ApplePayAuthorizationStatus.Failure;
+
+            foreach (var error in errors) {
+                var fields = error.field();
+
+                // If there exists a UserErrorPath that is atleast 2 Fields long, and the second last field is `billingAddress`
+                if (fields.Count > 2 && fields[fields.Count - 2].Equals("billingAddress")) {
+                    statusToReturn = ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
+                } else {
+                    statusToReturn = ApplePayAuthorizationStatus.Failure;
+                    break;
+                }
+            }
+
+            return statusToReturn;
+        }
+
+        private ApplePayAuthorizationStatus GetAuthorizationStatusFromShippingUserErrors(List<UserError> errors) {
+
+            string[] shippingAddressFields = {"address1", "address2", "city", "country", "province", "zip"};
+            var shippingAddressFieldsSet = new HashSet<string>(shippingAddressFields);
+
+            string[] shippingContactFields = {"firstName", "lastName", "phone", "email"};
+            var shippingContactFieldsSet = new HashSet<string>(shippingContactFields);
+
+            ApplePayAuthorizationStatus statusToReturn = ApplePayAuthorizationStatus.Failure;
+
+            foreach (var error in errors) {
+                var fields = error.field();
+                var lastField = fields[fields.Count - 1];
+
+                var isInvalidShippingAddressError =  shippingAddressFieldsSet.Contains(lastField);
+                var isInvalidShippingContactError =  shippingContactFieldsSet.Contains(lastField);
+
+                if (isInvalidShippingAddressError) {
+                    statusToReturn = ApplePayAuthorizationStatus.InvalidShippingPostalAddress;
+                } else if (isInvalidShippingContactError) {
+                    statusToReturn = ApplePayAuthorizationStatus.InvalidShippingContact;
+                } else {
+                    statusToReturn = ApplePayAuthorizationStatus.Failure;
+                    break;
+                }
+            }
+
+            return statusToReturn;
+        }
+
         // We only receive a partial shipping address before the user has authenticated
         // City, State, Zip, Country
         // So we will receive user errors from our GraphQL query, even though it was a success
         private ApplePayAuthorizationStatus GetAuthorizationStatusFromPreliminaryShippingUserErrors(List<UserError> errors) {
 
+            string[] shippingAddressFields = {"city", "country", "province", "zip"};
+            var shippingAddressFieldsSet = new HashSet<string>(shippingAddressFields);
+
             foreach (var error in errors) {
                 var fields = error.field();
                 var lastField = fields[fields.Count - 1];
-                var isInvalidShippingAddressError =
-                    lastField.Equals("city") || lastField.Equals("country") || lastField.Equals("province") || lastField.Equals("zip");
+                var isInvalidShippingAddressError = shippingAddressFieldsSet.Contains(lastField);
 
                 if (!isInvalidShippingAddressError) {
                     return ApplePayAuthorizationStatus.Failure;

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -144,23 +144,27 @@ namespace <%= namespace %>.SDK.iOS {
             }
         }
 
-         private ApplePayAuthorizationStatus GetAuthorizationStatusFromCheckoutUserErrors(List<UserError> errors) {
+        private ApplePayAuthorizationStatus GetAuthorizationStatusFromCheckoutUserErrors(List<UserError> errors) {
 
-            ApplePayAuthorizationStatus statusToReturn = ApplePayAuthorizationStatus.Failure;
-
+            // Check to see if any of the user errors are not billing address errors
+            // If it is not a billing address error return a failure
             foreach (var error in errors) {
                 var fields = error.field();
+                var isBillingAddressError = false;
 
-                // If there exists a UserErrorPath that is atleast 2 Fields long, and the second last field is `billingAddress`
-                if (fields.Count >= 2 && fields[fields.Count - 2].Equals("billingAddress")) {
-                    statusToReturn = ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
-                } else {
-                    statusToReturn = ApplePayAuthorizationStatus.Failure;
-                    break;
+                foreach(var field in fields) {
+                    if (field.Equals("billingAddress")) {
+                        isBillingAddressError = true;
+                        break;
+                    }
+                }
+
+                if (!isBillingAddressError) {
+                    return ApplePayAuthorizationStatus.Failure;
                 }
             }
 
-            return statusToReturn;
+            return ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
         }
 
         private ApplePayAuthorizationStatus GetAuthorizationStatusFromShippingUserErrors(List<UserError> errors) {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -66,25 +66,30 @@ namespace <%= namespace %>.SDK.iOS {
             var message = NativeMessage.CreateFromJSON(serializedMessage);
             var amount  = checkout.totalPrice();
             var payment = new ApplePayPayment(message.Content);
-            var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
 
-            Action performCheckout = () => {
-                CheckoutWithTokenizedPayment(tokenizedPaymentInput, checkout, (ApplePayEventResponse errorResponse) => {
+            if (payment.PaymentData == null) {
+                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success).ToJsonString());
+            } else {
+                var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
+
+                Action performCheckout = () => {
+                    CheckoutWithTokenizedPayment(tokenizedPaymentInput, checkout, (ApplePayEventResponse errorResponse) => {
+                        if (errorResponse == null) {
+                            message.Respond((new ApplePayEventResponse(ApplePayAuthorizationStatus.Success)).ToJsonString());
+                        } else {
+                            message.Respond(errorResponse.ToJsonString());
+                        }
+                    });
+                };
+
+                SetFinalCheckoutFieldsForPayment(payment, checkout, (ApplePayEventResponse errorResponse) => {
                     if (errorResponse == null) {
-                        message.Respond((new ApplePayEventResponse(ApplePayAuthorizationStatus.Success)).ToJsonString());
+                        performCheckout();
                     } else {
                         message.Respond(errorResponse.ToJsonString());
                     }
                 });
-            };
-
-            SetFinalCheckoutFieldsForPayment(payment, checkout, (ApplePayEventResponse errorResponse) => {
-                if (errorResponse == null) {
-                    performCheckout();
-                } else {
-                    message.Respond(errorResponse.ToJsonString());
-                }
-            });
+            }
         }
 
         public void DidFinishCheckoutSession(string serializedMessage) {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -63,7 +63,7 @@ namespace <%= namespace %>.SDK.iOS {
             var checkout = CurrentCart.CurrentCheckout;
             var message = NativeMessage.CreateFromJSON(serializedMessage);
             var amount  = checkout.totalPrice();
-            var payment = new PaymentDeserializer(message.Content);
+            var payment = new ApplePayPayment(message.Content);
             var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
 
 

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -8,6 +8,8 @@ namespace <%= namespace %>.SDK.iOS {
 
     public partial class iOSNativeCheckout : IApplePayEventReceiver {
 
+        private delegate void ApplePayEventHandlerCompletion(ApplePayEventResponse errorResponse);
+
         private enum NativePaymentStatus {
             Success, Cancelled, Failed
         }
@@ -66,63 +68,21 @@ namespace <%= namespace %>.SDK.iOS {
             var payment = new ApplePayPayment(message.Content);
             var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
 
-
-            Action<ShopifyError> respondToSetFinalCheckoutFieldsError = (ShopifyError error) => {
-                ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
-
-                // Check to see if this is a recoverable user error
-                if (error.Type == ShopifyError.ErrorType.UserError) {
-                    var userErrors = CurrentCart.UserErrors;
-                    var status = GetAuthorizationStatusFromShippingUserErrors(userErrors);
-
-                    if (status == ApplePayAuthorizationStatus.InvalidShippingPostalAddress) {
-                        response = new ApplePayEventResponse(status, GetSummaryItems());
-                    } else if (status == ApplePayAuthorizationStatus.InvalidShippingContact) {
-                        response = new ApplePayEventResponse(status, GetSummaryItems(), GetShippingMethods());
-                    }
-                }
-
-                message.Respond(response.ToJsonString());
-            };
-
-            Action<ShopifyError> respondToCheckoutError = (ShopifyError error) => {
-                ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
-
-                // Check to see if this is a recoverable user error
-                if (error.Type == ShopifyError.ErrorType.UserError) {
-                    var userErrors = CurrentCart.UserErrors;
-                    var status = GetAuthorizationStatusFromCheckoutUserErrors(userErrors);
-
-                    if (status != ApplePayAuthorizationStatus.Failure) {
-                        response = new ApplePayEventResponse(status, GetSummaryItems(), GetShippingMethods());
-                    } else {
-                        response = new ApplePayEventResponse(status);
-                    }
-                }
-
-                message.Respond(response.ToJsonString());
-            };
-
             Action performCheckout = () => {
-                CurrentCart.CheckoutWithTokenizedPayment(tokenizedPaymentInput, (ShopifyError error) => {
-                    if (error == null) {
-                        message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success).ToJsonString());
+                CheckoutWithTokenizedPayment(tokenizedPaymentInput, checkout, (ApplePayEventResponse errorResponse) => {
+                    if (errorResponse == null) {
+                        message.Respond((new ApplePayEventResponse(ApplePayAuthorizationStatus.Success)).ToJsonString());
                     } else {
-                        respondToCheckoutError(error);
+                        message.Respond(errorResponse.ToJsonString());
                     }
                 });
             };
 
-            ShippingFields? shippingFields = null;
-            if (checkout.requiresShipping()) {
-                shippingFields = new ShippingFields(payment.ShippingAddress, payment.ShippingIdentifier);
-            }
-
-            CurrentCart.SetFinalCheckoutFields(payment.Email, shippingFields, (ShopifyError error) => {
-                if (error == null) {
+            SetFinalCheckoutFieldsForPayment(payment, checkout, (ApplePayEventResponse errorResponse) => {
+                if (errorResponse == null) {
                     performCheckout();
                 } else {
-                    respondToSetFinalCheckoutFieldsError(error);
+                    message.Respond(errorResponse.ToJsonString());
                 }
             });
         }
@@ -145,7 +105,6 @@ namespace <%= namespace %>.SDK.iOS {
         }
 
         private ApplePayAuthorizationStatus GetAuthorizationStatusFromCheckoutUserErrors(List<UserError> errors) {
-
             // Check to see if any of the user errors are not billing address errors
             // If it is not a billing address error return a failure
             foreach (var error in errors) {
@@ -165,6 +124,61 @@ namespace <%= namespace %>.SDK.iOS {
             }
 
             return ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
+        }
+
+        private void SetFinalCheckoutFieldsForPayment(ApplePayPayment payment, Checkout checkout, ApplePayEventHandlerCompletion callback) {
+
+            ShippingFields? shippingFields = null;
+            if (checkout.requiresShipping()) {
+                shippingFields = new ShippingFields(payment.ShippingAddress, payment.ShippingIdentifier);
+            }
+
+            CurrentCart.SetFinalCheckoutFields(payment.Email, shippingFields, (ShopifyError error) => {
+                if (error == null) {
+                    callback(null);
+                } else {
+                    ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
+
+                    // Check to see if this is a recoverable user error
+                    if (error.Type == ShopifyError.ErrorType.UserError) {
+                        var userErrors = CurrentCart.UserErrors;
+                        var status = GetAuthorizationStatusFromShippingUserErrors(userErrors);
+
+                        if (status == ApplePayAuthorizationStatus.InvalidShippingPostalAddress) {
+                            response = new ApplePayEventResponse(status, GetSummaryItems());
+                        } else if (status == ApplePayAuthorizationStatus.InvalidShippingContact) {
+                            response = new ApplePayEventResponse(status, GetSummaryItems(), GetShippingMethods());
+                        }
+                    }
+
+                    callback(response);
+                }
+            });
+        }
+
+        private void CheckoutWithTokenizedPayment(TokenizedPaymentInput tokenizedPaymentInput, Checkout checkout, ApplePayEventHandlerCompletion callback) {
+
+            CurrentCart.CheckoutWithTokenizedPayment(tokenizedPaymentInput, (ShopifyError error) => {
+                if (error == null) {
+                    callback(null);
+                } else {
+                    ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
+
+                    // Check to see if this is a recoverable user error
+                    if (error.Type == ShopifyError.ErrorType.UserError) {
+                        var userErrors = CurrentCart.UserErrors;
+                        var status = GetAuthorizationStatusFromCheckoutUserErrors(userErrors);
+
+                        if (status != ApplePayAuthorizationStatus.Failure) {
+                            response = new ApplePayEventResponse(status, GetSummaryItems(), GetShippingMethods());
+                        } else {
+                            response = new ApplePayEventResponse(status);
+                        }
+                    }
+
+                    callback(response);
+                }
+            });
         }
 
         private ApplePayAuthorizationStatus GetAuthorizationStatusFromShippingUserErrors(List<UserError> errors) {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -152,7 +152,7 @@ namespace <%= namespace %>.SDK.iOS {
                 var fields = error.field();
 
                 // If there exists a UserErrorPath that is atleast 2 Fields long, and the second last field is `billingAddress`
-                if (fields.Count > 2 && fields[fields.Count - 2].Equals("billingAddress")) {
+                if (fields.Count >= 2 && fields[fields.Count - 2].Equals("billingAddress")) {
                     statusToReturn = ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
                 } else {
                     statusToReturn = ApplePayAuthorizationStatus.Failure;

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -66,31 +66,25 @@ namespace <%= namespace %>.SDK.iOS {
             var message = NativeMessage.CreateFromJSON(serializedMessage);
             var amount  = checkout.totalPrice();
             var payment = new ApplePayPayment(message.Content);
+            var tokenizedPaymentInput = new TokenizedPaymentInput(amount: amount, billingAddress: payment.BillingAddress, idempotencyKey: payment.TransactionIdentifier, paymentData: payment.PaymentData, type: "apple_pay");
 
-            // Apple Pay could return null payment data, or our serializer and deserializer fails
-            if (payment.PaymentData == null) {
-                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
-            } else {
-                var tokenizedPaymentInput = new TokenizedPaymentInput(amount: amount, billingAddress: payment.BillingAddress, idempotencyKey: payment.TransactionIdentifier, paymentData: payment.PaymentData, type: "apple_pay");
-
-                Action performCheckout = () => {
-                    CheckoutWithTokenizedPayment(tokenizedPaymentInput, checkout, (ApplePayEventResponse errorResponse) => {
-                        if (errorResponse == null) {
-                            message.Respond((new ApplePayEventResponse(ApplePayAuthorizationStatus.Success)).ToJsonString());
-                        } else {
-                            message.Respond(errorResponse.ToJsonString());
-                        }
-                    });
-                };
-
-                SetFinalCheckoutFieldsForPayment(payment, checkout, (ApplePayEventResponse errorResponse) => {
+            Action performCheckout = () => {
+                CheckoutWithTokenizedPayment(tokenizedPaymentInput, checkout, (ApplePayEventResponse errorResponse) => {
                     if (errorResponse == null) {
-                        performCheckout();
+                        message.Respond((new ApplePayEventResponse(ApplePayAuthorizationStatus.Success)).ToJsonString());
                     } else {
                         message.Respond(errorResponse.ToJsonString());
                     }
                 });
-            }
+            };
+
+            SetFinalCheckoutFieldsForPayment(payment, checkout, (ApplePayEventResponse errorResponse) => {
+                if (errorResponse == null) {
+                    performCheckout();
+                } else {
+                    message.Respond(errorResponse.ToJsonString());
+                }
+            });
         }
 
         public void DidFinishCheckoutSession(string serializedMessage) {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -104,28 +104,6 @@ namespace <%= namespace %>.SDK.iOS {
             }
         }
 
-        private ApplePayAuthorizationStatus GetAuthorizationStatusFromCheckoutUserErrors(List<UserError> errors) {
-            // Check to see if any of the user errors are not billing address errors
-            // If it is not a billing address error return a failure
-            foreach (var error in errors) {
-                var fields = error.field();
-                var isBillingAddressError = false;
-
-                foreach(var field in fields) {
-                    if (field.Equals("billingAddress")) {
-                        isBillingAddressError = true;
-                        break;
-                    }
-                }
-
-                if (!isBillingAddressError) {
-                    return ApplePayAuthorizationStatus.Failure;
-                }
-            }
-
-            return ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
-        }
-
         private void SetFinalCheckoutFieldsForPayment(ApplePayPayment payment, Checkout checkout, ApplePayEventHandlerCompletion callback) {
 
             ShippingFields? shippingFields = null;
@@ -179,6 +157,28 @@ namespace <%= namespace %>.SDK.iOS {
                     callback(response);
                 }
             });
+        }
+
+        private ApplePayAuthorizationStatus GetAuthorizationStatusFromCheckoutUserErrors(List<UserError> errors) {
+            // Check to see if any of the user errors are not billing address errors
+            // If it is not a billing address error return a failure
+            foreach (var error in errors) {
+                var fields = error.field();
+                var isBillingAddressError = false;
+
+                foreach(var field in fields) {
+                    if (field.Equals("billingAddress")) {
+                        isBillingAddressError = true;
+                        break;
+                    }
+                }
+
+                if (!isBillingAddressError) {
+                    return ApplePayAuthorizationStatus.Failure;
+                }
+            }
+
+            return ApplePayAuthorizationStatus.InvalidBillingPostalAddress;
         }
 
         private ApplePayAuthorizationStatus GetAuthorizationStatusFromShippingUserErrors(List<UserError> errors) {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -67,8 +67,9 @@ namespace <%= namespace %>.SDK.iOS {
             var amount  = checkout.totalPrice();
             var payment = new ApplePayPayment(message.Content);
 
+            // Apple Pay could return null payment data, or our serializer and deserializer fails
             if (payment.PaymentData == null) {
-                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success).ToJsonString());
+                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
             } else {
                 var tokenizedPaymentInput = new TokenizedPaymentInput(amount, payment.BillingAddress, payment.TransactionIdentifier, payment.PaymentData, "apple_pay");
 


### PR DESCRIPTION
Requires #153, so I set to temporary merge into that branch

+ Implements checkout with token and error handling
+ Adds missed deserializations for Payment
+ Adds Simulator compile time flag

##### I have not tested this yet, waiting on creating the correct environment on Core for testing

### Decisions
When handling Apple Pay errors, if more than one error is present such as `InvalidShippingContact` or `InvalidShippingAddress`, it doesn't matter which one we return, we can only return one at a time, so it is random to which one is returned