### PR TITLE
[Docs] Added additional caveats to the Android building

### DIFF
--- a/BUILDTARGETS.md
+++ b/BUILDTARGETS.md
@@ -9,10 +9,23 @@ You can find a more detailed explanation regarding platform specific dependencie
 
 # Android
 
-The Unity Buy SDK requires Android games to have a minimum API level of Android 4.4 'Kit Kat' (API Level 19)
+The Unity Buy SDK requires at least Unity 5.6.1 and Android games to have a minimum API level of Android 4.4 'Kit Kat' (API Level 19).
 
-In addition Unity 5.6 and above must be used to build on the Android platform. As such the `Build System` option in the `Build Settings` pane must be set to `Gradle`.
+## Building with Gradle (Known Issues)
 
+If you're looking to use the new Gradle build system introduced in Unity 5.6, you may run into the following:
+
+***Building for release error***
+* Error: `Avoid hardcoding the debug mode; leaving it out allows debug and release builds to automatically assign one [HardcodedDebugMode]`
+
+When using the Gradle build system in Unity 5.6.1, Unity adds the `android:debuggable` attribute to the AndroidManifest.xml file which causes issues with the linter. As a workaround,
+
+1. Select the `Export Project` setting in the Build Settings window and export the Gradle project.
+2. Import the Android project into Android Studio by selecting `New` -> `Import Project..` and selecting the exported Unity folder.
+3. Update the classpath in `gradle-wrapper.properties` inside the `<YourProject>/gradle/wrapper` folder to use Gradle 2.3.3 instead of 2.1.
+4. Generate the release signed APK using `Build` -> `Release signed APK...`
+
+Alternatively you can use the default `Internal` build system.
 
 # iOS
 


### PR DESCRIPTION
Added some issues when trying to build for release from Unity 5.6.1 using the new Gradle build system.