### PR TITLE
Remove variant id only overload

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -8,7 +8,7 @@ namespace Shopify.Tests
     using Shopify.Unity.GraphQL;
     using Shopify.Unity.SDK;
     using System.Text.RegularExpressions;
-    
+
     [TestFixture]
     public class TestCart {
         [SetUp]
@@ -17,12 +17,12 @@ namespace Shopify.Tests
             ShopifyBuy.Reset();
             #endif
         }
-        
+
         [Test]
         public void TestGenericQuery() {
             ShopifyBuy.Init(new MockLoader());
             string cartWithId = "cartId";
-            
+
             Assert.IsNotNull(ShopifyBuy.Client().Cart(), "created a cart");
             Assert.IsNotNull(ShopifyBuy.Client().Cart(cartWithId), "created a cart with id");
             Assert.AreNotEqual(ShopifyBuy.Client().Cart(), ShopifyBuy.Client().Cart(cartWithId));
@@ -33,10 +33,10 @@ namespace Shopify.Tests
             ShopifyBuy.Init(new MockLoader());
 
             Cart cart = ShopifyBuy.Client().Cart();
-            
+
             // Add something to the cart.
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ=="), 33);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw=="), 2);
 
             Assert.AreEqual(2, cart.LineItems.All().Count, "cart has 2 line items");
 
@@ -62,50 +62,46 @@ namespace Shopify.Tests
             Assert.AreEqual(0, cart.LineItems.All().Count, "has 0 items in cart");
             Assert.IsNull(cart.CurrentCheckout, "cart has a null Checkout");
         }
-        
+
         [Test]
         public void TestAddRemoveLineItems() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
-            
-            Dictionary<string,object> data = new Dictionary<string,object>();
-            data.Add("id", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==");
-            
-            ProductVariant variant = new ProductVariant(data);
-            
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
-            cart.LineItems.AddOrUpdate(variant, 2);
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=");
-            
+
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ=="), 33);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw=="), 2);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE="));
+
             Assert.AreEqual(3, cart.LineItems.All().Count, "has 3 items in cart");
             Assert.AreEqual(33, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==").Quantity, "variant 20756129155 Quantity is 33");
             Assert.AreEqual(2, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==").Quantity, "variant 20756129347 Quantity is 2");
             Assert.AreEqual(1, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=").Quantity, "variant 7336568131 Quantity is 1");
             Assert.AreEqual(null, cart.LineItems.Get("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzczMzY1NjgxMzE=").ID, "variant 7336568131 ID is null");
-            
+
             bool didDelete = cart.LineItems.Delete("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==");
             Assert.AreEqual(2, cart.LineItems.All().Count, "After remove had 2 items in cart");
             Assert.IsTrue(didDelete, "returned true when deleting");
-            
+
             didDelete = cart.LineItems.Delete("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC9pYW1ub3RyZWFs");
             Assert.IsFalse(didDelete, "returned false when did not delete");
         }
-        
+
         [Test]
         public void TestCastingLineItems() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
-            string variandId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
-            
-            cart.LineItems.AddOrUpdate(variandId, 33, new Dictionary<string, string>() {
+            var variantId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+            var variant = CreateProductVariant(variantId);
+
+            cart.LineItems.AddOrUpdate(variant, 33, new Dictionary<string, string>() {
                 {"fun", "things"}
             });
-            
-            CheckoutLineItemInput input = (CheckoutLineItemInput) cart.LineItems.Get(variandId);
-            CheckoutLineItemUpdateInput updateInput = (CheckoutLineItemUpdateInput) cart.LineItems.Get(variandId);
-            
+
+            CheckoutLineItemInput input = (CheckoutLineItemInput) cart.LineItems.Get(variantId);
+            CheckoutLineItemUpdateInput updateInput = (CheckoutLineItemUpdateInput) cart.LineItems.Get(variantId);
+
             Assert.IsNotNull(input);
             Assert.IsNotNull(updateInput);
             Assert.IsNotNull(input.customAttributes);
@@ -115,52 +111,53 @@ namespace Shopify.Tests
             Assert.AreEqual("things", input.customAttributes[0].value);
             Assert.AreEqual("things", updateInput.customAttributes[0].value);
         }
-        
+
         [Test]
         public void TestModifyingCustomAttributesMadeLineNotBeSaved() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
-            string variandId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+            string variantId = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+            var variant = CreateProductVariant(variantId);
             Dictionary<string,object> dataCheckoutLineItem = new Dictionary<string,object>() {
                 {"id", "a-checkout-id"},
                 {
-                    "variant", new Dictionary<string, object>() { 
-                        {"id", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ=="} 
+                    "variant", new Dictionary<string, object>() {
+                        {"id", "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ=="}
                     }
-                } 
+                }
             };
             List<CheckoutLineItem> checkoutLineItems = new List<CheckoutLineItem>() {
                 { new CheckoutLineItem(dataCheckoutLineItem) }
             };
-            
-            cart.LineItems.AddOrUpdate(variandId, 33, new Dictionary<string, string>() {
+
+            cart.LineItems.AddOrUpdate(variant, 33, new Dictionary<string, string>() {
                 {"fun", "things"}
             });
-            
+
             Assert.IsFalse(cart.LineItems.IsSaved, "initially is not saved");
-            
-            cart.LineItems.Get(variandId).GetCheckoutLineItemUpdateInput();
-            
+
+            cart.LineItems.Get(variantId).GetCheckoutLineItemUpdateInput();
+
             cart.LineItems.UpdateLineItemsFromCheckoutLineItems(checkoutLineItems);
 
             Assert.IsTrue(cart.LineItems.IsSaved, "after get input is saved");
-            
-            cart.LineItems.Get(variandId).CustomAttributes["fun"] = "stuff";
-            
+
+            cart.LineItems.Get(variantId).CustomAttributes["fun"] = "stuff";
+
             Assert.IsFalse(cart.LineItems.IsSaved, "after change is not saved");
         }
-        
+
         [Test]
         public void TestGetCheckoutLink() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
             string responseURL = null;
             ShopifyError error = null;
 
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==", 33);
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ=="), 33);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw=="), 2);
 
             cart.GetWebCheckoutLink(
                 success: (url) => {
@@ -180,9 +177,13 @@ namespace Shopify.Tests
         [Test]
         public void ModifyLineItems() {
             ShopifyBuy.Init(new MockLoader());
-            
-            string productId1 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
-            string productId2 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==";
+
+            string variantId1 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTE1NQ==";
+            var variant1 = CreateProductVariant(variantId1);
+
+            string variantId2 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==";
+            var variant2 = CreateProductVariant(variantId2);
+
             Dictionary<string, string> attributes1 = new Dictionary<string, string>() {
                 {"fancy", "i am fancy"},
                 {"boring", "i am boring"}
@@ -191,30 +192,30 @@ namespace Shopify.Tests
                 {"animal", "lion"},
                 {"spotted", "no"}
             };
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
-            
-            cart.LineItems.AddOrUpdate(productId1, 33);
-            cart.LineItems.AddOrUpdate(productId2, 33);
-            
-            cart.LineItems.AddOrUpdate(productId1, 100);
-            cart.LineItems.AddOrUpdate(productId1, null, attributes1);
-            cart.LineItems.AddOrUpdate(productId2, 6, attributes2);
-            
-            Assert.AreEqual(100, cart.LineItems.Get(productId1).Quantity, "variant 20756129155 Quantity is 100 after change");
-            Assert.AreEqual(6, cart.LineItems.Get(productId2).Quantity, "variant 20756129155 Quantity is 100 after change");
-            Assert.AreEqual("i am fancy", cart.LineItems.Get(productId1).CustomAttributes["fancy"]);
-            Assert.AreEqual("i am boring", cart.LineItems.Get(productId1).CustomAttributes["boring"]);
-            Assert.AreEqual("lion", cart.LineItems.Get(productId2).CustomAttributes["animal"]);
-            Assert.AreEqual("no", cart.LineItems.Get(productId2).CustomAttributes["spotted"]);
+
+            cart.LineItems.AddOrUpdate(variant1, 33);
+            cart.LineItems.AddOrUpdate(variant2, 33);
+
+            cart.LineItems.AddOrUpdate(variant1, 100);
+            cart.LineItems.AddOrUpdate(variant1, null, attributes1);
+            cart.LineItems.AddOrUpdate(variant2, 6, attributes2);
+
+            Assert.AreEqual(100, cart.LineItems.Get(variantId1).Quantity, "variant 20756129155 Quantity is 100 after change");
+            Assert.AreEqual(6, cart.LineItems.Get(variantId2).Quantity, "variant 20756129155 Quantity is 100 after change");
+            Assert.AreEqual("i am fancy", cart.LineItems.Get(variantId1).CustomAttributes["fancy"]);
+            Assert.AreEqual("i am boring", cart.LineItems.Get(variantId1).CustomAttributes["boring"]);
+            Assert.AreEqual("lion", cart.LineItems.Get(variantId2).CustomAttributes["animal"]);
+            Assert.AreEqual("no", cart.LineItems.Get(variantId2).CustomAttributes["spotted"]);
         }
-        
+
         [Test]
         public void AddEditRemoveViaSelectedOptions() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
-            
+
             string jsonString = @"
             {
                 ""title"": ""Many Variant"",
@@ -300,51 +301,51 @@ namespace Shopify.Tests
                 }
             }
             ";
-            
+
             Product product = new Product((Dictionary<string, object>) Json.Deserialize(jsonString));
-            
+
             Dictionary<string, string> selectedOptions1 = new Dictionary<string, string>() {
                 {"Size", "Small"},
                 {"Color", "Red"}
             };
-            
+
             Dictionary<string, string> selectedOptions2 = new Dictionary<string, string>() {
                 {"Size", "Large"},
                 {"Color", "Blue"}
             };
-            
+
             Dictionary<string, string> selectedOptions3 = new Dictionary<string, string>() {
                 {"Size", "Large"},
                 {"Color", "Red"}
             };
-            
-            
+
+
             cart.LineItems.AddOrUpdate(product, selectedOptions1, 3);
             cart.LineItems.AddOrUpdate(product, selectedOptions2, 123);
-            
+
             Assert.AreEqual(3, cart.LineItems.Get(product, selectedOptions1).Quantity, "was able to set using selected options");
             Assert.AreEqual(123, cart.LineItems.Get(product, selectedOptions2).Quantity, "was able to set using selected options");
-            
+
             cart.LineItems.AddOrUpdate(product, selectedOptions1, 13);
-            
+
             Assert.AreEqual(13, cart.LineItems.Get(product, selectedOptions1).Quantity, "was able to reset using selected options");
-            
+
             Assert.IsTrue(cart.LineItems.Delete(product, selectedOptions1), "returned true when line item was deleted");
             Assert.IsFalse(cart.LineItems.Delete(product, selectedOptions3), "returned false when no line item existed");
-            
+
             Assert.AreEqual(null, cart.LineItems.Get(product, selectedOptions1), "Get retuned null after attempting access deleted line item");
         }
-        
+
         [Test]
         public void TestGetCheckoutLinkWithPoll() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
             string responseURL = null;
             ShopifyError error = null;
 
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTPOLL==", 33);
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw==", 2);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTPOLL=="), 33);
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyOTM0Nw=="), 2);
 
             cart.GetWebCheckoutLink(
                 success: (url) => {
@@ -360,11 +361,11 @@ namespace Shopify.Tests
             Assert.AreEqual("line-item-id1", cart.LineItems.All()[0].ID, "Line item 1 has the correct ID set");
             Assert.AreEqual("line-item-id2", cart.LineItems.All()[1].ID, "Line item 2 has the correct ID set");
         }
-        
+
         [Test]
         public void TestGetCheckoutLinkAfterLineItemModifications() {
             ShopifyBuy.Init(new MockLoader());
-            
+
             Cart cart = ShopifyBuy.Client().Cart();
             string firstResponseURL = null;
             ShopifyError firstError = null;
@@ -375,8 +376,8 @@ namespace Shopify.Tests
             string variantId2 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NjEyDelete==";
             string variantId3 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8yMDc1NTMNewItem==";
 
-            cart.LineItems.AddOrUpdate(variantId1, 33);
-            cart.LineItems.AddOrUpdate(variantId2, 2);
+            cart.LineItems.AddOrUpdate(CreateProductVariant(variantId1), 33);
+            cart.LineItems.AddOrUpdate(CreateProductVariant(variantId2), 2);
 
             cart.GetWebCheckoutLink(
                 success: (url) => {
@@ -393,11 +394,11 @@ namespace Shopify.Tests
             Assert.AreEqual("line-item-id2", cart.LineItems.All()[1].ID, "Line item 2 has the correct ID set");
 
             // update item
-            cart.LineItems.AddOrUpdate(variantId1, 10);
+            cart.LineItems.AddOrUpdate(CreateProductVariant(variantId1), 10);
             // delete item
             cart.LineItems.Delete(variantId2);
             // new item
-            cart.LineItems.AddOrUpdate(variantId3, 3);
+            cart.LineItems.AddOrUpdate(CreateProductVariant(variantId3), 3);
 
             cart.GetWebCheckoutLink(
                 success: (url) => {
@@ -423,8 +424,8 @@ namespace Shopify.Tests
             string resultUrl = null;
             ShopifyError resultError = null;
 
-            cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError==", 1);
-            
+            cart.LineItems.AddOrUpdate(CreateProductVariant("Z2lkOi8vc2hvcGlmeS9Qcm9kdWNFyaWFudC8yMDc1NjEyUserError=="), 1);
+
             cart.GetWebCheckoutLink(
                 success: (url) => {
                     resultUrl = url;
@@ -441,6 +442,13 @@ namespace Shopify.Tests
             Assert.AreEqual(1, cart.UserErrors.Count);
             Assert.AreEqual("someField", cart.UserErrors[0].field()[0], "fields was correct");
             Assert.AreEqual("bad things happened", cart.UserErrors[0].message(), "messaged was correct");
+        }
+
+        private ProductVariant CreateProductVariant(string id) {
+            Dictionary<string,object> data = new Dictionary<string,object>();
+            data.Add("id", id);
+
+            return new ProductVariant(data);
         }
     }
 }

--- a/Assets/NativeTesting/iOS/ApplePayFlowTester.cs
+++ b/Assets/NativeTesting/iOS/ApplePayFlowTester.cs
@@ -79,7 +79,7 @@
         private void SetDefaultCartProducts(Action completion) {
             Client.products((products, error) => {
                 List<ProductVariant> productVariants = (List<ProductVariant>) products[0].variants();
-                CurrentCart.LineItems.AddOrUpdate(productVariants[0].id(), 1);
+                CurrentCart.LineItems.AddOrUpdate(productVariants[0], 1);
                 completion();
             });
         }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -162,10 +162,13 @@ void Start () {
         // In this case, the cart will have 3 copies of the variant.
         cart.LineItems.AddOrUpdate(firstProductFirstVariant, 3);
 
-        // AddOrUpdate is overloaded to accept either ProductVariants or strings, or to select a variant based on selected options.
-        // Alternately, you can use a product variant id string to create line items.
-        // This example updates the first product in the cart to have a quantity of 1.
-        cart.LineItems.AddOrUpdate(firstProductFirstVariant.id(), 1);
+        // AddOrUpdate is overloaded to accept either a ProductVariant or a Product and the options which describe a particular variant. For example, here we are adding the variant with corresponding options
+        Dictionary<string, string> options = new Dictionary<string, string>() {
+            {"size", "small"},
+            {"color", "red"}
+        };
+
+        cart.LineItems.AddOrUpdate(products[0], 1, options);
     });
 }
 ```

--- a/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/CartLineItems.cs.erb
@@ -135,9 +135,9 @@ namespace <%= namespace %>.SDK {
         }
 
         /// <summary>
-        /// Adds or updates an existing line item using a variant id.
+        /// Adds or updates a line item using a <see ref="ProductVariant">ProductVariant </see>.
         /// </summary>
-        /// <param name="variantId">variant id for a <see ref="ProductVariant">ProductVariant </see></param>
+        /// <param name="variant"><see ref="ProductVariant">ProductVariant </see> whose id will be used to create or update a line item</param>
         /// <param name="quantity">the number of items you'd like to order for variantId</param>
         /// <param name="customAttributes">can be used to define extra information for this line item</param>
         /// \code
@@ -145,10 +145,10 @@ namespace <%= namespace %>.SDK {
         /// // If no line item exists for `variantId`, then a new line item is created
         /// Cart cart = ShopifyBuy.Client().Cart();
         ///
-        /// cart.LineItems.AddOrUpdate(variantId, 3);
+        /// cart.LineItems.AddOrUpdate(variant, 3);
         /// \endcode
-        public void AddOrUpdate(string variantId, long? quantity = null, Dictionary<string, string> customAttributes = null) {
-            CartLineItem input = Get(variantId);
+        public void AddOrUpdate(ProductVariant variant, long? quantity = null, Dictionary<string, string> customAttributes = null) {
+            CartLineItem input = Get(variant.id());
 
             if (input != null) {
                 if (quantity != null) {
@@ -165,30 +165,13 @@ namespace <%= namespace %>.SDK {
 
                 LineItems.Add(
                     new CartLineItem(
-                        variantId: variantId,
+                        variantId: variant.id(),
                         onChange: OnLineItemChange,
                         quantity: (long) quantity,
                         customAttributes: customAttributes
                     )
                 );
             }
-        }
-
-        /// <summary>
-        /// Adds or updates a line item using a <see ref="ProductVariant">ProductVariant </see>.
-        /// </summary>
-        /// <param name="variant"><see ref="ProductVariant">ProductVariant </see> whose id will be used to create or update a line item</param>
-        /// <param name="quantity">the number of items you'd like to order for variantId</param>
-        /// <param name="customAttributes">can be used to define extra information for this line item</param>
-        /// \code
-        /// // Example that updates the quantity of items to be purchased to 3.
-        /// // If no line item exists for `variantId`, then a new line item is created
-        /// Cart cart = ShopifyBuy.Client().Cart();
-        ///
-        /// cart.LineItems.AddOrUpdate(variant, 3);
-        /// \endcode
-        public void AddOrUpdate(ProductVariant variant, long? quantity = null, Dictionary<string, string> customAttributes = null) {
-            AddOrUpdate(variant.id(), quantity, customAttributes);
         }
 
         /// <summary>
@@ -213,13 +196,13 @@ namespace <%= namespace %>.SDK {
         /// cart.LineItems.AddOrUpdate(product, selectedOptions, 3);
         /// \endcode
         public void AddOrUpdate(Product product, Dictionary<string, string> selectedOptions, long? quantity = null, Dictionary<string, string> customAttributes = null) {
-            string variantId = VariantFromSelectedOptions(product, selectedOptions).id();
+            var variant = VariantFromSelectedOptions(product, selectedOptions);
 
-            if (variantId == null) {
+            if (variant == null) {
                 throw new NoMatchingVariantException("Could not `AddOrUpdate` line item as no matching variant could be found for selected options");
             }
 
-            AddOrUpdate(variantId, quantity, customAttributes);
+            AddOrUpdate(variant, quantity, customAttributes);
         }
 
         /// <summary>
@@ -365,11 +348,11 @@ namespace <%= namespace %>.SDK {
         public void UpdateLineItemsFromCheckoutLineItems(List<CheckoutLineItem> checkoutLineItems) {
             foreach(CheckoutLineItem checkoutLineItem in checkoutLineItems) {
                 bool didUpdateID = false;
-                string checkoutVariantId = checkoutLineItem.variant().id();
+                var checkoutVariant = checkoutLineItem.variant();
                 string checkoutLineItemId = checkoutLineItem.id();
 
                 foreach(CartLineItem cartLineItem in LineItems) {
-                    if (cartLineItem.VariantId == checkoutVariantId) {
+                    if (cartLineItem.VariantId == checkoutVariant.id()) {
                         cartLineItem.ID = checkoutLineItemId;
                         didUpdateID = true;
                         break;
@@ -391,8 +374,8 @@ namespace <%= namespace %>.SDK {
                     } catch(NoQueryException error) {}
                     #pragma warning restore 0168
 
-                    AddOrUpdate(checkoutVariantId, quantity, customAttributes);
-                    Get(checkoutVariantId).ID = checkoutLineItemId;
+                    AddOrUpdate(checkoutVariant, quantity, customAttributes);
+                    Get(checkoutVariant.id()).ID = checkoutLineItemId;
                 }
             }
 


### PR DESCRIPTION
Per https://github.com/Shopify/unity-buy-sdk/pull/297/files#r135104239, changes the `AddOrUpdate` overloads to remove the option to add via variantId, preferring instead to only have the overloads for passing a ProductVariant, or a Product/options. 

Rationale is that as we use more attributes from the ProductVariant we want to be able to control how the attributes are associated with the CartLineItems.