### PR TITLE
[Fix] Added handling for single shipping rates

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/ApplePayFlowTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/ApplePayFlowTests.swift
@@ -74,8 +74,9 @@ class ApplePayFlowTests: XCTestCase {
         
         let expectation      = self.expectation(description: "MockAuthorizationController.invokeDidSelectShippingContact failed to complete")
         let expectedSubtotal = PKPaymentSummaryItem(label: "SUBTOTAL", amount: 25.47)
+        let expectedShipping = PKPaymentSummaryItem(label: "SHIPPING", amount: 8.44)
         let expectedTaxes    = PKPaymentSummaryItem(label: "TAXES",    amount: 2.93)
-        let expectedTotal    = PKPaymentSummaryItem(label: "TOTAL", amount: 25.47)
+        let expectedTotal    = PKPaymentSummaryItem(label: "TOTAL", amount: 33.91)
         
         let method = Tester.Method.checkout.rawValue
         let checkoutMessage = UnityMessage(content: "", object: Tester.name, method: method)
@@ -85,8 +86,9 @@ class ApplePayFlowTests: XCTestCase {
                 
                 XCTAssertEqual(status, PKPaymentAuthorizationStatus.success)
                 XCTAssertEqual(items[0], expectedSubtotal)
-                XCTAssertEqual(items[1], expectedTaxes)
-                XCTAssertEqual(items[2], expectedTotal)
+                XCTAssertEqual(items[1], expectedShipping)
+                XCTAssertEqual(items[2], expectedTaxes)
+                XCTAssertEqual(items[3], expectedTotal)
                 
                 XCTAssertEqual(methods[0], self.expeditedShippingMethod)
                 XCTAssertEqual(methods[1], self.xpressPostShippingMethod)

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -32,33 +32,48 @@ namespace <%= namespace %>.SDK.iOS {
             var contentDictionary = (Dictionary<string, object>)Json.Deserialize(message.Content);
             var mailingAddressInput = new MailingAddressInput(contentDictionary);
 
-            Action respondWithSuccess = () => {
-                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), GetShippingMethods()).ToJsonString());
-            };
-
-            Action<ShopifyError> respondToError = (ShopifyError error) => {
-                ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
-
-                // Check to see if this is a recoverable user error
-                if (error.Type == ShopifyError.ErrorType.UserError) {
-                    var userErrors = CartState.UserErrors;
-                    var status = GetAuthorizationStatusFromPreliminaryShippingUserErrors(userErrors);
-
-                    if (status == ApplePayAuthorizationStatus.InvalidShippingPostalAddress) {
-                        response = new ApplePayEventResponse(status, GetSummaryItems());
-                    }
-                }
-
-                message.Respond(response.ToJsonString());
-            };
-
             CartState.SetShippingAddress(mailingAddressInput, (ShopifyError error) => {
                 if (error == null) {
-                    respondWithSuccess();
+                    RespondToUpdateAddressSuccessForMessage(message);
                 } else {
-                    respondToError(error);
+                    RespondToUpdateAddressErrorForMessage(message, error);
                 }
             });
+        }
+
+        private void RespondToUpdateAddressSuccessForMessage(NativeMessage message) {
+            var shippingMethods = GetShippingMethods();
+
+            if (shippingMethods.Count == 1) {
+                // When there is one shipping method to select
+                // We must set it as the shipping line, as Apple Pay will not call
+                // The delegate method for selecting the only shipping method
+                CartState.SetShippingLine(shippingMethods[0].Identifier, (ShopifyError error) => {
+                    if (error == null) {
+                        message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), shippingMethods).ToJsonString());
+                    } else {
+                        message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure).ToJsonString());
+                    }
+                });
+            } else {
+                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), GetShippingMethods()).ToJsonString());
+            }
+        }
+
+        private void RespondToUpdateAddressErrorForMessage(NativeMessage message, ShopifyError error) {
+            ApplePayEventResponse response = new ApplePayEventResponse(ApplePayAuthorizationStatus.Failure);
+
+            // Check to see if this is a recoverable user error
+            if (error.Type == ShopifyError.ErrorType.UserError) {
+                var userErrors = CartState.UserErrors;
+                var status = GetAuthorizationStatusFromPreliminaryShippingUserErrors(userErrors);
+
+                if (status == ApplePayAuthorizationStatus.InvalidShippingPostalAddress) {
+                    response = new ApplePayEventResponse(status, GetSummaryItems());
+                }
+            }
+
+            message.Respond(response.ToJsonString());
         }
 
         public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs.erb
@@ -44,10 +44,8 @@ namespace <%= namespace %>.SDK.iOS {
         private void RespondToUpdateAddressSuccessForMessage(NativeMessage message) {
             var shippingMethods = GetShippingMethods();
 
-            if (shippingMethods.Count == 1) {
-                // When there is one shipping method to select
-                // We must set it as the shipping line, as Apple Pay will not call
-                // The delegate method for selecting the only shipping method
+            if (shippingMethods.Count > 0) {
+                // Set the first shipping method as the default
                 CartState.SetShippingLine(shippingMethods[0].Identifier, (ShopifyError error) => {
                     if (error == null) {
                         message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), shippingMethods).ToJsonString());
@@ -56,7 +54,7 @@ namespace <%= namespace %>.SDK.iOS {
                     }
                 });
             } else {
-                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), GetShippingMethods()).ToJsonString());
+                message.Respond(new ApplePayEventResponse(ApplePayAuthorizationStatus.Success, GetSummaryItems(), shippingMethods).ToJsonString());
             }
         }
 


### PR DESCRIPTION
+ Added check to see if there is one shipping method 
    + When there is one, update shipping lines immediately

##### Why?
+ When there is one shipping method, Apple does not call the delegate method for selecting a shipping line item.
+ Shopify Admin does not update the checkout query `Total`when there is only one shipping method, this seems like a bug.
    + You can checkout without selecting a shipping line item, and the total Shopify expects includes the single shipping cost when trying to complete a checkout

