### PR TITLE
[Fix] Fixes presentation and status bar issues with safari view controller for web checkouts

### DIFF
--- a/Assets/Plugins/iOS/Shopify/WebCheckoutSession.swift
+++ b/Assets/Plugins/iOS/Shopify/WebCheckoutSession.swift
@@ -55,7 +55,11 @@ private var activeWebPaySession: WebCheckoutSession?
         
         let webViewController = SFSafariViewController(url: url)
         webViewController.delegate = self
-        UnityAppController.root.present(webViewController, animated: true, completion: nil)
+
+        let navController = WebCheckoutNavigationController(rootViewController: webViewController)
+        navController.isNavigationBarHidden = true
+        UnityAppController.root.present(navController, animated: true, completion: nil)
+
         return true
     }
 }
@@ -72,5 +76,14 @@ private extension UnityAppController {
     static var root: UIViewController {
         let unityController = UIApplication.shared.delegate as! UnityAppController
         return unityController.rootViewController
+    }
+}
+
+// Small helper class for presenting the SFSafariViewController
+private class WebCheckoutNavigationController: UINavigationController {
+        
+    // Only allow the same rotations the underlying game allows.
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UnityAppController.root.supportedInterfaceOrientations
     }
 }

--- a/Assets/Plugins/iOS/Shopify/WebCheckoutSession.swift
+++ b/Assets/Plugins/iOS/Shopify/WebCheckoutSession.swift
@@ -79,7 +79,7 @@ private extension UnityAppController {
     }
 }
 
-// Small helper class for presenting the SFSafariViewController
+// Helper subclass that matches the Unity controller's configuration.
 private class UnityModalNavigationController: UINavigationController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UnityAppController.root.supportedInterfaceOrientations

--- a/Assets/Plugins/iOS/Shopify/WebCheckoutSession.swift
+++ b/Assets/Plugins/iOS/Shopify/WebCheckoutSession.swift
@@ -56,7 +56,7 @@ private var activeWebPaySession: WebCheckoutSession?
         let webViewController = SFSafariViewController(url: url)
         webViewController.delegate = self
 
-        let navController = WebCheckoutNavigationController(rootViewController: webViewController)
+        let navController = UnityModalNavigationController(rootViewController: webViewController)
         navController.isNavigationBarHidden = true
         UnityAppController.root.present(navController, animated: true, completion: nil)
 
@@ -80,10 +80,16 @@ private extension UnityAppController {
 }
 
 // Small helper class for presenting the SFSafariViewController
-private class WebCheckoutNavigationController: UINavigationController {
-        
-    // Only allow the same rotations the underlying game allows.
+private class UnityModalNavigationController: UINavigationController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UnityAppController.root.supportedInterfaceOrientations
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return UnityAppController.root.preferredStatusBarStyle
+    }
+    
+    override var prefersStatusBarHidden: Bool {
+        return UnityAppController.root.prefersStatusBarHidden
     }
 }


### PR DESCRIPTION
To resolve both the status bar and push animation issues, I've wrapped the SFSafariViewController with a custom UINavigationController. The custom UINavigationController will also constrain the rotation allowed to whatever the game supports. If the game is landscape only, the controller will only be landscape!