### PR TITLE
[Feature] Checkout with supported networks

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -47,8 +47,8 @@ class CartTests: XCTestCase {
         let serializedShippingMethod = String(data: shippingMethodData, encoding: .utf8)!
         
         // Put into an array of strings
-        let summaryItemsData    = try! JSONSerialization.data(withJSONObject: [serializedSummaryItem]);
-        let shippingMethodsData = try! JSONSerialization.data(withJSONObject: [serializedShippingMethod]);
+        let summaryItemsData    = try! JSONSerialization.data(withJSONObject: [serializedSummaryItem])
+        let shippingMethodsData = try! JSONSerialization.data(withJSONObject: [serializedShippingMethod])
         let serializedSummaryItems    = String(data: summaryItemsData,    encoding: .utf8)!.cString(using: .utf8)
         let serializedShippingMethods = String(data: shippingMethodsData, encoding: .utf8)!.cString(using: .utf8)
         

--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -43,23 +43,25 @@ class CartTests: XCTestCase {
         let shippingMethod      = Models.createShippingMethodJson(amount: shippingAmount, label: shippingLabel, identifier: identifier, detail: detail)
         let summaryItemData     = try! JSONSerialization.data(withJSONObject: summaryItem)
         let shippingMethodData  = try! JSONSerialization.data(withJSONObject: shippingMethod)
-        let serializedSummaryItem    = String.init(data: summaryItemData,    encoding: .utf8)!
-        let serializedShippingMethod = String.init(data: shippingMethodData, encoding: .utf8)!
+        let serializedSummaryItem    = String(data: summaryItemData,    encoding: .utf8)!
+        let serializedShippingMethod = String(data: shippingMethodData, encoding: .utf8)!
         
         // Put into an array of strings
         let summaryItemsData    = try! JSONSerialization.data(withJSONObject: [serializedSummaryItem]);
         let shippingMethodsData = try! JSONSerialization.data(withJSONObject: [serializedShippingMethod]);
-        let serializedSummaryItems    = String.init(data: summaryItemsData,    encoding: .utf8)!.cString(using: .utf8)
-        let serializedShippingMethods = String.init(data: shippingMethodsData, encoding: .utf8)!.cString(using: .utf8)
+        let serializedSummaryItems    = String(data: summaryItemsData,    encoding: .utf8)!.cString(using: .utf8)
+        let serializedShippingMethods = String(data: shippingMethodsData, encoding: .utf8)!.cString(using: .utf8)
         
         let merchantID        = "merchantID".cString(using: .utf8)
         let countryCode       = "US".cString(using: .utf8)
         let currencyCode      = "USD".cString(using: .utf8)
         let requiringShipping = true
         let unityObjectName   = "Tester".cString(using: .utf8)
+        
+        let supportedPaymentNetworks = Models.createSerializedPaymentNetworksString()
 
         XCTAssertNil(Cart.session)
-        _CreateApplePaySession(unityObjectName, merchantID, countryCode, currencyCode, serializedSummaryItems, serializedShippingMethods, requiringShipping)
+        _CreateApplePaySession(unityObjectName, merchantID, countryCode, currencyCode, supportedPaymentNetworks, serializedSummaryItems, serializedShippingMethods, requiringShipping)
         XCTAssertNotNil(Cart.session)
         
         let session = Cart.session!

--- a/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/CartTests.swift
@@ -74,5 +74,7 @@ class CartTests: XCTestCase {
         XCTAssertEqual(session.request.shippingMethods!.first!.amount,     NSDecimalNumber(string: shippingAmount))
         XCTAssertEqual(session.request.shippingMethods!.first!.identifier, identifier)
         XCTAssertEqual(session.request.shippingMethods!.first!.detail,     detail)
+        
+        XCTAssertEqual(session.request.supportedNetworks, Models.supportedPaymentNetworks)
     }
 }

--- a/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
@@ -47,6 +47,8 @@ struct Models {
     static let countryCode  = "US"
     static let currencyCode = "USD"
     
+    static let supportedPaymentNetworks: [PKPaymentNetwork] = [.amex, .visa, .masterCard]
+    
     // ----------------------------------
     //  MARK: - PersonNameComponents -
     //
@@ -179,6 +181,7 @@ struct Models {
                 countryCode: countryCode,
                 currencyCode: currencyCode,
                 requiringShippingAddressFields: requiringShippingAddressFields,
+                supportedNetworks: supportedPaymentNetworks,
                 summaryItems: createSummaryItems(),
                 shippingMethods: createShippingMethods(),
                 controllerType: controllerType)
@@ -188,9 +191,16 @@ struct Models {
                 countryCode: countryCode,
                 currencyCode: currencyCode,
                 requiringShippingAddressFields: requiringShippingAddressFields,
+                supportedNetworks: supportedPaymentNetworks,
                 summaryItems: createSummaryItems(),
                 shippingMethods: createShippingMethods())
         }
+    }
+    
+    static func createSerializedPaymentNetworksString() -> String {
+        let jsonData = try! JSONSerialization.data(withJSONObject: supportedPaymentNetworks)
+        let stringRepresentation = String(data: jsonData, encoding: .utf8)!
+        return stringRepresentation
     }
 }
 

--- a/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/PaymentSessionTests.swift
@@ -52,7 +52,7 @@ class PaymentSessionTests: XCTestCase {
         XCTAssertEqual(session.request.merchantIdentifier,   Models.merchantId)
         XCTAssertEqual(session.request.countryCode,          Models.countryCode)
         XCTAssertEqual(session.request.currencyCode,         Models.currencyCode)
-        XCTAssertEqual(session.request.supportedNetworks,    PaymentSession.supportedNetworks)
+        XCTAssertEqual(session.request.supportedNetworks,    Models.supportedPaymentNetworks)
         XCTAssertEqual(session.request.paymentSummaryItems,  summaryItems)
         XCTAssertEqual(session.request.shippingMethods!,     shippingMethods)
         XCTAssertEqual(session.request.merchantCapabilities, PaymentSession.capabilities)
@@ -64,13 +64,6 @@ class PaymentSessionTests: XCTestCase {
         XCTAssertEqual(noShippingSession.request.requiredShippingAddressFields, PKAddressField(rawValue: PKAddressField.email.rawValue | PKAddressField.phone.rawValue))
     }
     
-    // ----------------------------------
-    //  MARK: - Supported Networks -
-    //
-    func testSupportedNetworks() {
-        XCTAssertEqual(PaymentSession.supportedNetworks, [.amex, .masterCard, .visa])
-    }
-
     // ----------------------------------
     //  MARK: - Presenting and Dismissing -
     //

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.h
@@ -30,9 +30,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    bool _CreateApplePaySession(const char *unityDelegateObjectName, const char *merchantID, const char *countryCode, const char *currencyCode, const char *serializedSummaryItems, const char *serializedShippingMethods, bool requiringShipping);
-    bool _CanCheckoutWithApplePay();
-    bool _CanShowApplePaySetup();
+    bool _CreateApplePaySession(const char *unityDelegateObjectName, const char *merchantID, const char *countryCode, const char *currencyCode, const char *serializedPaymentNetworks, const char *serializedSummaryItems, const char *serializedShippingMethods, bool requiringShipping);
+    bool _CanCheckoutWithApplePay(const char *serializedSupportedNetworks);
+    bool _CanShowApplePaySetup(const char *serializedSupportedNetworks);
     void _ShowApplePaySetup();
     bool _PresentApplePayAuthorization();
 #ifdef __cplusplus

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.mm
@@ -30,19 +30,27 @@
 #import <SafariServices/SafariServices.h>
 #import "SwiftInterfaceHeader.h"
 
-bool _CanCheckoutWithApplePay() {
-    return [PaymentSession canMakePayments];
+bool _CanCheckoutWithApplePay(const char *serializedSupportedNetworks) {
+    return [Cart canMakePaymentsUsingSerializedNetworks:[NSString stringWithUTF8String:serializedSupportedNetworks]];
 }
 
-bool _CanShowApplePaySetup() {
-    return [PaymentSession canShowSetup];
+bool _CanShowApplePaySetup(const char *serializedSupportedNetworks) {
+    return [Cart canMakePaymentsUsingSerializedNetworks:[NSString stringWithUTF8String:serializedSupportedNetworks]];
 }
 
 void _ShowApplePaySetup() {
-    [PaymentSession showSetup];
+    [Cart showPaymentSetup];
 }
 
-bool _CreateApplePaySession(const char *unityDelegateObjectName, const char *merchantID, const char *countryCode, const char *currencyCode, const char *serializedSummaryItems, const char *serializedShippingMethods, bool requiringShipping) {
+bool _CreateApplePaySession(const char *unityDelegateObjectName,
+                            const char *merchantID,
+                            const char *countryCode,
+                            const char *currencyCode,
+                            const char *serializedSupportedNetworks,
+                            const char *serializedSummaryItems,
+                            const char *serializedShippingMethods,
+                            bool requiringShipping)
+{
 
     NSString *shippingMethodsString;
     if (serializedShippingMethods != nil) {
@@ -53,6 +61,7 @@ bool _CreateApplePaySession(const char *unityDelegateObjectName, const char *mer
                                                        merchantID:[NSString stringWithUTF8String:merchantID]
                                                       countryCode:[NSString stringWithUTF8String:countryCode]
                                                      currencyCode:[NSString stringWithUTF8String:currencyCode]
+                                      serializedSupportedNetworks:[NSString stringWithUTF8String:serializedSupportedNetworks]
                                            serializedSummaryItems:[NSString stringWithUTF8String:serializedSummaryItems]
                                         serializedShippingMethods:shippingMethodsString
                                                 requiringShipping:requiringShipping];

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -149,7 +149,7 @@ extension Cart {
         }
         
         return stringCollection.flatMap { string in
-            return PKPaymentNetwork.fromCardBrand(string)
+            return PKPaymentNetwork(string)
         }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -32,11 +32,12 @@ import PassKit
     private(set) static var session: PaymentSession?
     private static var dispatcher: ApplePayEventDispatcher?
     
-    static func createApplePaySession(unityDelegateObjectName: String, merchantID: String, countryCode: String, currencyCode: String, serializedSummaryItems: String, serializedShippingMethods: String?, requiringShipping: Bool) -> Bool {
+    static func createApplePaySession(unityDelegateObjectName: String, merchantID: String, countryCode: String, currencyCode: String, serializedSupportedNetworks: String, serializedSummaryItems: String, serializedShippingMethods: String?, requiringShipping: Bool) -> Bool {
         
         guard
-            let summaryItemsJson = extractItems(from: serializedSummaryItems),
-            let summaryItems     = PKPaymentSummaryItem.deserialize(summaryItemsJson)
+            let summaryItemsJson  = extractItems(from: serializedSummaryItems),
+            let summaryItems      = PKPaymentSummaryItem.deserialize(summaryItemsJson),
+            let supportedNetworks = supportedPaymentNetworks(from: serializedSupportedNetworks)
         else {
             return false
         }
@@ -60,6 +61,7 @@ import PassKit
                         countryCode: countryCode,
                         currencyCode: currencyCode,
                         requiringShippingAddressFields: requiringShipping,
+                        supportedNetworks: supportedNetworks,
                         summaryItems: summaryItems,
                         shippingMethods: shippingMethods)
         
@@ -76,14 +78,57 @@ import PassKit
         session.presentAuthorizationController()
         return true
     }
-    
-    private static func extractItems(from jsonString: String) -> [JSON]? {
+}
+
+
+//  ----------------------------------
+//  MARK: - Static PaymentSession helpers -
+//
+extension Cart {
+    public static func canMakePayments(usingSerializedNetworks networks: String) -> Bool {
         
-        guard
-            let data = jsonString.data(using: .utf8),
+        if let supportedNetworks = supportedPaymentNetworks(from: networks) {
+            return PaymentSession.canMakePayments(usingNetworks: supportedNetworks)
+        }
+        
+        return false
+    }
+    
+    public static func canShowSetup(forSerializedNetworks networks: String) -> Bool {
+        
+        if let supportedNetworks = supportedPaymentNetworks(from: networks) {
+            return PaymentSession.canShowSetup(forNetworks: supportedNetworks)
+        }
+        
+        return false
+    }
+    
+    public static func showPaymentSetup() {
+        PaymentSession.showSetup()
+    }
+}
+
+
+// ----------------------------------
+//  MARK: - String deserialization helpers -
+//
+extension Cart {
+    
+    fileprivate static func stringCollection(from jsonString: String) -> [String]? {
+        
+        if let data = jsonString.data(using: .utf8),
             let object = try? JSONSerialization.jsonObject(with: data),
-            let stringCollection = object as? [String]
-        else {
+            let stringCollection = object as? [String] {
+            return stringCollection
+        }
+        
+        return nil
+        
+    }
+    
+    fileprivate static func extractItems(from jsonString: String) -> [JSON]? {
+        
+        guard let stringCollection = stringCollection(from: jsonString) else {
             return nil
         }
         
@@ -95,6 +140,16 @@ import PassKit
             } else {
                 return nil
             }
+        }
+    }
+    
+    fileprivate static func supportedPaymentNetworks(from jsonString: String) -> [PKPaymentNetwork]? {
+        guard let stringCollection = stringCollection(from: jsonString) else {
+            return nil
+        }
+        
+        return stringCollection.flatMap { string in
+            return PKPaymentNetwork.fromCardBrand(string)
         }
     }
 }

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -84,7 +84,15 @@ import PassKit
     // ----------------------------------
     //  MARK: - Init -
     //
-    init(merchantId: String, countryCode: String, currencyCode: String, requiringShippingAddressFields: Bool, summaryItems: [PKPaymentSummaryItem], shippingMethods:[PKShippingMethod]?, controllerType: PaymentAuthorizationControlling.Type = PKPaymentAuthorizationViewController.self)
+    init(
+        merchantId: String,
+        countryCode: String,
+        currencyCode: String,
+        requiringShippingAddressFields: Bool,
+        supportedNetworks: [PKPaymentNetwork],
+        summaryItems: [PKPaymentSummaryItem],
+        shippingMethods:[PKShippingMethod]?,
+        controllerType: PaymentAuthorizationControlling.Type = PKPaymentAuthorizationViewController.self)
     {
         request = PKPaymentRequest.init()
         request.countryCode                   = countryCode
@@ -92,7 +100,7 @@ import PassKit
         request.merchantIdentifier            = merchantId
         request.requiredBillingAddressFields  = .all
         request.merchantCapabilities          = PaymentSession.capabilities
-        request.supportedNetworks             = PaymentSession.supportedNetworks
+        request.supportedNetworks             = supportedNetworks
         request.requiredShippingAddressFields = requiringShippingAddressFields ?
             .all : PKAddressField.init(rawValue: PKAddressField.email.rawValue | PKAddressField.phone.rawValue)
         
@@ -122,17 +130,16 @@ import PassKit
 //
 extension PaymentSession {
     
-    static let supportedNetworks: [PKPaymentNetwork] = [.amex, .masterCard, .visa]
-    static let capabilities: PKMerchantCapability    = [.capability3DS, .capabilityDebit, .capabilityCredit]
+    static let capabilities: PKMerchantCapability = [.capability3DS, .capabilityDebit, .capabilityCredit]
     
-    static func canMakePayments() -> Bool {
+    static func canMakePayments(usingNetworks networks: [PKPaymentNetwork]) -> Bool {
         return PKPaymentAuthorizationViewController.canMakePayments() &&
-            PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks, capabilities: capabilities)
+            PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: networks, capabilities: capabilities)
     }
     
-    static func canShowSetup() -> Bool {
+    static func canShowSetup(forNetworks networks: [PKPaymentNetwork]) -> Bool {
         return PKPaymentAuthorizationViewController.canMakePayments() &&
-            !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: PaymentSession.supportedNetworks, capabilities: capabilities)
+            !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: networks, capabilities: capabilities)
     }
     
     static func showSetup() {

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/iOSNativeCheckout.cs.erb
@@ -9,16 +9,24 @@ namespace <%= namespace %>.SDK.iOS {
 
     partial class iOSNativeCheckout : INativeCheckout {
         [DllImport ("__Internal")]
-        private static extern bool _CanCheckoutWithApplePay();
+        private static extern bool _CanCheckoutWithApplePay(string supportedPaymentNetworks);
 
         [DllImport ("__Internal")]
-        private static extern bool _CanShowApplePaySetup();
+        private static extern bool _CanShowApplePaySetup(string supportedPaymentNetworks);
 
         [DllImport ("__Internal")]
         private static extern void _ShowApplePaySetup();
 
         [DllImport ("__Internal")]
-        private static extern bool _CreateApplePaySession(string unityDelegateObjectName, string merchantID, string countryCode, string currencyCode, string serializedSummaryItems, string serializedShippingMethods, bool requiringShipping);
+        private static extern bool _CreateApplePaySession(
+            string unityDelegateObjectName,
+            string merchantID,
+            string countryCode,
+            string currencyCode,
+            string serializedSupportedNetworks,
+            string serializedSummaryItems,
+            string serializedShippingMethods,
+            bool requiringShipping);
 
         [DllImport ("__Internal")]
         private static extern void _PresentApplePayAuthorization();
@@ -40,7 +48,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// <param name="paymentSettings">The Shop's payment settings</param>
         /// <returns>True if the device is capable of paying with Apple Pay</returns>
         public bool CanCheckout(PaymentSettings paymentSettings) {
-            return _CanCheckoutWithApplePay();
+            return _CanCheckoutWithApplePay(SerializedPaymentNetworksFromCardBrands(paymentSettings.acceptedCardBrands()));
         }
 
         /// <summary>
@@ -49,7 +57,7 @@ namespace <%= namespace %>.SDK.iOS {
         /// <param name="paymentSettings">The Shop's payment settings</param>
         /// <returns>True if the device is capable of setting up Apple Pay </returns>
         public bool CanShowPaymentSetup(PaymentSettings paymentSettings) {
-            return _CanShowApplePaySetup();
+            return _CanShowApplePaySetup(SerializedPaymentNetworksFromCardBrands(paymentSettings.acceptedCardBrands()));
         }
 
         /// <summary>
@@ -78,10 +86,14 @@ namespace <%= namespace %>.SDK.iOS {
 
             var checkout = CartState.CurrentCheckout;
 
+            var supportedNetworksString = SerializedPaymentNetworksFromCardBrands(shopMetadata.PaymentSettings.acceptedCardBrands());
+
             var summaryItems = GetSummaryItemsFromCheckout(checkout);
             var summaryString = Json.Serialize(summaryItems);
+
             var currencyCodeString = checkout.currencyCode().ToString("G");
             var countryCodeString = shopMetadata.PaymentSettings.countryCode().ToString("G");
+
             var requiresShipping = checkout.requiresShipping();
 
             if (ApplePayEventBridge == null) {
@@ -89,7 +101,7 @@ namespace <%= namespace %>.SDK.iOS {
                 ApplePayEventBridge.Receiver = this;
             }
 
-            if (_CreateApplePaySession(GlobalGameObject.Name, key, countryCodeString, currencyCodeString, summaryString, null, requiresShipping)) {
+            if (_CreateApplePaySession(GlobalGameObject.Name, key, countryCodeString, currencyCodeString, supportedNetworksString, summaryString, null, requiresShipping)) {
                 _PresentApplePayAuthorization();
             } else {
                 var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create an Apple Pay payment request. Please check that your merchant ID is valid.");
@@ -129,6 +141,11 @@ namespace <%= namespace %>.SDK.iOS {
             }
 
             return shippingMethods;
+        }
+
+        private string SerializedPaymentNetworksFromCardBrands(List<CardBrand> cardBrands) {
+            var paymentNetworks = PaymentNetwork.NetworksFromCardBrands(cardBrands);
+            return Json.Serialize(paymentNetworks);
         }
     }
 }


### PR DESCRIPTION
+ Adds serialized supported payment networks as a parameter to the checkout related methods in iOS. 
+ Removes static supported payment networks in favour of the values passed through `PaymentSettings`