### PR TITLE
[Refactor] license scripts to fix lint issues and fixes #190

### DIFF
--- a/scripts/activate_license.sh
+++ b/scripts/activate_license.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
 
-. "$(dirname $0)/common.sh"
+. "$(dirname "$0")"/common.sh
+. "$(dirname "$0")"/has_license_credentials.sh
 
 UNITY_LICENSE_LOG_PATH="$PROJECT_ROOT"/license.log
 UNITY_LICENSE_PATH='/Library/Application Support/Unity/'
 
 which "$UNITY_PATH" &> /dev/null || die "Unity does not exist at $UNITY_PATH"
 
-# Activate license
-if [[ -n $UNITY_USERNAME && -n $UNITY_PASSWORD && -n $UNITY_SERIAL  ]] ; then
-    printf 'Unity acquiring %s license ...\n' "$UNITY_USERNAME"
+has_license_credentials || {
+    printf "Unity building with default license\n"
+    exit 0
+}
 
-    "$UNITY_PATH" \
-        -quit \
-        -batchmode \
-        -serial "$UNITY_SERIAL" \
-        -username "$UNITY_USERNAME" \
-        -password "$UNITY_PASSWORD" \
-        -logFile "$UNITY_LICENSE_LOG_PATH"
+printf 'Unity acquiring %s license ...\n' "$UNITY_USERNAME"
 
-    ACTIVATE_SUCCESS=$?
-    LICENSE_EXIST=$(ls -A "$UNITY_LICENSE_PATH")
+"$UNITY_PATH" \
+    -quit \
+    -batchmode \
+    -serial "$UNITY_SERIAL" \
+    -username "$UNITY_USERNAME" \
+    -password "$UNITY_PASSWORD" \
+    -logFile "$UNITY_LICENSE_LOG_PATH"
 
-    if [[ $ACTIVATE_SUCCESS = 0 && $LICENSE_EXIST ]] ; then
-        printf 'Acquired license\n'
-    else
-        printf '########## Failed to acquire license ##########\n'
-        cat "$UNITY_LICENSE_LOG_PATH"
-        exit 1
-    fi
+ACTIVATE_SUCCESS=$?
+LICENSE_EXIST=$(ls -A "$UNITY_LICENSE_PATH")
+
+if [[ $ACTIVATE_SUCCESS = 0 && $LICENSE_EXIST ]] ; then
+    printf 'Acquired license\n'
+    exit 0
 else
-    printf 'Unity building with default license'
+    printf '########## Failed to acquire license ##########\n'
+    cat "$UNITY_LICENSE_LOG_PATH"
+    exit 1
 fi
-
-exit 0

--- a/scripts/deactivate_license.sh
+++ b/scripts/deactivate_license.sh
@@ -1,30 +1,31 @@
 #!/bin/bash
 
-. "$(dirname $0)/common.sh"
+. "$(dirname "$0")"/common.sh
+. "$(dirname "$0")"/has_license_credentials.sh
 
 UNITY_LICENSE_LOG_PATH="$PROJECT_ROOT"/deactivate_license.log
 
 which "$UNITY_PATH" &> /dev/null || die "Unity does not exist at $UNITY_PATH"
 
-# Deactivate license
-if [[ -n "$UNITY_USERNAME" && -n "$UNITY_PASSWORD" && -n "$UNITY_SERIAL"  ]] ; then
-    printf 'Deactivating license ... \n'
+has_license_credentials || {
+    exit 0
+}
 
-    "$UNITY_PATH" \
-        -quit \
-        -batchmode \
-        -returnlicense \
-        -logFile "$UNITY_LICENSE_LOG_PATH"
+printf 'Deactivating license ... \n'
 
-    DEACTIVATE_SUCCESS=$?
+"$UNITY_PATH" \
+    -quit \
+    -batchmode \
+    -returnlicense \
+    -logFile "$UNITY_LICENSE_LOG_PATH"
 
-    if [[ $DEACTIVATE_SUCCESS = 0 ]] ; then
-        printf 'Deactivated license\n'
-    else
-        printf '########## Failed to deactivate license ##########\n'
-        cat "$UNITY_LICENSE_LOG_PATH"
-        exit 1
-    fi
+DEACTIVATE_SUCCESS=$?
+
+if [[ $DEACTIVATE_SUCCESS = 0 ]] ; then
+    printf 'Deactivated license\n'
+    exit 0
+else
+    printf '########## Failed to deactivate license ##########\n'
+    cat "$UNITY_LICENSE_LOG_PATH"
+    exit 1
 fi
-
-exit 0

--- a/scripts/has_license_credentials.sh
+++ b/scripts/has_license_credentials.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+has_license_credentials() {
+    if [[ -n $UNITY_USERNAME && -n $UNITY_PASSWORD && -n $UNITY_SERIAL  ]] ; then
+        return 0
+    else
+        return 1
+    fi
+}


### PR DESCRIPTION
+ Refactors the script to follow common practices
+ Resolves most of the lint errors thrown by `shellcheck`
+ Fixes #190, by moving license check to a function