### PR TITLE
Run unity outside of headless mode in CI  …

### DIFF
--- a/scripts/test_unity.sh
+++ b/scripts/test_unity.sh
@@ -18,8 +18,6 @@ UNITY_VERSION=$(ls "$UNITY_PACKAGE_MANAGER_PATH")
 printf "Testing with Unity Version: %s\n" "$UNITY_VERSION"
 
 "$UNITY_PATH" \
-    -batchmode \
-    -nographics \
     -force-opengl \
     -silent-crashes \
     -logFile "$UNITY_LOG_PATH" \


### PR DESCRIPTION
~~@sleroux noticed that when I changed the key to some editorprefs in another commit, it broke his local environment in exactly the same way as CI. So the idea is that InitializeOnLoad + window show crashes headless instances of unity.~~

~~This imports a relevant plist file into the correct location on CI so that the window does not automatically pop up.~~

Turns out if you just run unity with the GUI in CI it fixes this.