### PR TITLE
Added necessary changes for compiling on iOS 11

### DIFF
--- a/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationController.swift
+++ b/Assets/Plugins/iOS/Shopify/BuyTests/Mocks/MockAuthorizationController.swift
@@ -65,7 +65,7 @@ final class MockAuthorizationController: PKPaymentAuthorizationController {
     static func invokeDidAuthorizePayment(_ payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
         
         self.instances.forEach { authorizationController in
-            authorizationController.delegate?.paymentAuthorizationController(authorizationController, didAuthorizePayment: payment, completion: completion)
+            authorizationController.delegate?.paymentAuthorizationController?(authorizationController, didAuthorizePayment: payment, completion: completion)
         }
     }
     

--- a/Assets/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Plugins/iOS/Shopify/PaymentSession.swift
@@ -187,10 +187,14 @@ extension PaymentSession {
 //  MARK: - PKPaymentAuthorizationViewControllerDelegate -
 //
 extension PaymentSession: PKPaymentAuthorizationViewControllerDelegate {
-    
+
     func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         paymentAuthorizationDidFinish()
     }
+}
+
+@available(iOS, introduced: 8.0, deprecated: 11.0)
+extension PaymentSession {
     
     func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
         paymentAuthorization(didSelect: shippingMethod, completion: completion)
@@ -205,10 +209,24 @@ extension PaymentSession: PKPaymentAuthorizationViewControllerDelegate {
     }
 }
 
+@available(iOS 11.0, *)
+extension PaymentSession {
+    
+    func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didAuthorizePayment payment: PKPayment, handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {}
+    
+    public func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect shippingMethod: PKShippingMethod, handler completion: @escaping (PKPaymentRequestShippingMethodUpdate) -> Swift.Void) {}
+    
+    public func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelectShippingContact contact: PKContact, handler completion: @escaping (PKPaymentRequestShippingContactUpdate) -> Swift.Void) {}
+    
+    
+    public func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didSelect paymentMethod: PKPaymentMethod, handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Swift.Void) {}
+}
+
 // ----------------------------------
 //  MARK: - PKPaymentAuthorizationControllerDelegate -
 //
-@available(iOS 10.0, *)
+
+@available(iOS, introduced: 10.0, deprecated: 11.0)
 extension PaymentSession: PKPaymentAuthorizationControllerDelegate {
     
     func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
@@ -227,3 +245,16 @@ extension PaymentSession: PKPaymentAuthorizationControllerDelegate {
         paymentAuthorization(didAuthorizePayment: payment, completion: completion)
     }
 }
+
+@available(iOS 11.0, *)
+extension PaymentSession {
+    
+    func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didAuthorizePayment payment: PKPayment, handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {}
+    
+    public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didSelectShippingMethod shippingMethod: PKShippingMethod, handler completion: @escaping (PKPaymentRequestShippingMethodUpdate) -> Swift.Void) {}
+    
+    public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didSelectShippingContact contact: PKContact, handler completion: @escaping (PKPaymentRequestShippingContactUpdate) -> Swift.Void) {}
+    
+    public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didSelectPaymentMethod paymentMethod: PKPaymentMethod, handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Swift.Void) {}
+}
+


### PR DESCRIPTION
+ Merging into `ios-11-support` because this is not backwards compatible with versions older than Xcode 9
+ Adds new delegate methods that were added to `PassKit`
+ They are left blank for now until we are ready to handle them 
    + In the new delegate calls, PKPaymentRequestShippingContactUpdate and PKPaymentAuthorizationResult classes expects an array of PKError for initialization. Since errors are marshalled in from managed code, we have not implemented the functionality for creating PKError from the Storefront APIs.

#### Extra note:
CI will be failing for now, since iOS 11 requires the CI to use a beta version of Unity and Xcode. Bringing CI up to par will be done in another PR
