### PR TITLE
[Fix] Publish removing android files

### DIFF
--- a/scripts/native_tests.sh
+++ b/scripts/native_tests.sh
@@ -8,5 +8,6 @@ delete_native_tests() {
 
 # will restore all delete files needed for testing native extenstions
 restore_native_tests() {
-    git checkout $PROJECT_ROOT/Assets/Plugins/
+    git checkout $PROJECT_ROOT/Assets/Plugins/iOS/Shopify/BuyTests*
+    git checkout $PROJECT_ROOT/Assets/Plugins/iOS/Shopify/Unity-iPhone-Tests-Bridging-Header.h*
 }


### PR DESCRIPTION
+ Only the files that were removed should be checked-out to avoid checking out other files that have changes. Useful for debugging.

+ Used `*` to handle `.meta` files