### PR TITLE
[Fix] Moves reset logic into CartState

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -100,13 +100,10 @@ namespace <%= namespace %> {
         }
 
         /// <summary>
-        /// Resets the cart by removing all line items and resets all internal state. 
+        /// Resets the cart by removing all line items and resets all internal state.
         /// </summary>
         public void Reset() {
-            _LineItems = new CartLineItems(OnDeleteLineItem);
-            _UserErrors = null;
-            DeletedLineItems.Clear();
-            CurrentCheckout = null;
+            State.Reset();
         }
 
         public void GetWebCheckoutLink(GetWebCheckoutLinkSuccessCallback success, GetWebCheckoutLinkFailureCallback failure) {

--- a/scripts/generator/graphql_generator/csharp/CartState.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/CartState.cs.erb
@@ -46,6 +46,13 @@ namespace <%= namespace %> {
             _LineItems = new CartLineItems(OnDeleteLineItem);
         }
 
+        public void Reset() {
+            _LineItems = new CartLineItems(OnDeleteLineItem);
+            _UserErrors = null;
+            DeletedLineItems.Clear();
+            CurrentCheckout = null;
+        }
+
         public void SetShippingLine(string shippingRateHandle, CompletionCallback callback) {
             MutationQuery query = new MutationQuery();
 


### PR DESCRIPTION
Git didn't pick up the changes between CartState and the Reset patch so this resolves the compilation issue and moves the Reset method into CartState.