### PR TITLE
[Refactor] Refactors classes/methods that rely on UNITY_IOS to support monotesting.

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -127,6 +127,7 @@ module GraphQLGenerator
         SDK/iOS/ApplePayEventResponse
         SDK/iOS/ShippingMethod
         SDK/iOS/iOSWebCheckout
+        SDK/iOS/iOSWebViewMessageReceiver
         SDK/iOS/SummaryItem
         SDK/iOS/iOSNativeCheckout
         SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver

--- a/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
@@ -1,9 +1,7 @@
-#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.SDK {
     using System;
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
-    using UnityEngine;
     using <%= namespace %>.MiniJSON;
 
     public class NativeMessage {
@@ -25,8 +23,9 @@ namespace <%= namespace %>.SDK {
         }
 
         public void Respond(string message) {
+            #if !SHOPIFY_MONO_UNIT_TEST
             _RespondToNativeMessage(Identifier, message);
+            #endif
         }
     }
 }
-#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/IApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/IApplePayEventReceiver.cs.erb
@@ -2,7 +2,6 @@
 namespace <%= namespace %>.SDK.iOS {
     using System.Collections;
     using System.Collections.Generic;
-    using UnityEngine;
 
     public interface IApplePayEventReceiver {
         void UpdateSummaryItemsForShippingIdentifier(string serializedMessage);

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -68,7 +68,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// <param name="failure">Delegate method that will be notified upon a failure during the checkout process</param>
         /// <param name="cancelled">Delegate method that will be notified upon a cancellation during the checkout process</param>
         public void Checkout(string key, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
-
+            #if !SHOPIFY_MONO_UNIT_TEST
             OnSuccess = success;
             OnCancelled = cancelled;
             OnFailure = failure;
@@ -91,6 +91,7 @@ namespace <%= namespace %>.SDK.iOS {
                 var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create an Apple Pay payment request. Please check that your merchant ID is valid.");
                 OnFailure(error);
             }
+            #endif
         }
 
         private List<SummaryItem> GetSummaryItems() {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
@@ -1,9 +1,13 @@
 #if UNITY_IOS
 namespace <%= namespace %>.SDK.iOS {
-    using UnityEngine;
+    using System;
     using System.Runtime.InteropServices;
     using <%= namespace %>.SDK;
     using <%= namespace %>.GraphQL;
+
+    #if !SHOPIFY_MONO_UNIT_TEST
+    using UnityEngine;
+    #endif
 
     class iOSWebCheckout: IWebCheckout {
         private static iOSWebViewMessageReceiver _messageReceiver;
@@ -20,10 +24,13 @@ namespace <%= namespace %>.SDK.iOS {
         private static extern void _CheckoutWithWebView(string unityDelegateObjectName, string checkoutURL);
 
         public void Checkout(string checkoutURL, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
+            #if !SHOPIFY_MONO_UNIT_TEST
             SetupNativeMessageReceiver(success, cancelled, failure);
             _CheckoutWithWebView(GlobalGameObject.Name, checkoutURL);
+            #endif
         }
 
+        #if !SHOPIFY_MONO_UNIT_TEST
         private void SetupNativeMessageReceiver(CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
             if (_messageReceiver == null) {
                 _messageReceiver = GlobalGameObject.AddComponent<iOSWebViewMessageReceiver>();
@@ -36,40 +43,7 @@ namespace <%= namespace %>.SDK.iOS {
             _messageReceiver.OnCancelled = cancelled;
             _messageReceiver.OnFailure = failure;
         }
-    }
-
-    public class iOSWebViewMessageReceiver: MonoBehaviour {
-        public ShopifyClient Client;
-        public Checkout CurrentCheckout;
-
-        public CheckoutSuccessCallback OnSuccess;
-        public CheckoutCancelCallback OnCancelled;
-        public CheckoutFailureCallback OnFailure;
-
-        public void OnNativeMessage(string jsonMessage) {
-            var message = NativeMessage.CreateFromJSON(jsonMessage);
-            if (message.Content == "dismissed") {
-                var query = new QueryRootQuery();
-                query.node(
-                    buildQuery: n => n
-                        .onCheckout(c => c.completedAt()),
-                    id: CurrentCheckout.id()
-                );
-                
-                Client.Query(query, (response, error) => {
-                    if (error != null) {
-                        OnFailure(error);
-                    } else {
-                        var checkout = (Checkout) response.node();
-                        if (checkout.completedAt() != null) {
-                            OnSuccess();
-                        } else {
-                            OnCancelled();
-                        }
-                    } 
-                });
-            }
-        }
+        #endif
     }
 }
 #endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebViewMessageReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebViewMessageReceiver.cs.erb
@@ -1,0 +1,47 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System;
+    using System.Runtime.InteropServices;
+    using <%= namespace %>.SDK;
+    using <%= namespace %>.GraphQL;
+
+    #if !SHOPIFY_MONO_UNIT_TEST
+    using UnityEngine;
+    public partial class iOSWebViewMessageReceiver: MonoBehaviour {}
+    #endif
+
+    public partial class iOSWebViewMessageReceiver {
+        public ShopifyClient Client;
+        public Checkout CurrentCheckout;
+
+        public CheckoutSuccessCallback OnSuccess;
+        public CheckoutCancelCallback OnCancelled;
+        public CheckoutFailureCallback OnFailure;
+
+        public void OnNativeMessage(string jsonMessage) {
+            var message = NativeMessage.CreateFromJSON(jsonMessage);
+            if (message.Content == "dismissed") {
+                var query = new QueryRootQuery();
+                query.node(
+                    buildQuery: n => n
+                        .onCheckout(c => c.completedAt()),
+                    id: CurrentCheckout.id()
+                );
+                
+                Client.Query(query, (response, error) => {
+                    if (error != null) {
+                        OnFailure(error);
+                    } else {
+                        var checkout = (Checkout) response.node();
+                        if (checkout.completedAt() != null) {
+                            OnSuccess();
+                        } else {
+                            OnCancelled();
+                        }
+                    } 
+                });
+            }
+        }
+    }
+}
+#endif

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,17 @@ which mcs &> /dev/null || die "Mono is not installed"
 which nunit-console &> /dev/null || die "nunit-console is not installed"
 
 # we're defining SHOPIFY_TEST here so that source can check whether we're running assertions/tests
-mcs -debug -define:SHOPIFY_TEST -define:SHOPIFY_MONO_UNIT_TEST -recurse:'Assets/Shopify/*.cs' -recurse:'Assets/Editor/*.cs' -reference:nunit.framework.dll -target:library -out:test.dll
+mcs \
+    -debug \
+    -define:SHOPIFY_TEST \
+    -define:SHOPIFY_MONO_UNIT_TEST \
+    -define:UNITY_IOS \
+    -recurse:'Assets/Shopify/*.cs' \
+    -recurse:'Assets/Editor/*.cs' \
+    -recurse:'Assets/Editor/iOS/*.cs' \
+    -reference:nunit.framework.dll \
+    -target:library \
+    -out:test.dll
 
 if [ $? = 0 ] ; then
     nunit-console test.dll


### PR DESCRIPTION
* Defines UNITY_IOS preproccessor in test script mcs command to include all iOS dependent classes.
* Moves iOSWebViewMessageReceiver into it's own class for easier #ifdef exclusion for SHOPIFY_MONO_UNIT_TEST/UNITY_IOS.
* Removed not needed UnityEngine import for NativeMessage.cs.erb and wrapped extern call with !SHOPIFY_MONO_UNIT_TEST.
* Split ApplePayEventReceiverBridge.cs.erb into 2 partial classes to isolate MonoBehaviour subclassing.