### PR TITLE
[Cleanup] Adds instrument test for web intent listener

### DIFF
--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/WebIntentFragmentTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/WebIntentFragmentTest.java
@@ -1,0 +1,40 @@
+package com.shopify.unity.buy;
+
+import android.support.test.filters.MediumTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@MediumTest
+@RunWith(AndroidJUnit4.class)
+public class WebIntentFragmentTest implements WebIntentListener {
+
+    @Rule
+    public ActivityTestRule<MockUnityActivity> rule =
+        new ActivityTestRule<>(MockUnityActivity.class);
+
+    private boolean hasClosed = false;
+
+    @Test
+    public void testListener() {
+        WebIntentFragment webFragment = WebIntentFragment.newInstance("http://shopify.com");
+        webFragment.setListener(this);
+        rule.getActivity().getFragmentManager().beginTransaction().add(webFragment, "").commit();
+        assertFalse(hasClosed);
+
+        webFragment.onPause();
+        webFragment.onResume();
+        assertTrue(hasClosed);
+    }
+
+    @Override
+    public void onWebIntentClose() {
+        hasClosed = true;
+    }
+}

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/WebIntentFragment.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/WebIntentFragment.java
@@ -28,7 +28,7 @@ public final class WebIntentFragment extends Fragment {
         if (url != null) {
             CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
             CustomTabsIntent customTabsIntent = builder.build();
-            customTabsIntent.launchUrl(getActivity().getApplicationContext(), Uri.parse(url));
+            customTabsIntent.launchUrl(getActivity(), Uri.parse(url));
         }
     }
 


### PR DESCRIPTION
Converts the old web intent test from using roboelectric to using the instrument integration test on device.