### PR TITLE
[Fix] Android Gradle copy order

### DIFF
--- a/android/shopify_buy_plugin/build.gradle
+++ b/android/shopify_buy_plugin/build.gradle
@@ -56,6 +56,8 @@ task assembleUnity {
     dependsOn 'assembleRelease', 'copyAARToPlugins'
 }
 
+copyAARToPlugins.mustRunAfter('assembleRelease')
+
 task checkstyle(type: Checkstyle) {
     configFile = new File(rootDir, "checkstyle/config.xml")
     configProperties.checkstyleSuppressionsPath = new File(rootDir, "checkstyle/suppressions.xml")

--- a/android/shopify_buy_plugin/build.gradle
+++ b/android/shopify_buy_plugin/build.gradle
@@ -42,14 +42,14 @@ dependencies {
     testCompile 'org.json:json:20140107'
 }
 
-task copyAARToPlugins {
-    copy {
-        from('build/outputs/aar') {
-            rename "shopify_buy_plugin-release.aar", "shopify_buy_plugin.aar"
-            exclude '*-debug.aar'
-        }
-        into '../../Assets/Plugins/Android'
+task copyAARToPlugins(type: Copy) {
+
+    from('build/outputs/aar') {
+        rename "shopify_buy_plugin-release.aar", "shopify_buy_plugin.aar"
+        exclude '*-debug.aar'
     }
+    into '../../Assets/Plugins/Android'
+
     outputs.upToDateWhen { false }
 }
 

--- a/android/shopify_buy_plugin/build.gradle
+++ b/android/shopify_buy_plugin/build.gradle
@@ -50,6 +50,7 @@ task copyAARToPlugins {
         }
         into '../../Assets/Plugins/Android'
     }
+    outputs.upToDateWhen { false }
 }
 
 task assembleUnity {


### PR DESCRIPTION
+ copyAARToPlugins does not run every time or run in order sometimes. Adding these flags ensures that it is never `UP-TO-DATE` and runs after compiling