### PR TITLE
[Fix] Use store country code for payment session

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -103,6 +103,7 @@ module GraphQLGenerator
         SDK/DefaultQueriesProducts
         SDK/DefaultQueriesCollections
         SDK/DefaultQueriesCheckout
+        SDK/DefaultShopQueries
         SDK/Delegates
         SDK/GlobalGameObject
         SDK/QueryLoader

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -71,7 +71,7 @@ namespace <%= namespace %> {
         private INativeCheckout NativeCheckout;
         private PaymentSettings StorePaymentSettings;
 
-        private Client CurrentClient;
+        private ShopifyClient CurrentClient;
 
         #if (SHOPIFY_TEST)
         public CartState State;
@@ -95,6 +95,7 @@ namespace <%= namespace %> {
         /// \endcode
         public Cart(ShopifyClient client) {
             State = new CartState(client);
+            CurrentClient = client;
 
             #if UNITY_IOS
             WebCheckout = new iOSWebCheckout(this, client);
@@ -142,9 +143,9 @@ namespace <%= namespace %> {
                 if (error != null) {
                     failure(error);
                 } else {
-                    GetPaymentSettings(paymentSettings, error) => {
-                        if (error != null) {
-                            failure(error);
+                    GetPaymentSettings((paymentSettings, paymentSettingsError) => {
+                        if (paymentSettingsError != null) {
+                            failure(paymentSettingsError);
                         } else {
                             NativeCheckout.Checkout(key, paymentSettings, success, cancelled, failure);
                         }
@@ -152,6 +153,7 @@ namespace <%= namespace %> {
                 }
             });
         }
+
         public bool CanShowNativePaySetup() {
             if (NativeCheckout != null) {
                return  NativeCheckout.CanShowPaymentSetup();
@@ -168,7 +170,7 @@ namespace <%= namespace %> {
             }
         }
 
-        public bool CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
+        public void CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
             if (NativeCheckout != null) {
                 GetPaymentSettings((paymentSettings, error) => {
                     if (error != null) {
@@ -178,11 +180,11 @@ namespace <%= namespace %> {
                     }
                 });
             } else {
-                return false;
+                callback(false);
             }
         }
 
-        private void GetPaymentSettings(PaymentSettingHandler callback) {
+        private void GetPaymentSettings(PaymentSettingsHandler callback) {
             if (StorePaymentSettings != null) {
                 callback(StorePaymentSettings, null);
             } else {

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -168,9 +168,15 @@ namespace <%= namespace %> {
             }
         }
 
-        public bool CanCheckoutWithNativePay() {
+        public bool CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
             if (NativeCheckout != null) {
-                return NativeCheckout.CanCheckout();
+                GetPaymentSettings((paymentSettings, error) => {
+                    if (error != null) {
+                        callback(false);
+                    } else {
+                        callback(NativeCheckout.CanCheckout(paymentSettings));
+                    }
+                });
             } else {
                 return false;
             }

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -71,7 +71,7 @@ namespace <%= namespace %> {
         private INativeCheckout NativeCheckout;
         private PaymentSettings StorePaymentSettings;
 
-        private ShopifyClient CurrentClient;
+        private ShopifyClient Client;
 
         #if (SHOPIFY_TEST)
         public CartState State;
@@ -95,7 +95,7 @@ namespace <%= namespace %> {
         /// \endcode
         public Cart(ShopifyClient client) {
             State = new CartState(client);
-            CurrentClient = client;
+            Client = client;
 
             #if UNITY_IOS
             WebCheckout = new iOSWebCheckout(this, client);
@@ -188,7 +188,7 @@ namespace <%= namespace %> {
             if (StorePaymentSettings != null) {
                 callback(StorePaymentSettings, null);
             } else {
-                CurrentClient.paymentSettings((paymentSettings, error) => {
+                Client.paymentSettings((paymentSettings, error) => {
                     if (error == null) {
                         StorePaymentSettings = paymentSettings;
                     }

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -69,6 +69,9 @@ namespace <%= namespace %> {
 
         private IWebCheckout WebCheckout;
         private INativeCheckout NativeCheckout;
+        private PaymentSettings StorePaymentSettings;
+
+        private Client CurrentClient;
 
         #if (SHOPIFY_TEST)
         public CartState State;
@@ -139,7 +142,13 @@ namespace <%= namespace %> {
                 if (error != null) {
                     failure(error);
                 } else {
-                    NativeCheckout.Checkout(key, success, cancelled, failure);
+                    GetPaymentSettings(paymentSettings, error) => {
+                        if (error != null) {
+                            failure(error);
+                        } else {
+                            NativeCheckout.Checkout(key, paymentSettings, success, cancelled, failure);
+                        }
+                    });
                 }
             });
         }
@@ -164,6 +173,19 @@ namespace <%= namespace %> {
                 return NativeCheckout.CanCheckout();
             } else {
                 return false;
+            }
+        }
+
+        private void GetPaymentSettings(PaymentSettingHandler callback) {
+            if (StorePaymentSettings != null) {
+                callback(StorePaymentSettings, null);
+            } else {
+                CurrentClient.paymentSettings((paymentSettings, error) => {
+                    if (error == null) {
+                        StorePaymentSettings = paymentSettings;
+                    }
+                    callback(paymentSettings, error);
+                });
             }
         }
     }

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
@@ -12,6 +12,7 @@ namespace <%= namespace %>.SDK {
         public static DefaultProductsQueries products = new DefaultProductsQueries();
         public static DefaultCollectionsQueries collections = new DefaultCollectionsQueries();
         public static DefaultQueriesCheckout checkout = new DefaultQueriesCheckout();
+        public static DefaultShopQueries shop = new DefaultShopQueries();
 
         public static string GetAliasFromIndex(int idx) {
             return String.Format("a{0}", idx);

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultShopQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultShopQueries.cs.erb
@@ -1,0 +1,19 @@
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections.Generic;
+    using <%= namespace %>.GraphQL;
+
+    /// <summary>
+    /// Generates default queries for <see ref="ShopifyClient">ShopifyClient</see>.
+    /// </summary>
+    public class DefaultShopQueries {
+
+        public void PaymentSettings(QueryRootQuery query) {
+            query.shop(
+                buildQuery: shop => shop.paymentSettings(
+                    buildQuery: paymentSettings => paymentSettings.countryCode().currencyCode()
+                )
+            );
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -22,6 +22,8 @@ namespace <%= namespace %>.SDK {
     public delegate void ResponseQueryHandler(<%= schema.query_root_name %> response, ShopifyError error);
     public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, ShopifyError error);
 
+    public delegate void PaymentSettingsHandler(PaymentSettings paymentSettings, ShopifyError error)
+
     public delegate void OnCartLineItemChange();
 
     public delegate bool PollUpdatedHandler(QueryRoot updatedQueryRoot);

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -22,7 +22,7 @@ namespace <%= namespace %>.SDK {
     public delegate void ResponseQueryHandler(<%= schema.query_root_name %> response, ShopifyError error);
     public delegate void ResponseMutationHandler(<%= schema.mutation_root_name %> response, ShopifyError error);
 
-    public delegate void PaymentSettingsHandler(PaymentSettings paymentSettings, ShopifyError error)
+    public delegate void PaymentSettingsHandler(PaymentSettings paymentSettings, ShopifyError error);
 
     public delegate void OnCartLineItemChange();
 

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -28,6 +28,7 @@ namespace <%= namespace %>.SDK {
 
     public delegate bool PollUpdatedHandler(QueryRoot updatedQueryRoot);
 
+    public delegate void CanCheckoutWithNativePayCallback(bool canCheckout);
     public delegate void CheckoutSuccessCallback();
     public delegate void CheckoutFailureCallback(ShopifyError error);
     public delegate void CheckoutCancelCallback();

--- a/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
@@ -3,8 +3,21 @@ namespace <%= namespace %>.SDK {
     interface INativeCheckout {
         bool CanShowPaymentSetup();
         void ShowPaymentSetup();
-        bool CanCheckout();
-        /// Key is the public key that is used for encrypting a native payment's token data
-        void Checkout(string key, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
+
+        /// <summary>
+        /// Check whether the device supports making a native payment given the Shop's payment settings
+        /// </summary>
+        /// <param name="paymentSettings">The Shop's payment settings</param>
+        /// <returns>True if the device supports making a native payment</returns>
+        bool CanCheckout(PaymentSettings paymentSettings);
+
+        /// <summary>
+        /// Display the native payment sheet to perform a native payment
+        /// </summary>
+        /// <param name="key">The public key that is used for encrypting a native payment's token data</param>
+        /// <param name="success">The closure that is invoked upon success of the payment</param>
+        /// <param name="cancelled">The closure that is invoked upon cancellation of the payment</param>
+        /// <param name="failure">The closure that is invoked upon failure of the payment</param>
+        void Checkout(string key, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -38,7 +38,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// Checks if the device is capable of paying with Apple Pay
         /// </summary>
         /// <returns>True if the device is capable of paying with Apple Pay</returns>
-        public bool CanCheckout() {
+        public bool CanCheckout(PaymentSettings paymentSettings) {
             return _CanCheckoutWithApplePay();
         }
 
@@ -67,7 +67,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// <param name="success">Delegate method that will be notified upon a successful payment</param>
         /// <param name="failure">Delegate method that will be notified upon a failure during the checkout process</param>
         /// <param name="cancelled">Delegate method that will be notified upon a cancellation during the checkout process</param>
-        public void Checkout(string key, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
+        public void Checkout(string key, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
             #if !SHOPIFY_MONO_UNIT_TEST
             OnSuccess = success;
             OnCancelled = cancelled;
@@ -78,6 +78,7 @@ namespace <%= namespace %>.SDK.iOS {
             var summaryItems = GetSummaryItems();
             var summaryString = Json.Serialize(summaryItems);
             var currencyCodeString = checkout.currencyCode().ToString("G");
+            var countryCodeString = paymentSettings.countryCode().ToString("G");
             var requiresShipping = checkout.requiresShipping();
 
             if (ApplePayEventBridge == null) {
@@ -85,7 +86,7 @@ namespace <%= namespace %>.SDK.iOS {
                 ApplePayEventBridge.Receiver = this;
             }
 
-            if (_CreateApplePaySession(GlobalGameObject.Name, key, "CA", currencyCodeString, summaryString, null, requiresShipping)) {
+            if (_CreateApplePaySession(GlobalGameObject.Name, key, countryCodeString, currencyCodeString, summaryString, null, requiresShipping)) {
                 _PresentApplePayAuthorization();
             } else {
                 var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create an Apple Pay payment request. Please check that your merchant ID is valid.");

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -494,15 +494,14 @@ namespace <%= namespace %> {
         /// </summary>
         /// <param name="callback">callback that will receive responses from server</param>
         public void paymentSettings(PaymentSettingsHandler callback) {
-
             var query = new QueryRootQuery();
             DefaultQueries.shop.PaymentSettings(query);
 
             Query(query, (response, error) => {
                 if (error != null) {
-                    callback(response.shop().paymentSettings, error);
-                } else {
                     callback(null, error);
+                } else {
+                    callback(response.shop().paymentSettings(), null);
                 }
             });
         }

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -444,7 +444,7 @@ namespace <%= namespace %> {
         /// Note that <c>shop.collections</c> is a Connection (GraphQL paginated data structure). <see ref="ShopifyClient.collections">collections </see>
         /// will load all pages of collections by default unless a value is passed for the <c>first</c> param.
         /// </summary>
-        /// <param name="callback">will receive responses from server</param>
+        /// <param name="callback">callback that will receive responses from server</param>
         /// <param name="first">can be used to limit how many products are returned. For instance 10 would return only 10 collections</param>
         /// <param name="after">
         /// This is an advanced feature but when querying Relay Connections a cursor is returned which can be used to determine
@@ -484,6 +484,27 @@ namespace <%= namespace %> {
                     callback(nodesResult.ConvertAll(n => (Collection) n), responseError);
                 });
             }, first: first, after: after);
+        }
+
+        /// <summary>
+        /// Generates a query to fetch the <c>PaymentSettings</c> from a Shopify store. The generated query will query the following on paymentSettings:
+        ///     - currencyCode
+        ///     - countryCode
+        ///
+        /// </summary>
+        /// <param name="callback">callback that will receive responses from server</param>
+        public void paymentSettings(PaymentSettingsHandler callback) {
+
+            var query = new QueryRootQuery();
+            DefaultQueries.shop.PaymentSettings(query);
+
+            Query(query, (response, error) => {
+                if (error != null) {
+                    callback(response.shop().paymentSettings, error);
+                } else {
+                    callback(null, error);
+                }
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
###### Temporarily merging in to #195 to reduce files changed

+ Adds queries for PaymentSettings of a Store
+ Uses the country code from payment settings

#### Decisions made:
Since we need to fetch the payment settings of a store before we can perform a checkout, we fetch it only when it is needed instead of when the `Cart` is created. 

##### Cons
+ By doing this we have to pass in `PaymentSettings` through the methods in the INativePayment interface

##### Pros

+ Users who are already using the SDK don't have to make any changes
+ Users who don't need to support Apple Pay don't need to make the PaymentSettings query