### PR TITLE
[Fix] Cart tests for new MiniJson serialization

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -38,13 +38,19 @@ class CartTests: XCTestCase {
         let identifier     = "FreeShipping"
         let detail         = "10-15 Days"
         
-        let summaryItems        = [Models.createSummaryItemJson(amount: itemAmount, label: itemLabel)]
-        let shippingMethods     = [Models.createShippingMethodJson(amount: shippingAmount, label: shippingLabel, identifier: identifier, detail: detail)]
-        let summaryItemData     = try! JSONSerialization.data(withJSONObject: summaryItems)
-        let shippingMethodData  = try! JSONSerialization.data(withJSONObject: shippingMethods)
+        // Serialize a single summary item and shipping method
+        let summaryItem         = Models.createSummaryItemJson(amount: itemAmount, label: itemLabel)
+        let shippingMethod      = Models.createShippingMethodJson(amount: shippingAmount, label: shippingLabel, identifier: identifier, detail: detail)
+        let summaryItemData     = try! JSONSerialization.data(withJSONObject: summaryItem)
+        let shippingMethodData  = try! JSONSerialization.data(withJSONObject: shippingMethod)
+        let serializedSummaryItem    = String.init(data: summaryItemData,    encoding: .utf8)!
+        let serializedShippingMethod = String.init(data: shippingMethodData, encoding: .utf8)!
         
-        let serializedSummaryItems  = String.init(data: summaryItemData,    encoding: .utf8)!.cString(using: .utf8)
-        let serializedShippingItems = String.init(data: shippingMethodData, encoding: .utf8)!.cString(using: .utf8)
+        // Put into an array of strings
+        let summaryItemsData    = try! JSONSerialization.data(withJSONObject: [serializedSummaryItem]);
+        let shippingMethodsData = try! JSONSerialization.data(withJSONObject: [serializedShippingMethod]);
+        let serializedSummaryItems    = String.init(data: summaryItemsData,    encoding: .utf8)!.cString(using: .utf8)
+        let serializedShippingMethods = String.init(data: shippingMethodsData, encoding: .utf8)!.cString(using: .utf8)
         
         let merchantID        = "merchantID".cString(using: .utf8)
         let countryCode       = "US".cString(using: .utf8)
@@ -53,7 +59,7 @@ class CartTests: XCTestCase {
         let unityObjectName   = "Tester".cString(using: .utf8)
 
         XCTAssertNil(Cart.session)
-        _CreateApplePaySession(unityObjectName, merchantID, countryCode, currencyCode, serializedSummaryItems, serializedShippingItems, requiringShipping)
+        _CreateApplePaySession(unityObjectName, merchantID, countryCode, currencyCode, serializedSummaryItems, serializedShippingMethods, requiringShipping)
         XCTAssertNotNil(Cart.session)
         
         let session = Cart.session!


### PR DESCRIPTION
Since MiniJson serializes each Summary item and shipping method to a string and then serializes and array of them, I refactored the tests to fit this.