### PR TITLE
[Fix] Use EditorWindow.GetWindowWithRect and specify minSize for popup

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
@@ -15,9 +15,11 @@ namespace <%= namespace %>.SDK {
 
         [MenuItem("Shopify/Help")]
         public static void ShowWindow() {
-            var window = EditorWindow.GetWindow<ShopifyOnboardingPanel>();
-            window.ShowPopup();
+            var window = EditorWindow.GetWindowWithRect<ShopifyOnboardingPanel>(
+                new Rect(0, 0, DesiredWindowWidth, DesiredWindowHeight)
+            );
 
+            window.ShowPopup();
             EditorPrefs.SetBool(HasSeenOnboardingPanelEditorPrefsKey, true);
         }
 
@@ -35,6 +37,7 @@ namespace <%= namespace %>.SDK {
         private const float AccentBarHeight = 5f;
 
         private void OnEnable() {
+            minSize = new Vector2(DesiredWindowWidth, DesiredWindowHeight);
             titleContent = new GUIContent("Unity Buy SDK");
             position = new Rect(position.xMin, position.yMin, DesiredWindowWidth, DesiredWindowHeight);
             Styles = new ShopifyEditorStyleHelper();


### PR DESCRIPTION
There was a bug where the window was showing up in the wrong size on
some machines. This specifies a rect size for the window in its spawning
function, and specifies a minimum size for the window so that it is not
resizable and contains all of the content at all times.

This is a bit of a yolofix because I was unable to reproduce the bug, but this approach has its own merits outside of fixing that bug specifically (unresizable window for example)