### PR TITLE
[Refactor] Splits NativeMessage into Android/iOS parts

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -138,6 +138,7 @@ module GraphQLGenerator
         SDK/Android/AndroidPayEventReceiverBridge
         SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver
         SDK/Android/IAndroidPayEventReceiver
+        SDK/Android/NativeMessage.Android
         SDK/iOS/ApplePayAuthorizationStatus
         SDK/iOS/IApplePayEventReceiver
         SDK/iOS/ApplePayEventReceiverBridge
@@ -149,6 +150,7 @@ module GraphQLGenerator
         SDK/iOS/ApplePayContactInvalidError
         SDK/iOS/ApplePayShippingAddressUnservicableError
         SDK/iOS/ShippingMethod
+        SDK/iOS/NativeMessage.iOS
         SDK/iOS/PaymentNetwork
         SDK/iOS/iOSWebCheckout
         SDK/iOS/iOSNativeCheckout

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver.cs.erb
@@ -6,7 +6,9 @@ namespace <%= namespace %>.SDK.Android {
     using <%= namespace %>.SDK;
     using <%= namespace %>.MiniJSON;
 
+    #if !SHOPIFY_MONO_UNIT_TEST
     using UnityEngine;
+    #endif
 
     public partial class AndroidNativeCheckout : IAndroidPayEventReceiver {
         public void OnUpdateShippingAddress(string serializedMessage) {

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
@@ -9,7 +9,7 @@ namespace <%= namespace %>.SDK {
     #endif
 
     public partial class NativeMessage {
-        private AndroidJavaObject MessageCenter;
+        private static AndroidJavaObject MessageCenter;
 
         private static void _RespondToNativeMessage(string identifier, string message) {
             #if !SHOPIFY_MONO_UNIT_TEST

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
@@ -9,7 +9,9 @@ namespace <%= namespace %>.SDK {
     #endif
 
     public partial class NativeMessage {
+        #if !SHOPIFY_MONO_UNIT_TEST
         private static AndroidJavaObject MessageCenter;
+        #endif
 
         private static void _RespondToNativeMessage(string identifier, string message) {
             #if !SHOPIFY_MONO_UNIT_TEST

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
@@ -2,7 +2,6 @@
 namespace <%= namespace %>.SDK {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.InteropServices;
     using <%= namespace %>.MiniJSON;
 
     #if !SHOPIFY_MONO_UNIT_TEST
@@ -10,11 +9,14 @@ namespace <%= namespace %>.SDK {
     #endif
 
     public partial class NativeMessage {
+        private AndroidJavaObject MessageCenter;
+
         private static void _RespondToNativeMessage(string identifier, string message) {
             #if !SHOPIFY_MONO_UNIT_TEST
-            using (var messageCenter = new AndroidJavaObject("com.shopify.unity.buy.MessageCenter")) {
-                messageCenter.CallStatic("onUnityResponse", identifier, message);
+            if (MessageCenter == null) {
+                MessageCenter = new AndroidJavaObject("com.shopify.unity.buy.MessageCenter");
             }
+            MessageCenter.CallStatic("onUnityResponse", identifier, message);
             #endif
         }
     }

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/NativeMessage.Android.cs.erb
@@ -1,0 +1,22 @@
+#if UNITY_ANDROID
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.InteropServices;
+    using <%= namespace %>.MiniJSON;
+
+    #if !SHOPIFY_MONO_UNIT_TEST
+    using UnityEngine;
+    #endif
+
+    public partial class NativeMessage {
+        private static void _RespondToNativeMessage(string identifier, string message) {
+            #if !SHOPIFY_MONO_UNIT_TEST
+            using (var messageCenter = new AndroidJavaObject("com.shopify.unity.buy.MessageCenter")) {
+                messageCenter.CallStatic("onUnityResponse", identifier, message);
+            }
+            #endif
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/NativeMessage.cs.erb
@@ -4,11 +4,7 @@ namespace <%= namespace %>.SDK {
     using System.Runtime.InteropServices;
     using <%= namespace %>.MiniJSON;
 
-    public class NativeMessage {
-
-        [DllImport ("__Internal")]
-        private static extern void _RespondToNativeMessage(string identifier, string message);
-
+    public partial class NativeMessage {
         public string Identifier;
         public string Content;
 
@@ -23,7 +19,7 @@ namespace <%= namespace %>.SDK {
         }
 
         public void Respond(string message) {
-            #if !SHOPIFY_MONO_UNIT_TEST
+            #if !SHOPIFY_MONO_UNIT_TEST && (UNITY_IOS || UNITY_ANDROID)
             _RespondToNativeMessage(Identifier, message);
             #endif
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/NativeMessage.iOS.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/NativeMessage.iOS.cs.erb
@@ -1,0 +1,13 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK {
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.InteropServices;
+    using <%= namespace %>.MiniJSON;
+
+    public partial class NativeMessage {
+        [DllImport ("__Internal")]
+        private static extern void _RespondToNativeMessage(string identifier, string message);
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/NativeMessage.iOS.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/NativeMessage.iOS.cs.erb
@@ -3,7 +3,6 @@ namespace <%= namespace %>.SDK {
     using System;
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
-    using <%= namespace %>.MiniJSON;
 
     public partial class NativeMessage {
         [DllImport ("__Internal")]


### PR DESCRIPTION
Splits up NativeMessage into platform-dependent partial classes so we can use the same logic for Android message handling.