### PR TITLE
[Fix] Removes usage of handler/looper from MessageCenter

### DIFF
--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/UnityAndroidPayFragmentTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/UnityAndroidPayFragmentTest.java
@@ -133,7 +133,7 @@ public class UnityAndroidPayFragmentTest {
 
         fragment.onActivityResult(REQUEST_CODE_CHANGE_MASKED_WALLET, Activity.RESULT_OK, mockIntent);
         verify(mockCallbacks).onUpdateShippingAddress(mailingAddressEquals(expected),
-            any(MessageCenter.MessageCallbacks.class));
+            any(MessageCenter.MessageCallback.class));
     }
 
     @Test

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/AndroidPayCheckoutSession.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/AndroidPayCheckoutSession.java
@@ -111,13 +111,13 @@ public final class AndroidPayCheckoutSession implements AndroidPaySessionCallbac
             .commit();
     }
 
-    public void onUpdateShippingAddress(MailingAddressInput address, MessageCenter.MessageCallbacks messageCallbacks) {
+    public void onUpdateShippingAddress(MailingAddressInput address, MessageCenter.MessageCallback messageCallback) {
         UnityMessage msg = UnityMessage.fromAndroid(address.toJsonString());
         MessageCenter.UnityMessageReceiver receiver = new MessageCenter.UnityMessageReceiver(
             unityDelegateObjectName,
             MessageCenter.Method.ON_UPDATE_SHIPPING_ADDRESS
         );
-        MessageCenter.sendMessageTo(msg, receiver, messageCallbacks);
+        MessageCenter.sendMessageTo(msg, receiver, messageCallback);
     }
 
     public void onError(String error) {

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/AndroidPaySessionCallback.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/AndroidPaySessionCallback.java
@@ -8,5 +8,5 @@ interface AndroidPaySessionCallback {
 
     void onCancel();
 
-    void onUpdateShippingAddress(MailingAddressInput address, MessageCenter.MessageCallbacks messageCallbacks);
+    void onUpdateShippingAddress(MailingAddressInput address, MessageCenter.MessageCallback messageCallback);
 }

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MessageCenter.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MessageCenter.java
@@ -1,54 +1,33 @@
 package com.shopify.unity.buy;
 
-import android.os.Handler;
-import android.os.HandlerThread;
-
 import com.unity3d.player.UnityPlayer;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class MessageCenter {
-    private static final HandlerThread handlerThread = new HandlerThread("UnityMessageThread");
-    private static final Handler messageHandler = new Handler(handlerThread.getLooper());
-
     private static Map<String, MessageCallbacks> callbacksInWaiting = new HashMap<>();
 
     private MessageCenter() { }
 
     // Fire and forget sending of messages.
     static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver) {
-        messageHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
-            }
-        });
+        UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
     }
 
     // Send message with callbacks to invoke when complete.
     static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver, final MessageCallbacks callbacks) {
-        messageHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                callbacksInWaiting.put(msg.identifier, callbacks);
-                UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
-            }
-        });
+        callbacksInWaiting.put(msg.identifier, callbacks);
+        UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
     }
 
     @SuppressWarnings("unused")
     public static void onUnityResponse(final String result) {
-        messageHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                UnityMessage msg = UnityMessage.fromUnity(result);
-                MessageCallbacks callbacks = callbacksInWaiting.remove(msg.identifier);
-                if (callbacks != null) {
-                    callbacks.onResponse(msg.content);
-                }
-            }
-        });
+        UnityMessage msg = UnityMessage.fromUnity(result);
+        MessageCallbacks callbacks = callbacksInWaiting.remove(msg.identifier);
+        if (callbacks != null) {
+            callbacks.onResponse(msg.content);
+        }
     }
 
     static class UnityMessageReceiver {

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MessageCenter.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MessageCenter.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MessageCenter {
-    private static Map<String, MessageCallbacks> callbacksInWaiting = new HashMap<>();
+    private static Map<String, MessageCallback> callbacksInWaiting = new HashMap<>();
 
     private MessageCenter() { }
 
@@ -16,7 +16,7 @@ public class MessageCenter {
     }
 
     // Send message with callbacks to invoke when complete.
-    static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver, final MessageCallbacks callbacks) {
+    static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver, final MessageCallback callbacks) {
         callbacksInWaiting.put(msg.identifier, callbacks);
         UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
     }
@@ -24,7 +24,7 @@ public class MessageCenter {
     @SuppressWarnings("unused")
     public static void onUnityResponse(final String result) {
         UnityMessage msg = UnityMessage.fromUnity(result);
-        MessageCallbacks callbacks = callbacksInWaiting.remove(msg.identifier);
+        MessageCallback callbacks = callbacksInWaiting.remove(msg.identifier);
         if (callbacks != null) {
             callbacks.onResponse(msg.content);
         }
@@ -54,7 +54,7 @@ public class MessageCenter {
         }
     }
 
-    interface MessageCallbacks {
+    interface MessageCallback {
         void onResponse(String jsonResponse);
     }
 }

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/UnityAndroidPayFragment.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/UnityAndroidPayFragment.java
@@ -170,7 +170,7 @@ public class UnityAndroidPayFragment extends Fragment implements GoogleApiClient
                 MailingAddressInput input = new MailingAddressInput(maskedWallet.getBuyerShippingAddress());
 
                 if (sessionCallbacks != null) {
-                    sessionCallbacks.onUpdateShippingAddress(input, new MessageCenter.MessageCallbacks() {
+                    sessionCallbacks.onUpdateShippingAddress(input, new MessageCenter.MessageCallback() {
                         @Override
                         public void onResponse(String jsonResponse) {
                             // TODO: Create a new pay cart with the updated shipping address and request full wallet


### PR DESCRIPTION
Calling the message sender caushes a crash on the Android side and after giving it some thought realized that we don't actually need it at all. We can simply call the Unity send message commands. So I did just that.