### PR TITLE
Separate native and web classes

### DIFF
--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/AndroidPayCheckoutSessionTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/AndroidPayCheckoutSessionTest.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.androidpay;
 
 import android.app.Activity;
 import android.app.Fragment;

--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/UnityAndroidPayFragmentTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/UnityAndroidPayFragmentTest.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.androidpay;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -11,6 +11,7 @@ import com.google.android.gms.identity.intents.model.UserAddress;
 import com.google.android.gms.wallet.MaskedWallet;
 import com.google.android.gms.wallet.WalletConstants;
 import com.shopify.buy3.pay.PayCart;
+import com.shopify.unity.buy.MessageCenter;
 import com.shopify.unity.buy.models.MailingAddressInput;
 import com.shopify.unity.buy.utils.TestHelpers;
 

--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/view/widget/ShippingRatesViewTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/view/widget/ShippingRatesViewTest.java
@@ -1,17 +1,19 @@
-package com.shopify.unity.buy.view.widget;
+package com.shopify.unity.buy.androidpay.view.widget;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 
 import com.shopify.unity.buy.R;
+import com.shopify.unity.buy.androidpay.view.viewmodel.ShippingRatesViewModel;
 import com.shopify.unity.buy.utils.ForceLocaleRule;
-import com.shopify.unity.buy.view.viewmodel.TotalSummaryViewModel;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.util.Locale;
@@ -21,7 +23,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Flavio Faria
  */
-public class TotalSummaryViewTest {
+@RunWith(AndroidJUnit4.class)
+public class ShippingRatesViewTest {
 
     @ClassRule
     public static ForceLocaleRule localeTestRule = new ForceLocaleRule(Locale.US);
@@ -35,21 +38,17 @@ public class TotalSummaryViewTest {
 
     @Test
     public void update() throws Exception {
-        TotalSummaryView view = (TotalSummaryView) LayoutInflater
+        ShippingRatesView view = (ShippingRatesView) LayoutInflater
                 .from(themedContext)
-                .inflate(R.layout.view_confirmation_total_summary, null);
+                .inflate(R.layout.view_confirmation_shipping_rates, null);
 
-        TotalSummaryViewModel model = new TotalSummaryViewModel(
-                new BigDecimal(21.48),
-                new BigDecimal(3.20),
-                new BigDecimal(2.32),
-                new BigDecimal(27.00)
+        ShippingRatesViewModel model = new ShippingRatesViewModel(
+                "Shipping line",
+                new BigDecimal(3.45)
         );
 
         view.update(model);
-        assertEquals(view.getSubtotal().getText(), "$21.48");
-        assertEquals(view.getShipping().getText(), "$3.20");
-        assertEquals(view.getTax().getText(), "$2.32");
-        assertEquals(view.getTotal().getText(), "Total: $27.00");
+        assertEquals(view.getShippingLine().getText(), "Shipping line");
+        assertEquals(view.getPrice().getText(), "$3.45");
     }
 }

--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/view/widget/TotalSummaryViewTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/androidpay/view/widget/TotalSummaryViewTest.java
@@ -1,19 +1,17 @@
-package com.shopify.unity.buy.view.widget;
+package com.shopify.unity.buy.androidpay.view.widget;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 
 import com.shopify.unity.buy.R;
+import com.shopify.unity.buy.androidpay.view.viewmodel.TotalSummaryViewModel;
 import com.shopify.unity.buy.utils.ForceLocaleRule;
-import com.shopify.unity.buy.view.viewmodel.ShippingRatesViewModel;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.util.Locale;
@@ -23,8 +21,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Flavio Faria
  */
-@RunWith(AndroidJUnit4.class)
-public class ShippingRatesViewTest {
+public class TotalSummaryViewTest {
 
     @ClassRule
     public static ForceLocaleRule localeTestRule = new ForceLocaleRule(Locale.US);
@@ -38,17 +35,21 @@ public class ShippingRatesViewTest {
 
     @Test
     public void update() throws Exception {
-        ShippingRatesView view = (ShippingRatesView) LayoutInflater
+        TotalSummaryView view = (TotalSummaryView) LayoutInflater
                 .from(themedContext)
-                .inflate(R.layout.view_confirmation_shipping_rates, null);
+                .inflate(R.layout.view_confirmation_total_summary, null);
 
-        ShippingRatesViewModel model = new ShippingRatesViewModel(
-                "Shipping line",
-                new BigDecimal(3.45)
+        TotalSummaryViewModel model = new TotalSummaryViewModel(
+                new BigDecimal(21.48),
+                new BigDecimal(3.20),
+                new BigDecimal(2.32),
+                new BigDecimal(27.00)
         );
 
         view.update(model);
-        assertEquals(view.getShippingLine().getText(), "Shipping line");
-        assertEquals(view.getPrice().getText(), "$3.45");
+        assertEquals(view.getSubtotal().getText(), "$21.48");
+        assertEquals(view.getShipping().getText(), "$3.20");
+        assertEquals(view.getTax().getText(), "$2.32");
+        assertEquals(view.getTotal().getText(), "Total: $27.00");
     }
 }

--- a/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/web/WebIntentFragmentTest.java
+++ b/android/shopify_buy_plugin/src/androidTest/java/com/shopify/unity/buy/web/WebIntentFragmentTest.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.web;
 
 import android.app.Activity;
 import android.app.Fragment;
@@ -10,12 +10,11 @@ import android.support.test.runner.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @MediumTest
@@ -33,7 +32,7 @@ public class WebIntentFragmentTest implements WebIntentListener {
         FragmentTransaction mockFragmentTransaction = Mockito.mock(FragmentTransaction.class);
 
         when(mockFragmentManager.beginTransaction()).thenReturn(mockFragmentTransaction);
-        when(mockFragmentTransaction.add(any(Fragment.class), anyString())).thenReturn(mockFragmentTransaction);
+        when(mockFragmentTransaction.add(ArgumentMatchers.any(Fragment.class), ArgumentMatchers.anyString())).thenReturn(mockFragmentTransaction);
         when(this.mockActivity.getFragmentManager()).thenReturn(mockFragmentManager);
     }
 

--- a/android/shopify_buy_plugin/src/main/AndroidManifest.xml
+++ b/android/shopify_buy_plugin/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
             android:value="true" />
 
         <activity
-            android:name=".ConfirmationActivity"
+            android:name=".androidpay.ConfirmationActivity"
             android:theme="@style/BuyTheme" />
 
     </application>

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MaskedWalletHolder.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MaskedWalletHolder.java
@@ -3,6 +3,8 @@ package com.shopify.unity.buy;
 import android.content.Intent;
 
 import com.google.android.gms.wallet.MaskedWallet;
+import com.shopify.unity.buy.androidpay.ConfirmationActivity;
+import com.shopify.unity.buy.androidpay.UnityAndroidPayFragment;
 
 /**
  * Class that holds a {@link MaskedWallet} instance to be shared across

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MessageCenter.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/MessageCenter.java
@@ -12,12 +12,12 @@ public class MessageCenter {
     private MessageCenter() { }
 
     // Fire and forget sending of messages.
-    static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver) {
+    public static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver) {
         UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
     }
 
     // Send message with callbacks to invoke when complete.
-    static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver, final MessageCallback callbacks) {
+    public static void sendMessageTo(final UnityMessage msg, final UnityMessageReceiver receiver, final MessageCallback callbacks) {
         callbacksInWaiting.put(msg.identifier, callbacks);
         UnityPlayer.UnitySendMessage(receiver.unityDelegateObjectName, receiver.method.name, msg.toJsonString());
     }
@@ -31,17 +31,17 @@ public class MessageCenter {
         }
     }
 
-    static class UnityMessageReceiver {
+    public static class UnityMessageReceiver {
         private final String unityDelegateObjectName;
         private final Method method;
 
-        UnityMessageReceiver(String unityDelegateObjectName, Method method) {
+        public UnityMessageReceiver(String unityDelegateObjectName, Method method) {
             this.unityDelegateObjectName = unityDelegateObjectName;
             this.method = method;
         }
     }
 
-    enum Method {
+    public enum Method {
         ON_NATIVE_MESSAGE("OnNativeMessage"),
         ON_UPDATE_SHIPPING_ADDRESS("OnUpdateShippingAddress"),
         ON_ERROR("OnError"),
@@ -55,7 +55,7 @@ public class MessageCenter {
         }
     }
 
-    interface MessageCallback {
+    public interface MessageCallback {
         void onResponse(String jsonResponse);
     }
 }

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/ShopifyUnityPlayerActivity.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/ShopifyUnityPlayerActivity.java
@@ -3,6 +3,7 @@ package com.shopify.unity.buy;
 import android.app.Fragment;
 import android.content.Intent;
 
+import com.shopify.unity.buy.androidpay.AndroidPayCheckoutSession;
 import com.unity3d.player.UnityPlayerActivity;
 
 public class ShopifyUnityPlayerActivity extends UnityPlayerActivity {

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/UnityMessage.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/UnityMessage.java
@@ -1,5 +1,7 @@
 package com.shopify.unity.buy;
 
+import com.shopify.unity.buy.models.JsonSerializable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/AndroidPayCheckoutSession.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/AndroidPayCheckoutSession.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.androidpay;
 
 import android.app.Activity;
 import android.app.Fragment;
@@ -8,6 +8,8 @@ import android.support.annotation.VisibleForTesting;
 import com.google.android.gms.wallet.WalletConstants;
 import com.shopify.buy3.pay.PayCart;
 import com.shopify.buy3.pay.PayHelper;
+import com.shopify.unity.buy.MessageCenter;
+import com.shopify.unity.buy.UnityMessage;
 import com.shopify.unity.buy.models.MailingAddressInput;
 import com.shopify.unity.buy.models.PricingLineItems;
 import com.shopify.unity.buy.utils.Logger;

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/AndroidPaySessionCallback.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/AndroidPaySessionCallback.java
@@ -1,5 +1,6 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.androidpay;
 
+import com.shopify.unity.buy.MessageCenter;
 import com.shopify.unity.buy.models.MailingAddressInput;
 
 interface AndroidPaySessionCallback {

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/ConfirmationActivity.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/ConfirmationActivity.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.androidpay;
 
 import android.content.Context;
 import android.content.Intent;
@@ -10,10 +10,11 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
 import com.shopify.buy3.pay.PayCart;
-import com.shopify.unity.buy.view.viewmodel.ConfirmationViewModel;
-import com.shopify.unity.buy.view.viewmodel.ShippingRatesViewModel;
-import com.shopify.unity.buy.view.viewmodel.TotalSummaryViewModel;
-import com.shopify.unity.buy.view.widget.ConfirmationView;
+import com.shopify.unity.buy.R;
+import com.shopify.unity.buy.androidpay.view.viewmodel.ConfirmationViewModel;
+import com.shopify.unity.buy.androidpay.view.viewmodel.ShippingRatesViewModel;
+import com.shopify.unity.buy.androidpay.view.viewmodel.TotalSummaryViewModel;
+import com.shopify.unity.buy.androidpay.view.widget.ConfirmationView;
 
 import java.math.BigDecimal;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/UnityAndroidPayFragment.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/UnityAndroidPayFragment.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.androidpay;
 
 import android.app.Fragment;
 import android.content.Intent;
@@ -12,6 +12,8 @@ import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
 import com.shopify.buy3.pay.PayCart;
 import com.shopify.buy3.pay.PayHelper;
+import com.shopify.unity.buy.MaskedWalletHolder;
+import com.shopify.unity.buy.MessageCenter;
 import com.shopify.unity.buy.models.AndroidPayEventResponse;
 import com.shopify.unity.buy.models.MailingAddressInput;
 import com.shopify.unity.buy.models.PricingLineItems;

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/viewmodel/ConfirmationViewModel.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/viewmodel/ConfirmationViewModel.java
@@ -1,8 +1,8 @@
-package com.shopify.unity.buy.view.viewmodel;
+package com.shopify.unity.buy.androidpay.view.viewmodel;
 
 import android.support.annotation.NonNull;
 
-import com.shopify.unity.buy.view.widget.ConfirmationView;
+import com.shopify.unity.buy.androidpay.view.widget.ConfirmationView;
 
 /**
  * View model class that is used to populate a {@link ConfirmationView}.

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/viewmodel/ShippingRatesViewModel.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/viewmodel/ShippingRatesViewModel.java
@@ -1,8 +1,8 @@
-package com.shopify.unity.buy.view.viewmodel;
+package com.shopify.unity.buy.androidpay.view.viewmodel;
 
 import android.support.annotation.NonNull;
 
-import com.shopify.unity.buy.view.widget.ShippingRatesView;
+import com.shopify.unity.buy.androidpay.view.widget.ShippingRatesView;
 
 import java.math.BigDecimal;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/viewmodel/TotalSummaryViewModel.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/viewmodel/TotalSummaryViewModel.java
@@ -1,8 +1,8 @@
-package com.shopify.unity.buy.view.viewmodel;
+package com.shopify.unity.buy.androidpay.view.viewmodel;
 
 import android.support.annotation.NonNull;
 
-import com.shopify.unity.buy.view.widget.TotalSummaryView;
+import com.shopify.unity.buy.androidpay.view.widget.TotalSummaryView;
 
 import java.math.BigDecimal;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/ConfirmationView.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/ConfirmationView.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy.view.widget;
+package com.shopify.unity.buy.androidpay.view.widget;
 
 import android.content.Context;
 import android.support.annotation.Nullable;
@@ -16,7 +16,7 @@ import com.google.android.gms.wallet.fragment.WalletFragmentStyle;
 import com.shopify.buy3.pay.PayHelper;
 import com.shopify.unity.buy.MaskedWalletHolder;
 import com.shopify.unity.buy.R;
-import com.shopify.unity.buy.view.viewmodel.ConfirmationViewModel;
+import com.shopify.unity.buy.androidpay.view.viewmodel.ConfirmationViewModel;
 
 /**
  * Custom view that shows a checkout confirmation screen with broken down prices,

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/ShippingRatesView.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/ShippingRatesView.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy.view.widget;
+package com.shopify.unity.buy.androidpay.view.widget;
 
 import android.content.Context;
 import android.support.annotation.VisibleForTesting;
@@ -8,7 +8,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.shopify.unity.buy.R;
-import com.shopify.unity.buy.view.viewmodel.ShippingRatesViewModel;
+import com.shopify.unity.buy.androidpay.view.viewmodel.ShippingRatesViewModel;
 
 import java.text.NumberFormat;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/TotalSummaryView.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/TotalSummaryView.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy.view.widget;
+package com.shopify.unity.buy.androidpay.view.widget;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
@@ -9,7 +9,7 @@ import android.util.AttributeSet;
 import android.widget.TextView;
 
 import com.shopify.unity.buy.R;
-import com.shopify.unity.buy.view.viewmodel.TotalSummaryViewModel;
+import com.shopify.unity.buy.androidpay.view.viewmodel.TotalSummaryViewModel;
 
 import java.text.NumberFormat;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/Updatable.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/androidpay/view/widget/Updatable.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy.view.widget;
+package com.shopify.unity.buy.androidpay.view.widget;
 
 /**
  * Defines that a view consumes an object that is used to update the view state.

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/JsonSerializable.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/JsonSerializable.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.models;
 
 import org.json.JSONException;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/MailingAddressInput.java
@@ -4,7 +4,6 @@ import android.util.Log;
 
 import com.google.android.gms.identity.intents.model.UserAddress;
 import com.shopify.buy3.pay.PayAddress;
-import com.shopify.unity.buy.JsonSerializable;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/PricingLineItems.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/models/PricingLineItems.java
@@ -3,8 +3,6 @@ package com.shopify.unity.buy.models;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.shopify.unity.buy.JsonSerializable;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/web/WebCheckoutSession.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/web/WebCheckoutSession.java
@@ -1,8 +1,10 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.web;
 
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 
+import com.shopify.unity.buy.MessageCenter;
+import com.shopify.unity.buy.UnityMessage;
 import com.unity3d.player.UnityPlayer;
 
 public class WebCheckoutSession implements WebIntentListener {

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/web/WebIntentFragment.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/web/WebIntentFragment.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.web;
 
 import android.app.Fragment;
 import android.net.Uri;

--- a/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/web/WebIntentListener.java
+++ b/android/shopify_buy_plugin/src/main/java/com/shopify/unity/buy/web/WebIntentListener.java
@@ -1,4 +1,4 @@
-package com.shopify.unity.buy;
+package com.shopify.unity.buy.web;
 
 public interface WebIntentListener {
     void onWebIntentClose();

--- a/android/shopify_buy_plugin/src/main/res/layout/view_confirmation.xml
+++ b/android/shopify_buy_plugin/src/main/res/layout/view_confirmation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.shopify.unity.buy.view.widget.ConfirmationView
+<com.shopify.unity.buy.androidpay.view.widget.ConfirmationView
     android:id="@+id/confirmation"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -68,4 +68,4 @@
             android:text="@string/confirmation_confirm" />
     </FrameLayout>
 
-</com.shopify.unity.buy.view.widget.ConfirmationView>
+</com.shopify.unity.buy.androidpay.view.widget.ConfirmationView>

--- a/android/shopify_buy_plugin/src/main/res/layout/view_confirmation_shipping_rates.xml
+++ b/android/shopify_buy_plugin/src/main/res/layout/view_confirmation_shipping_rates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.shopify.unity.buy.view.widget.ShippingRatesView
+<com.shopify.unity.buy.androidpay.view.widget.ShippingRatesView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -57,4 +57,4 @@
         app:layout_constraintTop_toBottomOf="@+id/change"
         tools:text="$59.60" />
 
-</com.shopify.unity.buy.view.widget.ShippingRatesView>
+</com.shopify.unity.buy.androidpay.view.widget.ShippingRatesView>

--- a/android/shopify_buy_plugin/src/main/res/layout/view_confirmation_total_summary.xml
+++ b/android/shopify_buy_plugin/src/main/res/layout/view_confirmation_total_summary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.shopify.unity.buy.view.widget.TotalSummaryView
+<com.shopify.unity.buy.androidpay.view.widget.TotalSummaryView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -111,4 +111,4 @@
         app:layout_constraintTop_toBottomOf="@+id/view"
         tools:text="Total: $20.00" />
 
-</com.shopify.unity.buy.view.widget.TotalSummaryView>
+</com.shopify.unity.buy.androidpay.view.widget.TotalSummaryView>

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidNativeCheckout.cs.erb
@@ -61,7 +61,7 @@ namespace <%= namespace %>.SDK.Android {
 
             #if !SHOPIFY_MONO_UNIT_TEST
             const bool testing = true; // TODO parametrize for 3rd-party devs
-            using (var androidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.AndroidPayCheckoutSession", testing)) {
+            using (var androidPayCheckoutSession = new AndroidJavaObject("com.shopify.unity.buy.androidpay.AndroidPayCheckoutSession", testing)) {
                 object[] args = { GlobalGameObject.Name, MerchantName, key, pricingLineItemsString, currencyCodeString, CountryCodeString, requiresShipping };
                 if (androidPayCheckoutSession.Call<bool>("checkoutWithAndroidPay", args)) {
                     if (AndroidPayEventBridge == null) {

--- a/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidWebCheckout.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Android/AndroidWebCheckout.cs.erb
@@ -25,7 +25,7 @@ namespace <%= namespace %>.SDK.Android {
         }
 
         private const string UnityPlayerClassName = "com.unity3d.player.UnityPlayer";
-        private const string WebCheckoutSessionClassName = "com.shopify.unity.buy.WebCheckoutSession";
+        private const string WebCheckoutSessionClassName = "com.shopify.unity.buy.web.WebCheckoutSession";
 
         public AndroidWebCheckout(Cart cart, ShopifyClient client) {
             _cart = cart;


### PR DESCRIPTION
Since we're adding more classes recently, I thought the main package was becoming a little confusing and it'd be a good idea to isolate native and web-related classes in their respective classes.

<img width="289" alt="screen shot 2017-10-13 at 1 47 09 pm" src="https://user-images.githubusercontent.com/1800351/31558989-08cc1c3a-b01d-11e7-83ca-ff3ee03a3665.png">

A few considerations:

- `test_android.sh` is passing;
- Unit tests are passing;
- Instrumentation tests are passing;
- Human tests are passing.