### PR TITLE
[Fix] Fix CI issues for Android tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.2
+    - build-tools-26.0.0
     - extra-android-m2repository
-    - android-24
+    - android-26
     - extra-google-m2repository
     - extra-android-support
   licenses:

--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/models/MailingAddressInputTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/models/MailingAddressInputTest.java
@@ -5,6 +5,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.google.android.gms.identity.intents.model.UserAddress;
 
+import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -17,7 +18,7 @@ import static junit.framework.Assert.assertEquals;
 @SmallTest
 public class MailingAddressInputTest {
     @Test
-    public void testToJsonString() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testToJsonString() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, JSONException {
 
         final Constructor<UserAddress> constructor = UserAddress.class.getDeclaredConstructor(int.class, String.class, String.class,
                 String.class, String.class, String.class, String.class, String.class, String.class, String.class, String.class, String.class,
@@ -28,19 +29,16 @@ public class MailingAddressInputTest {
 
         MailingAddressInput mailingAddress = new MailingAddressInput(userAddress);
         String jsonString = mailingAddress.toJsonString();
+        MailingAddressInput outputMailingAddress = MailingAddressInput.fromJsonString(jsonString);
 
-        String expected = "{" +
-                "\"address1\":\"address1\"," +
-                "\"address2\":\"address2, address3, address4, address5\"," +
-                "\"city\":\"locality\"," +
-                "\"country\":\"countryCode\"," +
-                "\"firstName\":\"firstName\"," +
-                "\"lastName\":\"lastName\"," +
-                "\"phone\":\"phoneNumber\"," +
-                "\"province\":\"administrativeArea\"," +
-                "\"zip\":\"postalCode\"" +
-                "}";
-
-        assertEquals(jsonString, expected);
+        assertEquals(mailingAddress.address1, outputMailingAddress.address1);
+        assertEquals(mailingAddress.address2, outputMailingAddress.address2);
+        assertEquals(mailingAddress.city, outputMailingAddress.city);
+        assertEquals(mailingAddress.country, outputMailingAddress.country);
+        assertEquals(mailingAddress.firstName, outputMailingAddress.firstName);
+        assertEquals(mailingAddress.lastName, outputMailingAddress.lastName);
+        assertEquals(mailingAddress.phone, outputMailingAddress.phone);
+        assertEquals(mailingAddress.province, outputMailingAddress.province);
+        assertEquals(mailingAddress.zip, outputMailingAddress.zip);
     }
 }

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
@@ -11,8 +11,6 @@ import org.json.JSONObject;
 
 // A wrapper around PayAddress to convert it to Json.
 public class MailingAddressInput implements JsonSerializable {
-    private final PayAddress payAddress;
-
     private static final String ADDRESS_1 = "address1";
     private static final String ADDRESS_2 = "address2";
     private static final String CITY = "city";
@@ -23,22 +21,85 @@ public class MailingAddressInput implements JsonSerializable {
     private static final String PROVINCE = "province";
     private static final String ZIP = "zip";
 
+    public final String address1;
+    public final String address2;
+    public final String city;
+    public final String country;
+    public final String firstName;
+    public final String lastName;
+    public final String phone;
+    public final String province;
+    public final String zip;
+
     public MailingAddressInput(UserAddress userAddress) {
-        payAddress = PayAddress.fromUserAddress(userAddress);
+        PayAddress payAddress = PayAddress.fromUserAddress(userAddress);
+        this.address1 = payAddress.address1;
+        this.address2 = payAddress.address2;
+        this.city = payAddress.city;
+        this.country = payAddress.country;
+        this.firstName = payAddress.firstName;
+        this.lastName = payAddress.lastName;
+        this.phone = payAddress.phone;
+        this.province = payAddress.province;
+        this.zip = payAddress.zip;
+    }
+
+    public static MailingAddressInput fromJsonString(String json) throws JSONException {
+        String expected = "{" +
+            "\"address1\":\"address1\"," +
+            "\"address2\":\"address2, address3, address4, address5\"," +
+            "\"city\":\"locality\"," +
+            "\"country\":\"countryCode\"," +
+            "\"firstName\":\"firstName\"," +
+            "\"lastName\":\"lastName\"," +
+            "\"phone\":\"phoneNumber\"," +
+            "\"province\":\"administrativeArea\"," +
+            "\"zip\":\"postalCode\"" +
+            "}";
+
+        JSONObject obj = new JSONObject(json);
+        String address1 = obj.getString("address1");
+        String address2 = obj.getString("address2");
+        String city = obj.getString("city");
+        String country = obj.getString("country");
+        String firstName = obj.getString("firstName");
+        String lastName = obj.getString("lastName");
+        String phone = obj.getString("phone");
+        String province = obj.getString("province");
+        String zip = obj.getString("zip");
+
+        return new MailingAddressInput(address1, address2, city, country, firstName, lastName, phone, province, zip);
+    }
+
+
+    //CHECKSTYLE:OFF
+    private MailingAddressInput(String address1, String address2, String city,
+                                String country, String firstName, String lastName,
+                                String phone, String province, String zip) {
+        //CHECKSTLYE:ON
+        this.address1 = address1;
+        this.address2 = address2;
+        this.city = city;
+        this.country = country;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.phone = phone;
+        this.province = province;
+        this.zip = zip;
     }
 
     public String toJsonString() {
         JSONObject obj = new JSONObject();
         try {
-            obj.put(ADDRESS_1, payAddress.address1);
-            obj.put(ADDRESS_2, payAddress.address2);
-            obj.put(CITY, payAddress.city);
-            obj.put(COUNTRY, payAddress.country);
-            obj.put(FIRST_NAME, payAddress.firstName);
-            obj.put(LAST_NAME, payAddress.lastName);
-            obj.put(PHONE, payAddress.phone);
-            obj.put(PROVINCE, payAddress.province);
-            obj.put(ZIP, payAddress.zip);
+            obj.put(ADDRESS_1, address1);
+            obj.put(ADDRESS_2, address2);
+            obj.put(CITY, city);
+            obj.put(COUNTRY, country);
+            obj.put(FIRST_NAME, firstName);
+            obj.put(LAST_NAME, lastName);
+            obj.put(PHONE, phone);
+            obj.put(PROVINCE, province);
+            obj.put(ZIP, zip);
         } catch (JSONException e) {
             Log.e("ShopifyBuyPlugin", "Failed to convert MailingAddressInput into a JSON String.");
             e.printStackTrace();

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
@@ -21,15 +21,15 @@ public class MailingAddressInput implements JsonSerializable {
     private static final String PROVINCE = "province";
     private static final String ZIP = "zip";
 
-    public final String address1;
-    public final String address2;
-    public final String city;
-    public final String country;
-    public final String firstName;
-    public final String lastName;
-    public final String phone;
-    public final String province;
-    public final String zip;
+    final String address1;
+    final String address2;
+    final String city;
+    final String country;
+    final String firstName;
+    final String lastName;
+    final String phone;
+    final String province;
+    final String zip;
 
     public MailingAddressInput(UserAddress userAddress) {
         PayAddress payAddress = PayAddress.fromUserAddress(userAddress);
@@ -44,19 +44,7 @@ public class MailingAddressInput implements JsonSerializable {
         this.zip = payAddress.zip;
     }
 
-    public static MailingAddressInput fromJsonString(String json) throws JSONException {
-        String expected = "{" +
-            "\"address1\":\"address1\"," +
-            "\"address2\":\"address2, address3, address4, address5\"," +
-            "\"city\":\"locality\"," +
-            "\"country\":\"countryCode\"," +
-            "\"firstName\":\"firstName\"," +
-            "\"lastName\":\"lastName\"," +
-            "\"phone\":\"phoneNumber\"," +
-            "\"province\":\"administrativeArea\"," +
-            "\"zip\":\"postalCode\"" +
-            "}";
-
+    static MailingAddressInput fromJsonString(String json) throws JSONException {
         JSONObject obj = new JSONObject(json);
         String address1 = obj.getString("address1");
         String address2 = obj.getString("address2");

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
@@ -21,15 +21,15 @@ public class MailingAddressInput implements JsonSerializable {
     private static final String PROVINCE = "province";
     private static final String ZIP = "zip";
 
-    final String address1;
-    final String address2;
-    final String city;
-    final String country;
-    final String firstName;
-    final String lastName;
-    final String phone;
-    final String province;
-    final String zip;
+    public final String address1;
+    public final String address2;
+    public final String city;
+    public final String country;
+    public final String firstName;
+    public final String lastName;
+    public final String phone;
+    public final String province;
+    public final String zip;
 
     public MailingAddressInput(UserAddress userAddress) {
         PayAddress payAddress = PayAddress.fromUserAddress(userAddress);
@@ -58,7 +58,6 @@ public class MailingAddressInput implements JsonSerializable {
 
         return new MailingAddressInput(address1, address2, city, country, firstName, lastName, phone, province, zip);
     }
-
 
     //CHECKSTYLE:OFF
     private MailingAddressInput(String address1, String address2, String city,


### PR DESCRIPTION
Comparing string output of the Android JSON library is not a good idea since the ordering of properties is not guaranteed (which is expected but annoying). This patch modifies the class to allow being built from a JSON string so in the test we can reconstruct the object to do assertions on the properties. Also fixes an issue on Travis not accepting the latest build tools because we're using version 26 now.