### PR TITLE
[Android Pay] Adds custom override on UnityPlayerActivity in order to forward onActivityResult to fragments

### DIFF
--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.shopify.unity.buy">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${applicationId}">
     <application android:label="@string/app_name" android:supportsRtl="true">
         <meta-data
             android:name="com.google.android.gms.wallet.api.enabled"

--- a/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Assets/Plugins/Android/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.shopify.unity.buy">
+    <application android:label="@string/app_name" android:supportsRtl="true">
+        <meta-data
+            android:name="com.google.android.gms.wallet.api.enabled"
+            android:value="true" />
+
+        <activity android:name="com.shopify.unity.buy.ShopifyUnityPlayerActivity"
+                  android:label="@string/app_name"
+                  android:configChanges="fontScale|keyboard|keyboardHidden|locale|mnc|mcc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|uiMode|touchscreen">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/Assets/Plugins/Android/AndroidManifest.xml.meta
+++ b/Assets/Plugins/Android/AndroidManifest.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c73ac4d4bf327433a95b7106171f5078
+timeCreated: 1502375678
+licenseType: Free
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/android/shopify_buy_plugin/src/main/AndroidManifest.xml
+++ b/android/shopify_buy_plugin/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="buy.unity.shopfiy.com.unitybuyplugin">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.shopify.unity.buy">
     <application android:label="@string/app_name" android:supportsRtl="true">
-        <meta-data
-            android:name="com.google.android.gms.wallet.api.enabled"
-            android:value="true" />
-
         <!-- Only used for instrument tests! -->
         <activity android:name="com.shopify.unity.buy.MockUnityActivity" />
-
     </application>
 </manifest>

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/AndroidPayCheckoutSession.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/AndroidPayCheckoutSession.java
@@ -14,7 +14,7 @@ import com.unity3d.player.UnityPlayer;
 import java.io.IOException;
 
 public final class AndroidPayCheckoutSession implements AndroidPaySessionCallback {
-    private static final String PAY_FRAGMENT_TAG = "payFragment";
+    public static final String PAY_FRAGMENT_TAG = "payFragment";
 
     private final Activity rootActivity;
     private String unityDelegateObjectName;

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/ShopifyUnityPlayerActivity.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/ShopifyUnityPlayerActivity.java
@@ -1,0 +1,21 @@
+package com.shopify.unity.buy;
+
+import android.app.Fragment;
+import android.content.Intent;
+
+import com.unity3d.player.UnityPlayerActivity;
+
+public class ShopifyUnityPlayerActivity extends UnityPlayerActivity {
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        // Android Pay has an issue where the results of the wallet chooser do not get forwarded to child fragments
+        // so we need to do this manually.
+        Fragment androidPayFragment = getFragmentManager().findFragmentByTag(AndroidPayCheckoutSession.PAY_FRAGMENT_TAG);
+        if (androidPayFragment != null) {
+            androidPayFragment.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+}


### PR DESCRIPTION
Adds a custom Activity override on UnityPlayerActivity to work around a bug with Android Pay where onActivityResult is not fired to child fragments when the wallet chooser is dismissed.