### PR TITLE
[Fix] Adds cancelled state handling for web checkouts and tests

### DIFF
--- a/Assets/Editor/MockLoaderCheckouts.cs
+++ b/Assets/Editor/MockLoaderCheckouts.cs
@@ -17,7 +17,8 @@ namespace Shopify.Tests {
 
         // The following queries will return the completedAt date for a checkout for validation tesitng
         private const string QUERY_COMPLETED_AT_WITH_DATE = @"{node (id:""checkout-id""){__typename ...on Checkout{completedAt }}}";
-        private const string QUERY_COMPLETED_AT_WITH_NULL_DATE = @"{node (id:""checkout-id-failed""){__typename ...on Checkout{completedAt }}}";
+        private const string QUERY_COMPLETED_AT_WITH_NULL_DATE = @"{node (id:""checkout-id-cancelled""){__typename ...on Checkout{completedAt }}}";
+        private const string QUERY_COMPLETED_AT_ERROR = @"{node (id:""checkout-id-failed""){__typename ...on Checkout{completedAt }}}";
 
         public MockLoaderCheckouts() {
             SetupCreateResponse();
@@ -26,6 +27,7 @@ namespace Shopify.Tests {
             SetupUserErrorResponses();
             SetupCompletedAtWithDateResponse();
             SetupCompletedAtWithNullDateResponse();
+            SetupCompletedAtWithError();
         }
 
         private void SetupCreateResponse() {
@@ -278,6 +280,17 @@ namespace Shopify.Tests {
                             ""completedAt"": null
                         }
                     }
+                }"
+            );
+        }
+
+        private void SetupCompletedAtWithError() {
+            AddResponse(
+                QUERY_COMPLETED_AT_ERROR,
+                @"{
+                    ""errors"": [
+                        {""message"": ""GraphQL error from mock loader""}
+                    ]
                 }"
             );
         }

--- a/Assets/Editor/iOS/TestWebCheckout.cs
+++ b/Assets/Editor/iOS/TestWebCheckout.cs
@@ -19,7 +19,7 @@ namespace Shopify.Tests {
         }
 
         [Test]        
-        public void TestOnNativeMessageDismissedWithValidCheckout() {
+        public void TestWebCheckoutSucceeded() {
             bool didSucceed = false;
             bool didCancel = false;
             bool didFail = false;
@@ -39,7 +39,27 @@ namespace Shopify.Tests {
         }
 
         [Test]        
-        public void TestOnNativeMessageDismissedWithInvalidCheckout() {
+        public void TestWebCheckoutCancelled() {
+            bool didSucceed = false;
+            bool didCancel = false;
+            bool didFail = false;
+
+            var webViewMessageReceiver = CreateMockMessageReceiver("checkout-id-cancelled");
+
+            webViewMessageReceiver.OnSuccess = () => didSucceed = true;
+            webViewMessageReceiver.OnCancelled = () => didCancel = true;
+            webViewMessageReceiver.OnFailure = (e) => didFail = true;
+
+            string mockMessage = "{\"Identifier\": \"test\", \"Content\": \"dismissed\"}";
+            webViewMessageReceiver.OnNativeMessage(mockMessage);
+
+            Assert.IsFalse(didSucceed);
+            Assert.IsTrue(didCancel);
+            Assert.IsFalse(didFail);
+        }
+
+        [Test]        
+        public void TestWebCheckoutFailure() {
             bool didSucceed = false;
             bool didCancel = false;
             bool didFail = false;

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
@@ -49,41 +49,26 @@ namespace <%= namespace %>.SDK.iOS {
         public void OnNativeMessage(string jsonMessage) {
             var message = NativeMessage.CreateFromJSON(jsonMessage);
             if (message.Content == "dismissed") {
-                // Do a round trip to the server to see if the purchase is solid.
-                // Invoke callbacks on cart to pass to Unity
-                DidCheckoutCompleteSuccessfully(CurrentCheckout.id(), (didSucceed) => {
-                    if (didSucceed) {
-                        OnSuccess();
-                        return;
+                var query = new QueryRootQuery();
+                query.node(
+                    buildQuery: n => n
+                        .onCheckout(c => c.completedAt()),
+                    id: CurrentCheckout.id()
+                );
+                
+                Client.Query(query, (response, error) => {
+                    if (error != null) {
+                        OnFailure(error);
+                    } else {
+                        var checkout = (Checkout) response.node();
+                        if (checkout.completedAt() != null) {
+                            OnSuccess();
+                        } else {
+                            OnCancelled();
+                        }
                     } 
-
-                    var error = new ShopifyError(
-                        ShopifyError.ErrorType.NativePaymentProcessingError, 
-                        "User navigated to end of checkout without successfully checking out."
-                    );
-
-                    OnFailure(error);
                 });
             }
-        }
-
-        private delegate void VerifyCheckoutComplete(bool didSucceed);
-        private void DidCheckoutCompleteSuccessfully(string checkoutId, VerifyCheckoutComplete callback) {
-            var query = new QueryRootQuery();
-            query.node(
-                buildQuery: n => n
-                    .onCheckout(c => c.completedAt()),
-                id: CurrentCheckout.id()
-            );
-            
-            Client.Query(query, (response, error) => {
-                if (error != null) {
-                    callback(false);
-                } else {
-                    var checkout = (Checkout) response.node();
-                    callback(checkout.completedAt() != null);
-                } 
-            });
         }
     }
 }


### PR DESCRIPTION
Before, we were only ever invoking success when a checkout has a completedAt date or failure when it doesn't. In the case of cancelling the web checkout, the failure callback was being invoked instead of cancelled. It doesn't make much sense to 'fail' when the user just 'cancelled' so this patch will only call the failure callback if we ran into some kind of failure communicating with our API and calls cancelled if we don't see the completedAt date. This means that in cases of spoofing the web view that it will come back as cancelled but that seems like an edge case.