### PR TITLE
rename methods to clarify direction of sync

### DIFF
--- a/scripts/generator/graphql_generator/csharp/CartState.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/CartState.cs.erb
@@ -147,15 +147,15 @@ namespace <%= namespace %> {
 
         public void CheckoutSave(CompletionCallback callback) {
             if (!IsCreated) {
-                CheckoutCreate(callback);
+                CreateRemoteCheckoutFromLocalState(callback);
             } else if(!IsSaved) {
-                CheckoutUpdate(callback);
+                UpdateRemoteCheckoutFromLocalState(callback);
             } else {
                 callback(null);
             }
         }
 
-        public void CheckoutCreate(CompletionCallback callback) {
+        private void CreateRemoteCheckoutFromLocalState(CompletionCallback callback) {
             MutationQuery query = new MutationQuery();
 
             List<CheckoutLineItemInput> newLineItemInput = CartLineItems.ConvertToCheckoutLineItemInput(LineItems.All());
@@ -234,7 +234,7 @@ namespace <%= namespace %> {
             }
         }
 
-        void CheckoutUpdate(CompletionCallback callback) {
+        private void UpdateRemoteCheckoutFromLocalState(CompletionCallback callback) {
             MutationQuery query = new MutationQuery();
 
             // remove all line items them add them


### PR DESCRIPTION
Small refactor to make extra clear which way the sync is going with these methods. I am expecting that in introducing the IsCompleted method to the Cart that we will need an UpdateLocalStateFromRemoteCheckout, so it makes sense to disambiguate here.

cc @Shopify/gaming 