### PR TITLE
[Fix] Set native payment to null for Android for now until feature is complete

### DIFF
--- a/scripts/generator/graphql_generator/csharp/Cart.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Cart.cs.erb
@@ -130,7 +130,7 @@ namespace <%= namespace %> {
             NativeCheckout = new iOSNativeCheckout(State);
             #elif UNITY_ANDROID
             WebCheckout = new AndroidWebCheckout(this, client);
-            NativeCheckout = new AndroidNativeCheckout(State);
+            NativeCheckout = null;
             #else
             WebCheckout = null;
             NativeCheckout = null;


### PR DESCRIPTION
Sets AndroidNativePayment to null for now until native Android Pay is implemented. This will allow all of the API calls to fail.