### PR TITLE
[Fix] Hide web checkout message receiver name

### DIFF
--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidWebCheckout.cs.erb
@@ -36,7 +36,8 @@ namespace <%= namespace %>.SDK.Android {
             #if !SHOPIFY_MONO_UNIT_TEST
             using(var webCheckoutSession = new AndroidJavaObject(WebCheckoutSessionClassName)) {
                 SetupNativeMessageReceiver(success, cancelled, failure);
-                webCheckoutSession.Call("checkout", checkoutURL);
+                object[] args = { GetNativeMessageReceiverName(), checkoutURL };
+                webCheckoutSession.Call("checkout", args);
             }
             #endif
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/WebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/WebCheckout.cs.erb
@@ -16,5 +16,11 @@ namespace <%= namespace %>.SDK {
             }
             _messageReceiver.Init(Client, Cart.CurrentCheckout, success, cancelled, failure);
         }
+
+        #if !SHOPIFY_MONO_UNIT_TEST
+        protected String GetNativeMessageReceiverName() {
+            return GlobalGameObject.Name;
+        }
+        #endif
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSWebCheckout.cs.erb
@@ -32,7 +32,7 @@ namespace <%= namespace %>.SDK.iOS {
         public override void Checkout(string checkoutURL, CheckoutSuccessCallback success, CheckoutCancelCallback cancelled, CheckoutFailureCallback failure) {
             #if !SHOPIFY_MONO_UNIT_TEST
             SetupNativeMessageReceiver(success, cancelled, failure);
-            _CheckoutWithWebView(GlobalGameObject.Name, checkoutURL);
+            _CheckoutWithWebView(GetNativeMessageReceiverName(), checkoutURL);
             #endif
         }
     }


### PR DESCRIPTION
+ Since implementations of `WebCheckout` are not the ones adding a `NativeMessageReceiver` it makes sense that they should not be the ones to dictate what the name of the receiver is