### PR TITLE
[Fix] Removed extra recurse source definition in tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,6 @@ mcs \
     -define:UNITY_IOS \
     -recurse:'Assets/Shopify/*.cs' \
     -recurse:'Assets/Editor/*.cs' \
-    -recurse:'Assets/Editor/iOS/*.cs' \
     -reference:nunit.framework.dll \
     -target:library \
     -out:test.dll


### PR DESCRIPTION
`recurse:'Assets/Editor/*.cs'` is sufficient to include the `iOS` specific files