### PR TITLE
[Fix] Moves iOSWebViewMessageReceiver properties to public temporarily

### DIFF
--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
@@ -38,13 +38,13 @@ namespace <%= namespace %>.SDK.iOS {
         }
     }
 
-    class iOSWebViewMessageReceiver: MonoBehaviour {
-        internal ShopifyClient Client;
-        internal Checkout CurrentCheckout;
+    public class iOSWebViewMessageReceiver: MonoBehaviour {
+        public ShopifyClient Client;
+        public Checkout CurrentCheckout;
 
-        internal CheckoutSuccessCallback OnSuccess;
-        internal CheckoutCancelCallback OnCancelled;
-        internal CheckoutFailureCallback OnFailure;
+        public CheckoutSuccessCallback OnSuccess;
+        public CheckoutCancelCallback OnCancelled;
+        public CheckoutFailureCallback OnFailure;
 
         public void OnNativeMessage(string jsonMessage) {
             var message = NativeMessage.CreateFromJSON(jsonMessage);


### PR DESCRIPTION
Fixes random compile issue in Unity by moving the properties to public for now. This will be cleaned up when we do the public API audit.