### PR TITLE
[Docs] Removes Gradle requirement for building Android APKs

### DIFF
--- a/BUILDTARGETS.md
+++ b/BUILDTARGETS.md
@@ -9,7 +9,7 @@ You can find a more detailed explanation regarding platform specific dependencie
 
 # Android
 
-The Unity Buy SDK requires Android games to have a minimum API level of Android 4.4 'Kit Kat' (API Level 19)
+The Unity Buy SDK requires Android games to have a minimum API level of Android 4.4 'Kit Kat' (API Level 19).
 
 # iOS
 

--- a/BUILDTARGETS.md
+++ b/BUILDTARGETS.md
@@ -11,9 +11,6 @@ You can find a more detailed explanation regarding platform specific dependencie
 
 The Unity Buy SDK requires Android games to have a minimum API level of Android 4.4 'Kit Kat' (API Level 19)
 
-In addition Unity 5.6 and above must be used to build on the Android platform. As such the `Build System` option in the `Build Settings` pane must be set to `Gradle`.
-
-
 # iOS
 
 The Unity Buy SDK requires iOS games to have a minimum target SDK of iOS 9 and support Swift 3.


### PR DESCRIPTION
With the changes to pulling in dependencies using the PlayServicesResolver, we no longer require developers to use Gradle as their build method.