### PR TITLE
[Feature] Asset Store Build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,13 @@
 which ruby &> /dev/null || die "Ruby is not installed"
 which bundle &> /dev/null || die "Bundler is not installed"
 
+# default to github publish destination if none is provided
+if [ $# -eq 0 ] ; then
+    PUBLISH_DESTINATION=github
+else
+    PUBLISH_DESTINATION=$1
+fi
+
 start "generating GraphQL client"
-$SCRIPTS_ROOT/generate.sh || die "Could not generate Ruby client"
+$SCRIPTS_ROOT/generate.sh $PUBLISH_DESTINATION || die "Could not generate Ruby client"
 end "generating GraphQL client"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,10 +1,10 @@
 die() {
-    echo $@;
+    out $@;
     exit 1;
 }
 
 out() {
-    echo $@;
+    echo -e $@;
 }
 
 start() {

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,7 +1,7 @@
 . $(dirname $0)/common.sh
 
 bundle --gemfile=$SCRIPTS_ROOT/generator/Gemfile
-$SCRIPTS_ROOT/generator/update_schema
+$SCRIPTS_ROOT/generator/update_schema $1
 
 if [ $? = 0 ] ; then
     echo "Generate finished"

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -20,12 +20,17 @@ module GraphQLGenerator
       end
     end
 
-    attr_reader :scalars, :schema, :namespace, :version
+    attr_reader :scalars, :schema, :namespace, :version, :publish_destination
 
-    def initialize(schema, namespace:, custom_scalars: [], script_name: $0)
+    def initialize(schema, publish_destination, namespace:, custom_scalars: [], script_name: $0)
+      if publish_destination != "asset-store" && publish_destination != "github"
+        raise "publish_destination is invalid valid values are: asset-store or github"
+      end
+
       @schema = schema
       @namespace = namespace
       @script_name = script_name
+      @publish_destination = publish_destination
 
       @version = File.read(File.expand_path("../../../version", __FILE__)).strip
 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -24,7 +24,7 @@ module GraphQLGenerator
 
     def initialize(schema, publish_destination, namespace:, custom_scalars: [], script_name: $0)
       if publish_destination != "asset-store" && publish_destination != "github"
-        raise "publish_destination is invalid valid values are: asset-store or github"
+        raise "'publish_destination' is invalid. Valid values are: 'asset-store' or 'github'"
       end
 
       @schema = schema

--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
@@ -73,8 +73,9 @@ namespace <%= namespace %>.SDK {
                 Styles.BodyStyle
             );
 
-            if (GUILayout.Button("Start your free trial", Styles.ButtonStyle))
+            if (GUILayout.Button("Start your free trial", Styles.ButtonStyle)) {
                 Application.OpenURL("https://www.shopify.ca/signup?signup_types=unity_buy_sdk,<%= publish_destination %>");
+            }
             
             GUILayout.Label("Learn how to connect your game to your Shopify store", Styles.SubheadingStyle);
 

--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
@@ -74,7 +74,7 @@ namespace <%= namespace %>.SDK {
             );
 
             if (GUILayout.Button("Start your free trial", Styles.ButtonStyle)) {
-                Application.OpenURL("https://www.shopify.ca/signup?signup_types=unity_buy_sdk,<%= publish_destination %>");
+                Application.OpenURL("https://www.shopify.com/signup?signup_types=unity_buy_sdk,<%= publish_destination %>");
             }
             
             GUILayout.Label("Learn how to connect your game to your Shopify store", Styles.SubheadingStyle);

--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
@@ -74,8 +74,12 @@ namespace <%= namespace %>.SDK {
             );
 
             if (GUILayout.Button("Start your free trial", Styles.ButtonStyle))
-            Application.OpenURL("https://www.shopify.ca/signup");
+            <% if publish_destination == "asset-store" %>
 
+            <% else %>
+                Application.OpenURL("https://www.shopify.ca/signup");
+            <% end %>
+            
             GUILayout.Label("Learn how to connect your game to your Shopify store", Styles.SubheadingStyle);
 
             GUILayout.Label(

--- a/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/ShopifyOnboardingPanel.cs.erb
@@ -74,11 +74,7 @@ namespace <%= namespace %>.SDK {
             );
 
             if (GUILayout.Button("Start your free trial", Styles.ButtonStyle))
-            <% if publish_destination == "asset-store" %>
-
-            <% else %>
-                Application.OpenURL("https://www.shopify.ca/signup");
-            <% end %>
+                Application.OpenURL("https://www.shopify.ca/signup?signup_types=unity_buy_sdk,<%= publish_destination %>");
             
             GUILayout.Label("Learn how to connect your game to your Shopify store", Styles.SubheadingStyle);
 

--- a/scripts/generator/update_schema
+++ b/scripts/generator/update_schema
@@ -54,7 +54,11 @@ end
 schema = GraphQLSchema.new(JSON.parse(File.read(schema_filename)))
 script_name = "scripts/generator/update_schema"
 
-GraphQLGenerator::CSharp.new(schema,
+publish_destination = ARGV[0]
+
+GraphQLGenerator::CSharp.new(
+  schema,
+  publish_destination,
   namespace: 'Shopify.Unity',
   script_name: script_name,
   custom_scalars: [

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,6 +23,7 @@ VERSION=`cat $SCRIPTS_ROOT/version`
 
 VERSION_ARRAY=( ${VERSION//./ } )
 PUBLISH_DESTINATION=$2
+UNITY_PACKAGE=shopify-buy.unitypackage
 
 if [ $# -eq 0 ] ; then
     echo "If you'd like to bump versions pass: major, minor, or patch. Using $VERSION for now."
@@ -70,6 +71,12 @@ check "docs"
 # copy EXAMPLES.md to Assets/Shopify/examples.txt
 cp $PROJECT_ROOT/EXAMPLES.md $PROJECT_ROOT/Assets/Shopify/examples.txt
 
+if [ "$PUBLISH_DESTINATION" = "asset-store" ] ; then
+    UNITY_PACKAGE=shopify-buy-asset-store.unitypackage
+fi
+
+echo "Exporting the unitypackage at: $UNITY_PACKAGE"
+
 # create the new unitypackage
 $UNITY_PATH \
     -batchmode \
@@ -77,7 +84,7 @@ $UNITY_PATH \
     -silent-crashes \
     -logFile $UNITY_LOG_PATH \
     -projectPath $PROJECT_ROOT \
-    -exportPackage Assets/Shopify Assets/Plugins shopify-buy.unitypackage \
+    -exportPackage Assets/Shopify Assets/Plugins $UNITY_PACKAGE \
     -quit
 
 # restore files used for native extensions

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,6 +22,7 @@ delete_native_tests
 VERSION=`cat $SCRIPTS_ROOT/version`
 
 VERSION_ARRAY=( ${VERSION//./ } )
+PUBLISH_DESTINATION=$2
 
 if [ $# -eq 0 ] ; then
     echo "If you'd like to bump versions pass: major, minor, or patch. Using $VERSION for now."
@@ -34,9 +35,15 @@ elif [ $1 = "minor" ] ; then
     VERSION_ARRAY[2]=0
 elif [ $1 = "patch" ] ; then
     ((VERSION_ARRAY[2]++))
+elif [ $1 = "github" -o $1 = "asset-store" ] ; then
+    PUBLISH_DESTINATION=$1
 else
-    echo "Invalid version identifier: \"$1\". You must pass in either: major, minor, or patch"
+    echo -e "\nInvalid first parameter: \"$1\". You must pass in either a version bump param or a publish destination:\nmajor,\nminor,\npatch,\ngithub,\nasset-store"
     exit 1
+fi
+
+if [ "$PUBLISH_DESTINATION" != "github" ] && [ "$PUBLISH_DESTINATION" != "asset-store" ] ; then
+    die "\nInvalid publish target.\n\nPublish target should be:\n\"asset-store\"\n\"github\"\n\nExample: scripts/publish.sh github\n"
 fi
 
 VERSION="${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}.${VERSION_ARRAY[2]}"
@@ -45,7 +52,7 @@ echo $VERSION > $SCRIPTS_ROOT/version
 echo "Version used $1: $VERSION"
 
 # Run generate.sh to create source code including the potentially new version number
-$SCRIPTS_ROOT/generate.sh
+$SCRIPTS_ROOT/generate.sh $PUBLISH_DESTINATION
 check "generate"
 
 # Run tests just in case

--- a/scripts/test_watch.sh
+++ b/scripts/test_watch.sh
@@ -1,1 +1,1 @@
-nodemon --exec "scripts/build.sh && scripts/test.sh" -e .cs,.erb,.rb --ignore Assets/Shopify
+nodemon --exec "scripts/build.sh github && scripts/test.sh" -e .cs,.erb,.rb --ignore Assets/Shopify


### PR DESCRIPTION
This PR implements having the ability to generate different source for the Unity Buy SDK based on the distribution platform we hit. Mainly we do this for tracking purposes so we can see where signups come from. For instance the `ShopifyOnboardingPanel.cs` looks like this when distributing to Github:
```
if (GUILayout.Button("Start your free trial", Styles.ButtonStyle))
            Application.OpenURL("https://www.shopify.ca/signup?signup_types=unity_buy_sdk,github");
```
And for `asset-store`:
```
if (GUILayout.Button("Start your free trial", Styles.ButtonStyle))
            Application.OpenURL("https://www.shopify.ca/signup?signup_types=unity_buy_sdk,asset-store");
```