### PR TITLE
[Android Pay] Adds interface for bridging calls between Android and Unity 

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -134,6 +134,10 @@ module GraphQLGenerator
         SDK/WebCheckout
         SDK/NativeWebViewMessageReceiver
         SDK/Android/AndroidWebCheckout
+        SDK/Android/AndroidNativeCheckout
+        SDK/Android/AndroidPayEventReceiverBridge
+        SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver
+        SDK/Android/IAndroidPayEventReceiver
         SDK/iOS/ApplePayAuthorizationStatus
         SDK/iOS/IApplePayEventReceiver
         SDK/iOS/ApplePayEventReceiverBridge
@@ -144,7 +148,6 @@ module GraphQLGenerator
         SDK/iOS/iOSNativeCheckout
         SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver
         SDK/iOS/ApplePayPayment
-        SDK/Android/AndroidNativeCheckout
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver.cs.erb
@@ -1,0 +1,26 @@
+#if UNITY_ANDROID
+namespace <%= namespace %>.SDK.Android {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Runtime.InteropServices;
+    using <%= namespace %>.SDK;
+    using <%= namespace %>.MiniJSON;
+
+    using UnityEngine;
+
+    public partial class AndroidNativeCheckout : IAndroidPayEventReceiver {
+        public void OnUpdateShippingAddress(string serializedMessage) {
+        }
+
+        public void OnUpdateShippingLine(string serializedMessage) {
+        }
+
+        public void OnError(string serializedMessage) {
+        }
+
+        public void OnCancel(string serializedMessage) {
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.AndroidPayEventReceiver.cs.erb
@@ -3,7 +3,6 @@ namespace <%= namespace %>.SDK.Android {
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Runtime.InteropServices;
     using <%= namespace %>.SDK;
     using <%= namespace %>.MiniJSON;
 

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
@@ -62,8 +62,10 @@ namespace <%= namespace %>.SDK.Android {
             using (var androidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.AndroidPayCheckoutSession")) {
                 object[] args = { GlobalGameObject.Name, merchantName, key, pricingLineItemsString, currencyCodeString, countryCodeString, requiresShipping, true };
                 if (androidPayCheckoutSession.Call<bool>("checkoutWithAndroidPay", args)) {
-                    AndroidPayEventBridge = GlobalGameObject.AddComponent<AndroidPayEventReceiverBridge>();
-                    AndroidPayEventBridge.Receiver = this;
+                    if (AndroidPayEventBridge == null) {
+                        AndroidPayEventBridge = GlobalGameObject.AddComponent<AndroidPayEventReceiverBridge>();
+                        AndroidPayEventBridge.Receiver = this;
+                    }
                 } else {
                     // TODO: Create more meaningful error?
                     var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create Android Pay session.");

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
@@ -11,9 +11,10 @@ namespace <%= namespace %>.SDK.Android {
     using UnityEngine;
     #endif
 
-    public class AndroidNativeCheckout : INativeCheckout {
+    public partial class AndroidNativeCheckout : INativeCheckout {
         private CartState CartState;
         private AndroidJavaObject AndroidPayCheckoutSession;
+        private AndroidPayEventReceiverBridge AndroidPayEventBridge;
 
         private CheckoutSuccessCallback OnSuccess;
         private CheckoutCancelCallback OnCancelled;
@@ -23,7 +24,7 @@ namespace <%= namespace %>.SDK.Android {
             CartState = cartState;
         }
 
-        public bool CanShowPaymentSetup() {
+        public bool CanShowPaymentSetup(PaymentSettings paymentSettings) {
             // TODO
             return true;
         }
@@ -60,16 +61,15 @@ namespace <%= namespace %>.SDK.Android {
             var requiresShipping = checkout.requiresShipping();
 
             #if !SHOPIFY_MONO_UNIT_TEST
-            using (var androidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.AndroidPayCheckoutSession")) {
-                // TODO: Replace with mono object for receiving callbacks with.
-                object[] args = { "testing", merchantName, key, pricingLineItemsString, currencyCodeString, countryCodeString, requiresShipping };
-                if (androidPayCheckoutSession.Call<bool>("checkoutWithAndroidPay", args)) {
-                    // TODO: Do I need to do anything on the Unity side after we've created the session
-                } else {
-                    // TODO: Create more meaningful error?
-                    var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create Android Pay session.");
-                    OnFailure(error);
-                }
+            AndroidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.AndroidPayCheckoutSession");
+            object[] args = { GlobalGameObject.Name, merchantName, key, pricingLineItemsString, currencyCodeString, countryCodeString, requiresShipping, true };
+            if (AndroidPayCheckoutSession.Call<bool>("checkoutWithAndroidPay", args)) {
+                AndroidPayEventBridge = GlobalGameObject.AddComponent<AndroidPayEventReceiverBridge>();
+                AndroidPayEventBridge.Receiver = this;
+            } else {
+                // TODO: Create more meaningful error?
+                var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create Android Pay session.");
+                OnFailure(error);
             }
             #endif
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
@@ -13,7 +13,6 @@ namespace <%= namespace %>.SDK.Android {
 
     public partial class AndroidNativeCheckout : INativeCheckout {
         private CartState CartState;
-        private AndroidJavaObject AndroidPayCheckoutSession;
         private AndroidPayEventReceiverBridge AndroidPayEventBridge;
 
         private CheckoutSuccessCallback OnSuccess;
@@ -25,8 +24,7 @@ namespace <%= namespace %>.SDK.Android {
         }
 
         public bool CanShowPaymentSetup(PaymentSettings paymentSettings) {
-            // TODO
-            return true;
+            return false;
         }
 
         public void ShowPaymentSetup() {
@@ -61,15 +59,16 @@ namespace <%= namespace %>.SDK.Android {
             var requiresShipping = checkout.requiresShipping();
 
             #if !SHOPIFY_MONO_UNIT_TEST
-            AndroidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.AndroidPayCheckoutSession");
-            object[] args = { GlobalGameObject.Name, merchantName, key, pricingLineItemsString, currencyCodeString, countryCodeString, requiresShipping, true };
-            if (AndroidPayCheckoutSession.Call<bool>("checkoutWithAndroidPay", args)) {
-                AndroidPayEventBridge = GlobalGameObject.AddComponent<AndroidPayEventReceiverBridge>();
-                AndroidPayEventBridge.Receiver = this;
-            } else {
-                // TODO: Create more meaningful error?
-                var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create Android Pay session.");
-                OnFailure(error);
+            using (var androidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.AndroidPayCheckoutSession")) {
+                object[] args = { GlobalGameObject.Name, merchantName, key, pricingLineItemsString, currencyCodeString, countryCodeString, requiresShipping, true };
+                if (androidPayCheckoutSession.Call<bool>("checkoutWithAndroidPay", args)) {
+                    AndroidPayEventBridge = GlobalGameObject.AddComponent<AndroidPayEventReceiverBridge>();
+                    AndroidPayEventBridge.Receiver = this;
+                } else {
+                    // TODO: Create more meaningful error?
+                    var error = new ShopifyError(ShopifyError.ErrorType.NativePaymentProcessingError, "Unable to create Android Pay session.");
+                    OnFailure(error);
+                }
             }
             #endif
         }

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidPayEventReceiverBridge.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidPayEventReceiverBridge.cs.erb
@@ -1,0 +1,31 @@
+#if UNITY_ANDROID
+namespace <%= namespace %>.SDK.Android {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    #if !SHOPIFY_MONO_UNIT_TEST
+    using UnityEngine;
+    public partial class AndroidPayEventReceiverBridge : MonoBehaviour {}
+    #endif
+
+    public partial class AndroidPayEventReceiverBridge : IAndroidPayEventReceiver { 
+        public IAndroidPayEventReceiver Receiver;
+
+        public void OnUpdateShippingAddress(string serializedMessage) {
+            Receiver.OnUpdateShippingAddress(serializedMessage);
+        }
+
+        public void OnUpdateShippingLine(string serializedMessage) {
+            Receiver.OnUpdateShippingAddress(serializedMessage);
+        }
+
+        public void OnError(string serializedMessage ) {
+            Receiver.OnError(serializedMessage);
+        }
+
+        public void OnCancel(string serializedMessage) {
+            Receiver.OnCancel(serializedMessage);
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/IAndroidPayEventReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/IAndroidPayEventReceiver.cs.erb
@@ -1,0 +1,14 @@
+
+#if UNITY_ANDROID
+namespace <%= namespace %>.SDK.Android {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public interface IAndroidPayEventReceiver {
+        void OnUpdateShippingAddress(string serializedMessage);
+        void OnUpdateShippingLine(string serializedMessage);
+        void OnError(string serializedMessage);
+        void OnCancel(string serializedMessage);
+    }
+}
+#endif


### PR DESCRIPTION
Mirrors the same technique we used for passing messages from iOS to Unity but for Android. Stubbed out the receiver calls in the partial extension off of AndroidNativeCheckout.