### PR TITLE
[Feature] Adds classes in Unity to represent Apple Pay Errors

### DIFF
--- a/Assets/Editor/iOS/TestApplePayError.cs
+++ b/Assets/Editor/iOS/TestApplePayError.cs
@@ -1,0 +1,99 @@
+#if UNITY_IOS
+namespace Shopify.Tests {
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using Shopify.Unity.SDK.iOS;
+    using Shopify.Unity.MiniJSON;
+
+    [TestFixture]
+    public class TestApplePayErrorSerialization {
+
+        [Test]
+        public void TestErrorSerialization() {
+
+            var expectedDescription = "test";
+            var expectedType = ApplePayError.ErrorType.ShippingAddressUnservicable;
+
+            var applePayError = new ApplePayError(expectedType, expectedDescription);
+            var serialized = (Dictionary<string, object>) applePayError.ToJson();
+
+            Assert.AreEqual(serialized["Type"], expectedType);
+            Assert.AreEqual(serialized["Description"], expectedDescription);
+        }
+
+        [Test]
+        public void TestAddressInvalidErrorSerialization() {
+
+            var expectedDescription = "test";
+            var expectedType = ApplePayError.ErrorType.PaymentShippingAddress;
+            var expectedField = ApplePayAddressInvalidError.AddressField.City;
+
+            var applePayError = new ApplePayAddressInvalidError(expectedType, expectedDescription, expectedField);
+            var serialized = (Dictionary<string, object>) applePayError.ToJson();
+
+            Assert.AreEqual(serialized["Type"], expectedType);
+            Assert.AreEqual(serialized["Description"], expectedDescription);
+            Assert.AreEqual(serialized["Field"], expectedField);
+        }
+
+        [Test]
+        public void TestShippingAddressInvalidErrorSerialization() {
+
+            var expectedDescription = "test";
+            var expectedType = ApplePayError.ErrorType.PaymentShippingAddress;
+            var expectedField = ApplePayAddressInvalidError.AddressField.City;
+
+            var applePayError = new ApplePayShippingAddressInvalidError(expectedDescription, expectedField);
+            var serialized = (Dictionary<string, object>) applePayError.ToJson();
+
+            Assert.AreEqual(serialized["Type"], expectedType);
+            Assert.AreEqual(serialized["Description"], expectedDescription);
+            Assert.AreEqual(serialized["Field"], expectedField);
+        }
+
+        [Test]
+        public void TestBillingAddressInvalidErrorSerialization() {
+
+            var expectedDescription = "test";
+            var expectedType = ApplePayError.ErrorType.PaymentBillingAddress;
+            var expectedField = ApplePayAddressInvalidError.AddressField.City;
+
+            var applePayError = new ApplePayBillingAddressInvalidError(expectedDescription, expectedField);
+            var serialized = (Dictionary<string, object>) applePayError.ToJson();
+
+            Assert.AreEqual(serialized["Type"], expectedType);
+            Assert.AreEqual(serialized["Description"], expectedDescription);
+            Assert.AreEqual(serialized["Field"], expectedField);
+        }
+
+        [Test]
+        public void TestContactInvalidErrorSerialization() {
+
+            var expectedDescription = "test";
+            var expectedType = ApplePayError.ErrorType.PaymentContactInvalid;
+            var expectedField = ApplePayContactInvalidError.ContactField.EmailAddress;
+
+            var applePayError = new ApplePayContactInvalidError(expectedDescription, expectedField);
+            var serialized = (Dictionary<string, object>) applePayError.ToJson();
+
+            Assert.AreEqual(serialized["Type"], expectedType);
+            Assert.AreEqual(serialized["Description"], expectedDescription);
+            Assert.AreEqual(serialized["Field"], expectedField);
+        }
+
+        [Test]
+        public void TestShippingAddressUnservicableErrorSerialization() {
+
+            var expectedDescription = "test";
+            var expectedType = ApplePayError.ErrorType.ShippingAddressUnservicable;
+
+            var applePayError = new ApplePayShippingAddressUnservicableError(expectedDescription);
+            var serialized = (Dictionary<string, object>) applePayError.ToJson();
+
+            Assert.AreEqual(serialized["Type"], expectedType);
+            Assert.AreEqual(serialized["Description"], expectedDescription);
+        }
+    }
+}
+#endif

--- a/Assets/Editor/iOS/TestApplePayError.cs.meta
+++ b/Assets/Editor/iOS/TestApplePayError.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4eaa144b4b547437797e1e0352ecb5d2
+timeCreated: 1502817866
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -142,6 +142,12 @@ module GraphQLGenerator
         SDK/iOS/IApplePayEventReceiver
         SDK/iOS/ApplePayEventReceiverBridge
         SDK/iOS/ApplePayEventResponse
+        SDK/iOS/ApplePayError
+        SDK/iOS/ApplePayAddressInvalidError
+        SDK/iOS/ApplePayShippingAddressInvalidError
+        SDK/iOS/ApplePayBillingAddressInvalidError
+        SDK/iOS/ApplePayContactInvalidError
+        SDK/iOS/ApplePayShippingAddressUnservicableError
         SDK/iOS/ShippingMethod
         SDK/iOS/PaymentNetwork
         SDK/iOS/iOSWebCheckout

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayAddressInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayAddressInvalidError.cs.erb
@@ -1,0 +1,32 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public class ApplePayAddressInvalidError: ApplePayError {
+
+            public enum AddressField {
+                Street,
+                Sublocality,
+                City,
+                SubAdministrativeArea,
+                State,
+                PostalCode,
+                Country,
+                ISOCountryCode
+            }
+
+        public readonly AddressField Field;
+
+        public ApplePayAddressInvalidError(ErrorType type, string description, AddressField field): base(type, description) {
+            Field = field;
+        }
+
+        public override object ToJson() {
+            var dict = (Dictionary<string, object>)base.ToJson();
+            dict["Field"] = Field;
+            return dict;
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayBillingAddressInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayBillingAddressInvalidError.cs.erb
@@ -1,0 +1,10 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public class ApplePayBillingAddressInvalidError: ApplePayAddressInvalidError {
+        public ApplePayBillingAddressInvalidError(string description, AddressField field): base(ErrorType.PaymentBillingAddress, description, field) {}
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayContactInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayContactInvalidError.cs.erb
@@ -1,0 +1,29 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public class ApplePayContactInvalidError: ApplePayError {
+
+        public enum ContactField {
+            PostalAddress,
+            EmailAddress,
+            PhoneNumber,
+            Name,
+            PhoneticName
+        }
+
+        public readonly ContactField Field;
+
+        public ApplePayContactInvalidError(string description, ContactField field): base(ErrorType.PaymentContactInvalid, description) {
+            Field = field;
+        }
+
+        public override object ToJson() {
+            var dict = (Dictionary<string, object>)base.ToJson();
+            dict["Field"] = Field;
+            return dict;
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayError.cs.erb
@@ -1,0 +1,34 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+    using <%= namespace %>.SDK;
+
+    public class ApplePayError: Serializable {
+
+        public enum ErrorType {
+            PaymentBillingAddress,
+            PaymentShippingAddress,
+            PaymentContactInvalid,
+            ShippingAddressUnservicable
+        }
+
+        public readonly ErrorType Type;
+        public readonly string Description;
+
+        public ApplePayError(ErrorType type, string description) {
+            Type = type;
+            Description = description;
+        }
+
+        public override object ToJson() {
+            var dict = new Dictionary<string, object>();
+
+            dict["Type"] = Type;
+            dict["Description"] = Description;
+
+            return dict;
+        }
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayShippingAddressInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayShippingAddressInvalidError.cs.erb
@@ -1,0 +1,10 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public class ApplePayShippingAddressInvalidError: ApplePayAddressInvalidError {
+        public ApplePayShippingAddressInvalidError(string description, AddressField field): base(ErrorType.PaymentShippingAddress, description, field) {}
+    }
+}
+#endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayShippingAddressUnservicableError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayShippingAddressUnservicableError.cs.erb
@@ -1,0 +1,10 @@
+#if UNITY_IOS
+namespace <%= namespace %>.SDK.iOS {
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public class ApplePayShippingAddressUnservicableError: ApplePayError {
+        public ApplePayShippingAddressUnservicableError(string description): base(ErrorType.ShippingAddressUnservicable, description) {}
+    }
+}
+#endif


### PR DESCRIPTION
+ Adds `ApplePayError` classes that will map to `PKErrors` on iOS
+ Decided to move fields enum inside class to use namespace as context