### PR TITLE
[Feature] Adds caching for Shop's name whenever we fetch PaymentSettings

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -76,6 +76,7 @@ namespace <%= namespace %> {
         private IWebCheckout WebCheckout;
         private INativeCheckout NativeCheckout;
         private PaymentSettings StorePaymentSettings;
+        private String ShopName;
 
         private ShopifyClient Client;
 
@@ -175,11 +176,11 @@ namespace <%= namespace %> {
                 if (error != null) {
                     failure(error);
                 } else {
-                    GetPaymentSettings((paymentSettings, paymentSettingsError) => {
+                    GetPaymentSettingsAndShopName((paymentSettings, shopName, paymentSettingsError) => {
                         if (paymentSettingsError != null) {
                             failure(paymentSettingsError);
                         } else {
-                            NativeCheckout.Checkout(key, paymentSettings, success, cancelled, failure);
+                            NativeCheckout.Checkout(key, shopName, paymentSettings, success, cancelled, failure);
                         }
                     });
                 }
@@ -219,7 +220,7 @@ namespace <%= namespace %> {
         /// </param>
         public void CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
             if (NativeCheckout != null) {
-                GetPaymentSettings((paymentSettings, error) => {
+                GetPaymentSettingsAndShopName((paymentSettings, shopName, error) => {
                     if (error != null) {
                         callback(false);
                     } else {
@@ -231,20 +232,22 @@ namespace <%= namespace %> {
             }
         }
 
-        private void GetPaymentSettings(PaymentSettingsHandler callback) {
-            if (StorePaymentSettings != null) {
-                callback(StorePaymentSettings, null);
+        private void GetPaymentSettingsAndShopName(PaymentSettingsShopNameHandler callback) {
+            if (StorePaymentSettings != null && ShopName != null) {
+                callback(StorePaymentSettings, ShopName, null);
             } else {
                 var query = new QueryRootQuery();
                 DefaultQueries.shop.PaymentSettings(query);
+                DefaultQueries.shop.Name(query);
 
                 Client.Query(query, (response, error) => {
                     if (error != null) {
-                        callback(null, error);
+                        callback(null, null, error);
                     } else {
                         StorePaymentSettings = response.shop().paymentSettings();
+                        ShopName = response.shop().name();
 
-                        callback(StorePaymentSettings, null);
+                        callback(StorePaymentSettings, ShopName, null);
                     }
                 });
             }

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -29,6 +29,14 @@ namespace <%= namespace %> {
             ShippingAddress = shippingAddress;
         }
     }
+
+    /// <summary>
+    /// Data struct containing metadata associated with a Shop.
+    /// </summary>
+    public struct ShopMetadata {
+        public String Name;
+        public PaymentSettings PaymentSettings;
+    }
     
     /// <summary>
     /// Manages line items for an order. Can also be used to generate a web checkout link to check out in browser.
@@ -75,8 +83,7 @@ namespace <%= namespace %> {
 
         private IWebCheckout WebCheckout;
         private INativeCheckout NativeCheckout;
-        private PaymentSettings StorePaymentSettings;
-        private String ShopName;
+        private ShopMetadata? ShopMetadata;
 
         private ShopifyClient Client;
 
@@ -176,11 +183,11 @@ namespace <%= namespace %> {
                 if (error != null) {
                     failure(error);
                 } else {
-                    GetPaymentSettingsAndShopName((paymentSettings, shopName, paymentSettingsError) => {
-                        if (paymentSettingsError != null) {
-                            failure(paymentSettingsError);
+                    GetShopMetadata((metadata, metadataError) => {
+                        if (metadataError != null) {
+                            failure(metadataError);
                         } else {
-                            NativeCheckout.Checkout(key, shopName, paymentSettings, success, cancelled, failure);
+                            NativeCheckout.Checkout(key, metadata.Value.Name, metadata.Value.PaymentSettings, success, cancelled, failure);
                         }
                     });
                 }
@@ -220,11 +227,11 @@ namespace <%= namespace %> {
         /// </param>
         public void CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
             if (NativeCheckout != null) {
-                GetPaymentSettingsAndShopName((paymentSettings, shopName, error) => {
+                GetShopMetadata((metadata, error) => {
                     if (error != null) {
                         callback(false);
                     } else {
-                        callback(NativeCheckout.CanCheckout(paymentSettings));
+                        callback(NativeCheckout.CanCheckout(metadata.Value.PaymentSettings));
                     }
                 });
             } else {
@@ -232,9 +239,9 @@ namespace <%= namespace %> {
             }
         }
 
-        private void GetPaymentSettingsAndShopName(PaymentSettingsShopNameHandler callback) {
-            if (StorePaymentSettings != null && ShopName != null) {
-                callback(StorePaymentSettings, ShopName, null);
+        private void GetShopMetadata(ShopMetadataHandler callback) {
+            if (ShopMetadata != null) {
+                callback(ShopMetadata, null);
             } else {
                 var query = new QueryRootQuery();
                 DefaultQueries.shop.PaymentSettings(query);
@@ -242,12 +249,13 @@ namespace <%= namespace %> {
 
                 Client.Query(query, (response, error) => {
                     if (error != null) {
-                        callback(null, null, error);
+                        callback(null, error);
                     } else {
-                        StorePaymentSettings = response.shop().paymentSettings();
-                        ShopName = response.shop().name();
-
-                        callback(StorePaymentSettings, ShopName, null);
+                        var metadata = new ShopMetadata();
+                        metadata.PaymentSettings = response.shop().paymentSettings();
+                        metadata.Name = response.shop().name();
+                        ShopMetadata = metadata;
+                        callback(ShopMetadata, null);
                     }
                 });
             }

--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -187,7 +187,7 @@ namespace <%= namespace %> {
                         if (metadataError != null) {
                             failure(metadataError);
                         } else {
-                            NativeCheckout.Checkout(key, metadata.Value.Name, metadata.Value.PaymentSettings, success, cancelled, failure);
+                            NativeCheckout.Checkout(key, metadata.Value, success, cancelled, failure);
                         }
                     });
                 }

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultShopQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultShopQueries.cs.erb
@@ -15,5 +15,9 @@ namespace <%= namespace %>.SDK {
                 )
             );
         }
+
+        public void Name(QueryRootQuery query) {
+            query.shop(s => s.name());
+        }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -22,7 +22,7 @@ namespace <%= namespace %>.SDK {
     public delegate void QueryRootHandler(<%= schema.query_root_name %> queryRoot, ShopifyError error);
     public delegate void MutationRootHandler(<%= schema.mutation_root_name %> mutationRoot, ShopifyError error);
 
-    public delegate void PaymentSettingsHandler(PaymentSettings paymentSettings, ShopifyError error);
+    public delegate void PaymentSettingsShopNameHandler(PaymentSettings paymentSettings, string shopName, ShopifyError error);
 
     public delegate void OnCartLineItemChange();
 

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -22,7 +22,7 @@ namespace <%= namespace %>.SDK {
     public delegate void QueryRootHandler(<%= schema.query_root_name %> queryRoot, ShopifyError error);
     public delegate void MutationRootHandler(<%= schema.mutation_root_name %> mutationRoot, ShopifyError error);
 
-    public delegate void PaymentSettingsShopNameHandler(PaymentSettings paymentSettings, string shopName, ShopifyError error);
+    public delegate void ShopMetadataHandler(ShopMetadata? metadata, ShopifyError error);
 
     public delegate void OnCartLineItemChange();
 

--- a/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
@@ -15,9 +15,10 @@ namespace <%= namespace %>.SDK {
         /// Display the native payment sheet to perform a native payment
         /// </summary>
         /// <param name="key">The public key that is used for encrypting a native payment's token data</param>
+        /// <param name="shopMetadata">The shop's metadata containing name and payment settings</param>
         /// <param name="success">The closure that is invoked upon success of the payment</param>
         /// <param name="cancelled">The closure that is invoked upon cancellation of the payment</param>
         /// <param name="failure">The closure that is invoked upon failure of the payment</param>
-        void Checkout(string key, string shopName, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
+        void Checkout(string key, ShopMetadata shopMetadata, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
@@ -18,6 +18,6 @@ namespace <%= namespace %>.SDK {
         /// <param name="success">The closure that is invoked upon success of the payment</param>
         /// <param name="cancelled">The closure that is invoked upon cancellation of the payment</param>
         /// <param name="failure">The closure that is invoked upon failure of the payment</param>
-        void Checkout(string key, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
+        void Checkout(string key, string shopName, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -67,7 +67,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// <param name="success">Delegate method that will be notified upon a successful payment</param>
         /// <param name="failure">Delegate method that will be notified upon a failure during the checkout process</param>
         /// <param name="cancelled">Delegate method that will be notified upon a cancellation during the checkout process</param>
-        public void Checkout(string key, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
+        public void Checkout(string key, string shopName, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
             #if !SHOPIFY_MONO_UNIT_TEST
             OnSuccess = success;
             OnCancelled = cancelled;

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -64,10 +64,11 @@ namespace <%= namespace %>.SDK.iOS {
         ///  Displays a payment interface to the user based on the contents of the Cart
         /// </remarks>
         /// <param name="key">Merchant ID for Apple Pay from the Apple Developer Portal</param>
+        /// <param name="shopMetadata">The shop's metadata containing name and payment settings</param>
         /// <param name="success">Delegate method that will be notified upon a successful payment</param>
         /// <param name="failure">Delegate method that will be notified upon a failure during the checkout process</param>
         /// <param name="cancelled">Delegate method that will be notified upon a cancellation during the checkout process</param>
-        public void Checkout(string key, string shopName, PaymentSettings paymentSettings, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
+        public void Checkout(string key, ShopMetadata shopMetadata, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
             #if !SHOPIFY_MONO_UNIT_TEST
             OnSuccess = success;
             OnCancelled = cancelled;
@@ -78,7 +79,7 @@ namespace <%= namespace %>.SDK.iOS {
             var summaryItems = GetSummaryItems();
             var summaryString = Json.Serialize(summaryItems);
             var currencyCodeString = checkout.currencyCode().ToString("G");
-            var countryCodeString = paymentSettings.countryCode().ToString("G");
+            var countryCodeString = shopMetadata.PaymentSettings.countryCode().ToString("G");
             var requiresShipping = checkout.requiresShipping();
 
             if (ApplePayEventBridge == null) {


### PR DESCRIPTION
Android Pay requires a merchant name so this patch appends to the existing GraphQL query we're making to get the payment settings to get the shop name.