### PR TITLE
[Fix] Native checkout supported payment network

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -206,12 +206,21 @@ namespace <%= namespace %> {
         /// <summary>
         /// Determine whether the user can be shown to setup their native payment solution
         /// </summary>
-        /// <returns>True if the user can be shown a native payment setup</returns>
-        public bool CanShowNativePaySetup() {
+        /// <param name="callback">
+        /// Closure that is invoked with the result.
+        /// True is returned if the user can be shown a native payment app to setup their payment card
+        /// </param>
+        public void CanShowNativePaySetup(CanShowNativePaySetupCallback callback) {
             if (NativeCheckout != null) {
-                return  NativeCheckout.CanShowPaymentSetup();
+                GetShopMetadata((metadata, error) => {
+                    if (error != null) {
+                        callback(false);
+                    } else {
+                        callback(NativeCheckout.CanShowPaymentSetup(metadata.Value.PaymentSettings));
+                    }
+                });
             } else {
-                return false;
+                callback(false);
             }
         }
 

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -29,6 +29,7 @@ namespace <%= namespace %>.SDK {
     public delegate bool PollUpdatedHandler(QueryRoot updatedQueryRoot);
 
     public delegate void CanCheckoutWithNativePayCallback(bool canCheckout);
+    public delegate void CanShowNativePaySetupCallback(bool canShowPaymentSetup);
     public delegate void CheckoutSuccessCallback();
     public delegate void CheckoutFailureCallback(ShopifyError error);
     public delegate void CheckoutCancelCallback();

--- a/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/INativeCheckout.cs.erb
@@ -1,7 +1,17 @@
 namespace <%= namespace %>.SDK {
 
     interface INativeCheckout {
-        bool CanShowPaymentSetup();
+
+        /// <summary>
+        /// Check whether the device supports displaying a native wallet application to setup the user's payment card
+        /// </summary>
+        /// <param name="paymentSettings">The Shop's payment settings</param>
+        /// <returns>True if the device supports displaying a native wallet application</returns>
+        bool CanShowPaymentSetup(PaymentSettings paymentSettings);
+
+        /// <summary>
+        /// Invokes a native method that will prompt the user to setup the user's payment card via the native wallet application
+        /// </summary>
         void ShowPaymentSetup();
 
         /// <summary>

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -37,6 +37,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// <summary>
         /// Checks if the device is capable of paying with Apple Pay
         /// </summary>
+        /// <param name="paymentSettings">The Shop's payment settings</param>
         /// <returns>True if the device is capable of paying with Apple Pay</returns>
         public bool CanCheckout(PaymentSettings paymentSettings) {
             return _CanCheckoutWithApplePay();
@@ -45,8 +46,9 @@ namespace <%= namespace %>.SDK.iOS {
         /// <summary>
         /// Checks if the device is capable of setting up Apple Pay
         /// </summary>
+        /// <param name="paymentSettings">The Shop's payment settings</param>
         /// <returns>True if the device is capable of setting up Apple Pay </returns>
-        public bool CanShowPaymentSetup() {
+        public bool CanShowPaymentSetup(PaymentSettings paymentSettings) {
             return _CanShowApplePaySetup();
         }
 


### PR DESCRIPTION
+ Makes `canShowPaymentSetup` asynchronous because we need to fetch the shop's payment settings 