### PR TITLE
[Tests] Adds tests for iOS Web Checkouts OnNativeMessage

### DIFF
--- a/Assets/Editor/MockLoaderCheckouts.cs
+++ b/Assets/Editor/MockLoaderCheckouts.cs
@@ -15,11 +15,17 @@ namespace Shopify.Tests {
         // The following query will return a user error
         private const string CREATE_QUERY_SENDS_USERERROR = @"mutation{checkoutCreate (input:{allowPartialAddresses:true,lineItems:[{quantity:1,variantId:""Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError==""}]}){checkout {id webUrl currencyCode requiresShipping subtotalPrice totalTax totalPrice ready lineItems (first:250){edges {node {id variant {id }}cursor }pageInfo {hasNextPage }}}userErrors {field message }}}";
 
+        // The following queries will return the completedAt date for a checkout for validation tesitng
+        private const string QUERY_COMPLETED_AT_WITH_DATE = @"{node (id:""checkout-id""){__typename ...on Checkout{completedAt }}}";
+        private const string QUERY_COMPLETED_AT_WITH_NULL_DATE = @"{node (id:""checkout-id-failed""){__typename ...on Checkout{completedAt }}}";
+
         public MockLoaderCheckouts() {
             SetupCreateResponse();
             SetupCreateResponsesForPolling();
             SetupCreateThenUpdateResponse();
             SetupUserErrorResponses();
+            SetupCompletedAtWithDateResponse();
+            SetupCompletedAtWithNullDateResponse();
         }
 
         private void SetupCreateResponse() {
@@ -242,6 +248,34 @@ namespace Shopify.Tests {
                                     ""message"": ""bad things happened""
                                 }
                             ]
+                        }
+                    }
+                }"
+            );
+        }
+
+        private void SetupCompletedAtWithDateResponse() {
+            AddResponse(
+                QUERY_COMPLETED_AT_WITH_DATE,
+                @"{
+                    ""data"": {
+                        ""node"": {
+                            ""__typename"": ""Checkout"",
+                            ""completedAt"": ""2017-07-11T16:42:34+00:00""
+                        }
+                    }
+                }"
+            );
+        }
+
+        private void SetupCompletedAtWithNullDateResponse() {
+            AddResponse(
+                QUERY_COMPLETED_AT_WITH_NULL_DATE,
+                @"{
+                    ""data"": {
+                        ""node"": {
+                            ""__typename"": ""Checkout"",
+                            ""completedAt"": null
                         }
                     }
                 }"

--- a/Assets/Editor/iOS/TestWebCheckout.cs
+++ b/Assets/Editor/iOS/TestWebCheckout.cs
@@ -1,0 +1,73 @@
+#if UNITY_IOS
+namespace Shopify.Tests {
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Shopify.Unity;
+    using Shopify.Unity.SDK;
+    using Shopify.Unity.SDK.iOS;
+
+    [TestFixture]
+    public class TestWebCheckout {
+        [SetUp]
+        public void Setup() {
+            #if (SHOPIFY_TEST)
+            ShopifyBuy.Reset();
+            #endif
+
+            ShopifyBuy.Init(new MockLoader());
+        }
+
+        [Test]        
+        public void TestOnNativeMessageDismissedWithValidCheckout() {
+            bool didSucceed = false;
+            bool didCancel = false;
+            bool didFail = false;
+
+            var webViewMessageReceiver = CreateMockMessageReceiver("checkout-id");
+
+            webViewMessageReceiver.OnSuccess = () => didSucceed = true;
+            webViewMessageReceiver.OnCancelled = () => didCancel = true;
+            webViewMessageReceiver.OnFailure = (e) => didFail = true;
+
+            string mockMessage = "{\"Identifier\": \"test\", \"Content\": \"dismissed\"}";
+            webViewMessageReceiver.OnNativeMessage(mockMessage);
+
+            Assert.IsTrue(didSucceed);
+            Assert.IsFalse(didCancel);
+            Assert.IsFalse(didFail);
+        }
+
+        [Test]        
+        public void TestOnNativeMessageDismissedWithInvalidCheckout() {
+            bool didSucceed = false;
+            bool didCancel = false;
+            bool didFail = false;
+
+            var webViewMessageReceiver = CreateMockMessageReceiver("checkout-id-failed");
+
+            webViewMessageReceiver.OnSuccess = () => didSucceed = true;
+            webViewMessageReceiver.OnCancelled = () => didCancel = true;
+            webViewMessageReceiver.OnFailure = (e) => didFail = true;
+
+            string mockMessage = "{\"Identifier\": \"test\", \"Content\": \"dismissed\"}";
+            webViewMessageReceiver.OnNativeMessage(mockMessage);
+
+            Assert.IsFalse(didSucceed);
+            Assert.IsFalse(didCancel);
+            Assert.IsTrue(didFail);
+        }
+
+        private iOSWebViewMessageReceiver CreateMockMessageReceiver(string checkoutId) {
+
+            var webViewMessageReceiver = new iOSWebViewMessageReceiver();
+
+            var cartDict = new Dictionary<string, object> { {"id", checkoutId} };
+            webViewMessageReceiver.CurrentCheckout = new Checkout(cartDict);
+            webViewMessageReceiver.Client = ShopifyBuy.Client();
+
+            return webViewMessageReceiver;
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
@@ -46,7 +46,7 @@ namespace <%= namespace %>.SDK.iOS {
         internal CheckoutCancelCallback OnCancelled;
         internal CheckoutFailureCallback OnFailure;
 
-        void OnNativeMessage(string jsonMessage) {
+        public void OnNativeMessage(string jsonMessage) {
             var message = NativeMessage.CreateFromJSON(jsonMessage);
             if (message.Content == "dismissed") {
                 // Do a round trip to the server to see if the purchase is solid.


### PR DESCRIPTION
Using https://github.com/Shopify/unity-buy-sdk/pull/171 as a base, this patch adds new tests for the web checkout's core logic that lives in `OnNativeMessage`.