### PR TITLE
[Fix] Adds UNITY_IPHONE checks to build pipeline scripts

### DIFF
--- a/Assets/Editor/BuildPipeline/ShopifyBuildPipeline.cs
+++ b/Assets/Editor/BuildPipeline/ShopifyBuildPipeline.cs
@@ -28,11 +28,13 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         [MenuItem("Build/Build Shopify iOS Tests")]
         public static void BuildIosForTests()
         {
+            #if UNITY_IOS
             string path = PlayerPath;
             string[] scenes = {"Assets/Scenes/iOSTestScene.unity"};
             PlayerSettings.iOS.sdkVersion = iOSSdkVersion.SimulatorSDK;
             BuildPipeline.BuildPlayer(scenes, path, BuildTarget.iOS, BuildOptions.Development);
             iOSTestPostProcessor.ProcessForTests(path);
+            #endif
         }
 
         private static string PlayerPathFromArguments(string[] arguments) {

--- a/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
+++ b/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_IOS
 namespace Shopify.Unity.Editor.BuildPipeline {
     using UnityEngine;
     using UnityEditor;

--- a/Assets/UnityTestTools/NativeTesting/iOS/ApplePayEventTesterReceiver.cs
+++ b/Assets/UnityTestTools/NativeTesting/iOS/ApplePayEventTesterReceiver.cs
@@ -2,6 +2,7 @@
 namespace Shopify.Tests.iOS {
     using System.Collections;
     using System.Collections.Generic;
+    using Shopify.Unity.SDK;
     using Shopify.Unity.SDK.iOS;
 
     public class ApplePayEventTesterReceiver : IApplePayEventReceiver {

--- a/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/ExtendedPBXProject.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/ExtendedPBXProject.cs.erb
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_IOS
 namespace <%= namespace %>.Editor.BuildPipeline {
     using UnityEngine;
     using UnityEditor.iOS.Xcode;

--- a/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
@@ -7,6 +7,8 @@ namespace <%= namespace %>.Editor.BuildPipeline {
     using System.IO;
     using System;
 
+
+    #if UNITY_IOS
     /// <summary>
     /// Custom iOS build post processor that modifies the exported Xcode project to support the SDK.
     /// </summary>
@@ -68,5 +70,6 @@ namespace <%= namespace %>.Editor.BuildPipeline {
             }
         }
     }
+    #endif
 }
 #endif

--- a/scripts/test_iOS.sh
+++ b/scripts/test_iOS.sh
@@ -14,6 +14,7 @@ which "$UNITY_PATH" &> /dev/null || die "Unity does not exist at $UNITY_PATH"
     -silent-crashes \
     -logFile "$UNITY_IOS_LOG_PATH" \
     -projectPath "$PROJECT_ROOT" \
+    -buildTarget ios \
     -executeMethod Shopify.Unity.Editor.BuildPipeline.ShopifyBuildPipeline.BuildIosForTests \
     -buildPlayerPath "$IOS_BUILD_PATH" \
     -quit


### PR DESCRIPTION
On machines that don't support the iOS player (like Windows), the package won't compile because of errors with the iOS-only build pipeline scripts.