### PR TITLE
[Fix] Webcheckout mono tests

### DIFF
--- a/scripts/generator/graphql_generator/csharp/SDK/WebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/WebCheckout.cs.erb
@@ -11,10 +11,14 @@ namespace <%= namespace %>.SDK {
         public abstract void Checkout(string checkoutURL, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure);
 
         protected void SetupNativeMessageReceiver(CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
+
+            #if !SHOPIFY_MONO_UNIT_TEST
             if (_messageReceiver == null) {
                 _messageReceiver = GlobalGameObject.AddComponent<NativeWebViewMessageReceiver>();
             }
+
             _messageReceiver.Init(Client, Cart.CurrentCheckout, success, cancelled, failure);
+            #endif
         }
     }
 }


### PR DESCRIPTION
Adds compile flags that removes the warning for `GlobalGameObject` not being defined, since `GlobalGameObject` is only defined when compiling for non Mono test