### PR TITLE
omit includes for iOSPostProcessor unless on ios

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_IOS
 namespace <%= namespace %>.Editor.BuildPipeline {
     using UnityEngine;
     using UnityEditor;
@@ -7,8 +7,6 @@ namespace <%= namespace %>.Editor.BuildPipeline {
     using System.IO;
     using System;
 
-
-    #if UNITY_IOS
     /// <summary>
     /// Custom iOS build post processor that modifies the exported Xcode project to support the SDK.
     /// </summary>
@@ -70,6 +68,5 @@ namespace <%= namespace %>.Editor.BuildPipeline {
             }
         }
     }
-    #endif
 }
 #endif


### PR DESCRIPTION
Fixes https://github.com/Shopify/unity-buy-sdk-examples/issues/17

> UNITY_IOS  #define directive for compiling/executing code for the iOS platform.

https://docs.unity3d.com/Manual/PlatformDependentCompilation.html

It appears we were actually already using conditional compilation here, we just need to make a bit of an adjustment so that the using statements are omitted as well, unless doing an ios build.

@Shopify/gaming @pushmatrix 