### PR TITLE
[Feature] Added constructor to errors that takes in a MailingAddressInputField

### DIFF
--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayAddressInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayAddressInvalidError.cs.erb
@@ -1,31 +1,66 @@
 #if UNITY_IOS
 namespace <%= namespace %>.SDK.iOS {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
 
     public class ApplePayAddressInvalidError: ApplePayError {
 
-            public enum AddressField {
-                Street,
-                Sublocality,
-                City,
-                SubAdministrativeArea,
-                State,
-                PostalCode,
-                Country,
-                ISOCountryCode
-            }
+        public enum AddressField {
+            Street,
+            Sublocality,
+            City,
+            SubAdministrativeArea,
+            State,
+            PostalCode,
+            Country,
+            ISOCountryCode
+        }
 
         public readonly AddressField Field;
 
+        /// <summary>
+        /// Constructor for ApplePayAddressInvalidError
+        /// </summary>
+        /// <param name="type">Type of AddressInvalidError</param>
+        /// <param name="description">Localized description for the error</param>
+        /// <param name="field">A <see cref="AddressField"/> that represents the field that caused this error</param>
         public ApplePayAddressInvalidError(ErrorType type, string description, AddressField field): base(type, description) {
             Field = field;
+        }
+
+        /// <summary>
+        /// Constructor for ApplePayAddressInvalidError
+        /// </summary>
+        /// <param name="type">Type of AddressInvalidError</param>
+        /// <param name="description">Localized description for the error</param>
+        /// <param name="mailingAddressInputField">A field key from <see cref="MailingAddressInput"/> that represents the field that caused this error</param>
+        /// <exception cref="ArgumentException">The value given for mailingAddressInputField does not have an equivalent representation as a AddressField</exception>
+        public ApplePayAddressInvalidError(ErrorType type, string description, string mailingAddressInputField): base(type, description) {
+            Field = AddressFieldFromMailingAddressInputField(mailingAddressInputField);
         }
 
         public override object ToJson() {
             var dict = (Dictionary<string, object>)base.ToJson();
             dict["Field"] = Field;
             return dict;
+        }
+
+        /// Field is a string representation of a field key from MailingAddressInput
+        private AddressField AddressFieldFromMailingAddressInputField(string field) {
+            if (field.Equals(MailingAddressInput.address1FieldKey) || field.Equals(MailingAddressInput.address2FieldKey)) {
+                return AddressField.Street;
+            } else if (field.Equals(MailingAddressInput.cityFieldKey)) {
+                return AddressField.City;
+            } else if (field.Equals(MailingAddressInput.countryFieldKey)) {
+                return AddressField.Country;
+            } else if (field.Equals(MailingAddressInput.provinceFieldKey)) {
+                return AddressField.State;
+            } else if (field.Equals(MailingAddressInput.zipFieldKey)) {
+                return AddressField.PostalCode;
+            } else {
+                throw new ArgumentException("No matching AddressField for MailingAddressInputField with value: " + field);
+            }
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayBillingAddressInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayBillingAddressInvalidError.cs.erb
@@ -4,6 +4,7 @@ namespace <%= namespace %>.SDK.iOS {
 
     public class ApplePayBillingAddressInvalidError: ApplePayAddressInvalidError {
         public ApplePayBillingAddressInvalidError(string description, AddressField field): base(ErrorType.PaymentBillingAddress, description, field) {}
+        public ApplePayBillingAddressInvalidError(string description, string mailingAddressInputField): base(ErrorType.PaymentBillingAddress, description, mailingAddressInputField) {}
     }
 }
 #endif

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayContactInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayContactInvalidError.cs.erb
@@ -1,5 +1,6 @@
 #if UNITY_IOS
 namespace <%= namespace %>.SDK.iOS {
+    using System;
     using System.Collections.Generic;
 
     public class ApplePayContactInvalidError: ApplePayError {
@@ -14,14 +15,42 @@ namespace <%= namespace %>.SDK.iOS {
 
         public readonly ContactField Field;
 
+        /// <summary>
+        /// Constructor for ApplePayContactInvalidError
+        /// </summary>
+        /// <param name="description">Localized description for the error</param>
+        /// <param name="field">A <see cref="ContactField"/> that represents the field that caused this error</param>
         public ApplePayContactInvalidError(string description, ContactField field): base(ErrorType.PaymentContactInvalid, description) {
             Field = field;
+        }
+
+        /// <summary>
+        /// Constructor for ApplePayContactInvalidError
+        /// </summary>
+        /// <param name="description">Localized description for the error</param>
+        /// <param name="mailingAddressInputField">A field key from <see cref="MailingAddressInput"/> that represents the field that caused this error</param>
+        /// <exception cref="ArgumentException">The value given for mailingAddressInputField does not have an equivalent representation as a ContactField</exception>
+        public ApplePayContactInvalidError(string description, string mailingAddressInputField): base(ErrorType.PaymentContactInvalid, description) {
+            Field = ContactFieldFromMailingAddressInputField(mailingAddressInputField);
         }
 
         public override object ToJson() {
             var dict = (Dictionary<string, object>)base.ToJson();
             dict["Field"] = Field;
             return dict;
+        }
+
+        /// Field is a string representation of a field key from MailingAddressInput
+        private ContactField ContactFieldFromMailingAddressInputField(string field) {
+            if (field.Equals(MailingAddressInput.zipFieldKey)) {
+                return ContactField.PostalAddress;
+            } else if (field.Equals(MailingAddressInput.phoneFieldKey)) {
+                return ContactField.PhoneNumber;
+            } else if (field.Equals(MailingAddressInput.firstNameFieldKey) || field.Equals(MailingAddressInput.lastNameFieldKey)) {
+                return ContactField.Name;
+            } else {
+                throw new ArgumentException("No matching ContactField for field with value: " + field);
+            }
         }
     }
 }

--- a/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayShippingAddressInvalidError.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/iOS/ApplePayShippingAddressInvalidError.cs.erb
@@ -4,6 +4,7 @@ namespace <%= namespace %>.SDK.iOS {
 
     public class ApplePayShippingAddressInvalidError: ApplePayAddressInvalidError {
         public ApplePayShippingAddressInvalidError(string description, AddressField field): base(ErrorType.PaymentShippingAddress, description, field) {}
+        public ApplePayShippingAddressInvalidError(string description, string mailingAddressInputField): base(ErrorType.PaymentBillingAddress, description, mailingAddressInputField) {}
     }
 }
 #endif


### PR DESCRIPTION
+ Adds constructors to `ApplePayErrors` that take in a `MailingAddressInput` field.

#### Motivation
+ An incorrect value for a field in `MailingAddressInput` causes a `UserError` with `MailingAddressInput` fields. Since `ApplePayErrors` represent `UserErrors` when making requests related to Apple Pay, it should be that a `MailingAddressInput` field is mapped to an `ApplePayError`