### PR TITLE
Added capabilites and default networks to PaymentSession

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift
@@ -55,7 +55,7 @@ class PaymentSessionTests: XCTestCase {
         XCTAssertEqual(session.request.supportedNetworks,    PaymentSession.supportedNetworks)
         XCTAssertEqual(session.request.paymentSummaryItems,  summaryItems)
         XCTAssertEqual(session.request.shippingMethods!,     shippingMethods)
-        XCTAssertEqual(session.request.merchantCapabilities, .capability3DS)
+        XCTAssertEqual(session.request.merchantCapabilities, PaymentSession.capabilities)
         XCTAssertEqual(session.request.requiredShippingAddressFields, .all)
         XCTAssertEqual(session.request.requiredBillingAddressFields,  .all)
         
@@ -68,7 +68,7 @@ class PaymentSessionTests: XCTestCase {
     //  MARK: - Supported Networks -
     //
     func testSupportedNetworks() {
-        XCTAssertEqual(PaymentSession.supportedNetworks, [.amex, .masterCard, .visa, .discover])
+        XCTAssertEqual(PaymentSession.supportedNetworks, [.amex, .masterCard, .visa])
     }
 
     // ----------------------------------

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -91,7 +91,7 @@ import PassKit
         request.currencyCode                  = currencyCode
         request.merchantIdentifier            = merchantId
         request.requiredBillingAddressFields  = .all
-        request.merchantCapabilities          = .capability3DS
+        request.merchantCapabilities          = PaymentSession.capabilities
         request.supportedNetworks             = PaymentSession.supportedNetworks
         request.requiredShippingAddressFields = requiringShippingAddressFields ?
             .all : PKAddressField.init(rawValue: PKAddressField.email.rawValue | PKAddressField.phone.rawValue)
@@ -122,16 +122,17 @@ import PassKit
 //
 extension PaymentSession {
     
-    static let supportedNetworks: [PKPaymentNetwork] = [.amex, .masterCard, .visa, .discover]
+    static let supportedNetworks: [PKPaymentNetwork] = [.amex, .masterCard, .visa]
+    static let capabilities: PKMerchantCapability    = [.capability3DS, .capabilityDebit, .capabilityCredit]
     
     static func canMakePayments() -> Bool {
         return PKPaymentAuthorizationViewController.canMakePayments() &&
-            PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks)
+            PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks, capabilities: capabilities)
     }
     
     static func canShowSetup() -> Bool {
         return PKPaymentAuthorizationViewController.canMakePayments() &&
-            !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks)
+            !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks, capabilities: capabilities)
     }
     
     static func showSetup() {


### PR DESCRIPTION
+ Sets the capabilities and networks that Shopify Pay uses, until we can fetch those from the Storefront API