### PR TITLE
[Fix] Missed a couple of paths from Plugins folder move that caused iOS tests to fail

### DIFF
--- a/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
+++ b/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
@@ -23,7 +23,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         /// Sets the correct build properties to run
         private static void SetBuildProperties(ExtendedPBXProject project) {
             iOSPostProcessor.SetBuildProperties(project);
-            project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Plugins/iOS/Shopify/Unity-iPhone-Tests-Bridging-Header.h");
+            project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Tests-Bridging-Header.h");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@loader_path/Frameworks");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.ProjectModuleNameKey, "$(PRODUCT_NAME:c99extidentifier)Tests");
             project.SetBuildPropertyForConfig(project.GetDebugConfig(project.UnityTargetGuid), ExtendedPBXProject.EnableTestabilityKey, "YES");
@@ -32,7 +32,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
 
         /// Sets the correct target for Shopify Tests
         private static void SetCorrectTestsTarget(ExtendedPBXProject project) {
-            string testPath = Path.Combine(project.BuildPath, "Libraries/Plugins/iOS/Shopify/BuyTests/");
+            string testPath = Path.Combine(project.BuildPath, "Libraries/Shopify/Plugins/iOS/Shopify/BuyTests/");
             var testDirectory = new DirectoryInfo(testPath);
 
             try {

--- a/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
@@ -26,7 +26,7 @@ namespace <%= namespace %>.Editor.BuildPipeline {
         // Sets the required project settings for the Xcode project to work with the SDK.
         public static void SetBuildProperties(ExtendedPBXProject project) {
             project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "3.0");
-            project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h");
+            project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@executable_path/Frameworks");
 
             bool isBelowMinimumTarget = false;


### PR DESCRIPTION
When we moved the Plugins folder from the top level to below Shopify/ there were a couple of paths that weren't updated in the iOS post processing scripts that caused the iOS test project export to fail.