### PR TITLE
Fixes newlines for die messages. Also fixes a test for when you're pu…

### DIFF
--- a/Assets/Editor/TestShopify.cs
+++ b/Assets/Editor/TestShopify.cs
@@ -216,7 +216,7 @@ namespace Shopify.Tests
 
         [Test]
         public void TestHasVersionNumberWithPublishDestination() {
-            Regex version = new Regex(@"^\d+\.\d+\.\d+-github$");
+            Regex version = new Regex(@"^\d+\.\d+\.\d+(-github|-asset-store)$");
 
             Assert.IsTrue(version.IsMatch(ShopifyBuy.VERSION));
         }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -6,7 +6,7 @@ die() {
 }
 
 out() {
-    printf "%s" "$*"
+    echo -e $*
 }
 
 start() {


### PR DESCRIPTION
This PR just fixes a couple of small things when building `asset-store` dists.

1. Fixes the test to allow for a version number followed by `-asset-store`
2. Makes the die messaging be able to handle newlines