### PR TITLE
[Android] Excluded support-annotations and removed AAR dependencies

### DIFF
--- a/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Assets/Plugins/Android/mainTemplate.gradle
@@ -43,9 +43,4 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile(name: 'shopify_buy_plugin', ext:'aar')
-
-    compile 'com.android.support:appcompat-v7:26.0.0'
-    compile 'com.android.support:customtabs:26.0.0'
-    compile 'com.shopify.mobilebuysdk:buy3-pay-support:1.0.0'
-    compile 'com.squareup.moshi:moshi:1.5.0'
 }

--- a/android/shopify_buy_plugin/build.gradle
+++ b/android/shopify_buy_plugin/build.gradle
@@ -32,8 +32,12 @@ dependencies {
     androidTestCompile 'org.mockito:mockito-android:2.7.15'
 
     compile project(':unity_classes')
-    compile 'com.android.support:appcompat-v7:26.0.0'
-    compile 'com.android.support:customtabs:26.0.0'
+    compile('com.android.support:appcompat-v7:26.0.0') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    compile('com.android.support:customtabs:26.0.0') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
     compile 'com.shopify.mobilebuysdk:buy3-pay-support:1.0.0'
     compile 'com.squareup.moshi:moshi:1.5.0'
 


### PR DESCRIPTION
support-annotations is a popular library amongst Android plugins and causes conflicts when present within multiple plugins within a user's game. This usually only occurs when trying to make a signed release build for multidex-enabled builds. This PR excludes the dependency from our own dependencies to reduce the risk of collision.