### PR TITLE
[Fix] Check publish.sh build's return value

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -73,10 +73,12 @@ $UNITY_PATH \
     -exportPackage Assets/Shopify Assets/Plugins shopify-buy.unitypackage \
     -quit
 
+PUBLISH_SUCCESS=$?
+
 # restore files used for native extensions
 restore_native_tests
 
-if [ $? = 0 ] ; then
+if [[ $PUBLISH_SUCCESS = 0 ]] ; then
     # clean up examples.txt
     rm $PROJECT_ROOT/Assets/Shopify/examples.txt
 


### PR DESCRIPTION
+ Adds a variable that records the build return value
+ Changes the if statement to check for that value instead of the return value of `restore_native_tests`