### PR TITLE
[Feature] Native Pay Button UI/Script for iOS

### DIFF
--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h
@@ -4,7 +4,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, float height);
+    const char* _GenerateApplePayButtonImage(const char *type, const char* style, 
+                                             float width, float height,
+                                             bool includeMinimumSpacingForIOS);
 #ifdef __cplusplus
 }
 #endif

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h
@@ -1,0 +1,12 @@
+#ifndef ApplePayButtonGenerator_h
+#define ApplePayButtonGenerator_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, float height);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h.meta
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: e41e326d52ccc4ad6abe932af9b2c3a2
+timeCreated: 1507917928
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 1
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
@@ -5,12 +5,24 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+    // Types
+    static char plainType[] = "PLAIN";
+    static char buyType[] = "BUY";
+    static char setupType[] = "SETUP";
+    static char inStoreType[] = "IN_STORE";
+    static char donateType[] = "DONATE";
+    
+    // Styles
+    static char whiteStyle[] = "WHITE";
+    static char blackStyle[] = "BLACK";
+    static char whiteOutlineStyle[] = "WHITE_OUTLINE";
+    
     PKPaymentButtonStyle SBPayButtonStyleFromString(const char *style) {
-        if (strncmp(style, "WHITE", 5) == 0) {
+        if (strncmp(style, whiteStyle, sizeof(whiteStyle)) == 0) {
             return PKPaymentButtonStyleWhite;
-        } else if (strncmp(style, "BLACK", 5) == 0) {
+        } else if (strncmp(style, blackStyle, sizeof(blackStyle)) == 0) {
             return PKPaymentButtonStyleBlack;
-        } else if (strncmp(style, "WHITE_OUTLINE", 11) == 0) {
+        } else if (strncmp(style, whiteOutlineStyle, sizeof(whiteOutlineStyle)) == 0) {
             return PKPaymentButtonStyleWhiteOutline;
         } else {
             return PKPaymentButtonStyleBlack;
@@ -18,15 +30,15 @@ extern "C" {
     }
     
     PKPaymentButtonType SBPayButtonTypeFromString(const char *type) {
-        if (strncmp(type, "PLAIN", 5) == 0) {
+        if (strncmp(type, plainType, sizeof(plainType)) == 0) {
             return PKPaymentButtonTypePlain;
-        } else if (strncmp(type, "BUY", 3) == 0) {
+        } else if (strncmp(type, buyType, sizeof(buyType)) == 0) {
             return PKPaymentButtonTypeBuy;
-        } else if (strncmp(type, "SETUP", 5) == 0) {
+        } else if (strncmp(type, setupType, sizeof(setupType)) == 0) {
             return PKPaymentButtonTypeSetUp;
-        } else if (strncmp(type, "IN_STORE", 6) == 0) {
+        } else if (strncmp(type, inStoreType, sizeof(inStoreType)) == 0) {
             return PKPaymentButtonTypeInStore;
-        } else if (strncmp(type, "DONATE", 6) == 0) {
+        } else if (strncmp(type, donateType, sizeof(donateType)) == 0) {
             return PKPaymentButtonTypeDonate;
         } else {
             return PKPaymentButtonTypePlain;

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
@@ -46,7 +46,9 @@ extern "C" {
     }
     
     // Generates a base64 encoded string containing the rendered image output of a PKPaymentButton from iOS.
-    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, float height, bool includeMinMargin) {
+    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, 
+                                             float height, bool includeMinMargin,
+                                             bool includeMinimumSpacingForIOS) {
         PKPaymentButton* button = [PKPaymentButton buttonWithType:SBPayButtonTypeFromString(type)
                                                             style:SBPayButtonStyleFromString(style)];
         CGSize size = CGSizeMake(width, height);
@@ -54,7 +56,7 @@ extern "C" {
         // According to Apple Design guidelines, there must be a minimum spacing around the Apple Pay button of at least 1/10 the height.
         // We include this as an optional property when rendering the button image.
         CGFloat minSpace = 0;
-        if (false) {
+        if (includeMinimumSpacingForIOS) {
             minSpace = 0.10 * height;
             button.frame = CGRectMake(0, 0, size.width - 2 * minSpace, size.height - 2 * minSpace);
         } else {

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
@@ -34,6 +34,7 @@ extern "C" {
         }
     }
     
+    // Helper method for making a copy of a C String.
     const char* cStringCopy(const char* string) {
         if (string == NULL)
             return NULL;
@@ -44,26 +45,40 @@ extern "C" {
         return res;
     }
     
-    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, float height) {
+    // Generates a base64 encoded string containing the rendered image output of a PKPaymentButton from iOS.
+    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, float height, bool includeMinMargin) {
         PKPaymentButton* button = [PKPaymentButton buttonWithType:SBPayButtonTypeFromString(type)
                                                             style:SBPayButtonStyleFromString(style)];
         CGSize size = CGSizeMake(width, height);
-        button.frame = CGRectMake(0, 0, size.width, size.height);
+                       
+        // According to Apple Design guidelines, there must be a minimum spacing around the Apple Pay button of at least 1/10 the height.
+        // We include this as an optional property when rendering the button image.
+        CGFloat minSpace = 0;
+        if (false) {
+            minSpace = 0.10 * height;
+            button.frame = CGRectMake(0, 0, size.width - 2 * minSpace, size.height - 2 * minSpace);
+        } else {
+            button.frame = CGRectMake(0, 0, size.width, size.height);
+        }
         
         UnityAppController* unityController = (UnityAppController*)UIApplication.sharedApplication.delegate;
         [unityController.rootView insertSubview:button atIndex:0];
         
-        // Take snapshot of the Apple Pay button
+        // Take snapshot of the Apple Pay button.
         UIGraphicsBeginImageContextWithOptions(size, NO, [UIScreen mainScreen].scale);
         CGContextRef context = UIGraphicsGetCurrentContext();
+        CGContextTranslateCTM(context, minSpace, minSpace);
         [button.layer renderInContext:context];
         UIImage* snapshot = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
         
         [button removeFromSuperview];
         
-        // Convert to bytes and pass to Unity
+        // Convert to bytes and pass to Unity.
         NSString *byteArray = [UIImagePNGRepresentation(snapshot) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+        
+        // We create a malloc'ed copy of the string here so we can manually release the memory associated
+        // with it on the Unity side using Marshal.FreeHGlobal.
         return cStringCopy([byteArray UTF8String]);
     }
 #ifdef __cplusplus

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <PassKit/PassKit.h>
 #import "UnityAppController.h"
@@ -7,11 +6,11 @@
 extern "C" {
 #endif
     PKPaymentButtonStyle SBPayButtonStyleFromString(const char *style) {
-        if (strcmp(style, "white") == 0) {
+        if (strncmp(style, "WHITE", 5) == 0) {
             return PKPaymentButtonStyleWhite;
-        } else if (strcmp(style, "black") == 0) {
+        } else if (strncmp(style, "BLACK", 5) == 0) {
             return PKPaymentButtonStyleBlack;
-        } else if (strcmp(style, "whiteOutline") == 0) {
+        } else if (strncmp(style, "WHITE_OUTLINE", 11) == 0) {
             return PKPaymentButtonStyleWhiteOutline;
         } else {
             return PKPaymentButtonStyleBlack;
@@ -19,15 +18,15 @@ extern "C" {
     }
     
     PKPaymentButtonType SBPayButtonTypeFromString(const char *type) {
-        if (strcmp(type, "plain") == 0) {
+        if (strncmp(type, "PLAIN", 5) == 0) {
             return PKPaymentButtonTypePlain;
-        } else if (strcmp(type, "buy") == 0) {
+        } else if (strncmp(type, "BUY", 3) == 0) {
             return PKPaymentButtonTypeBuy;
-        } else if (strcmp(type, "setUp") == 0) {
+        } else if (strncmp(type, "SETUP", 5) == 0) {
             return PKPaymentButtonTypeSetUp;
-        } else if (strcmp(type, "inStore") == 0) {
+        } else if (strncmp(type, "IN_STORE", 6) == 0) {
             return PKPaymentButtonTypeInStore;
-        } else if (strcmp(type, "donate") == 0) {
+        } else if (strncmp(type, "DONATE", 6) == 0) {
             return PKPaymentButtonTypeDonate;
         } else {
             return PKPaymentButtonTypePlain;
@@ -35,13 +34,12 @@ extern "C" {
     }
     
     // Helper method for making a copy of a C String.
-    const char* cStringCopy(const char* string) {
+    const char* cStringCopy(const char* string, size_t length) {
         if (string == NULL)
             return NULL;
         
-        char* res = (char*)malloc(strlen(string) + 1);
-        strcpy(res, string);
-        
+        char* res = (char*)malloc((length + 1) * sizeof(char));
+        strncpy(res, string, length + 1);
         return res;
     }
     
@@ -81,7 +79,8 @@ extern "C" {
         
         // We create a malloc'ed copy of the string here so we can manually release the memory associated
         // with it on the Unity side using Marshal.FreeHGlobal.
-        return cStringCopy([byteArray UTF8String]);
+        const char *utf8String = [byteArray UTF8String];
+        return cStringCopy(utf8String, strlen(utf8String));
     }
 #ifdef __cplusplus
 }

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
@@ -1,0 +1,72 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <PassKit/PassKit.h>
+#import "UnityAppController.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    PKPaymentButtonStyle SBPayButtonStyleFromString(const char *style) {
+        if (strcmp(style, "white") == 0) {
+            return PKPaymentButtonStyleWhite;
+        } else if (strcmp(style, "black") == 0) {
+            return PKPaymentButtonStyleBlack;
+        } else if (strcmp(style, "whiteOutline") == 0) {
+            return PKPaymentButtonStyleWhiteOutline;
+        } else {
+            return PKPaymentButtonStyleBlack;
+        }
+    }
+    
+    PKPaymentButtonType SBPayButtonTypeFromString(const char *type) {
+        if (strcmp(type, "plain") == 0) {
+            return PKPaymentButtonTypePlain;
+        } else if (strcmp(type, "buy") == 0) {
+            return PKPaymentButtonTypeBuy;
+        } else if (strcmp(type, "setUp") == 0) {
+            return PKPaymentButtonTypeSetUp;
+        } else if (strcmp(type, "inStore") == 0) {
+            return PKPaymentButtonTypeInStore;
+        } else if (strcmp(type, "donate") == 0) {
+            return PKPaymentButtonTypeDonate;
+        } else {
+            return PKPaymentButtonTypePlain;
+        }
+    }
+    
+    const char* cStringCopy(const char* string) {
+        if (string == NULL)
+            return NULL;
+        
+        char* res = (char*)malloc(strlen(string) + 1);
+        strcpy(res, string);
+        
+        return res;
+    }
+    
+    const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, float height) {
+        PKPaymentButton* button = [PKPaymentButton buttonWithType:SBPayButtonTypeFromString(type)
+                                                            style:SBPayButtonStyleFromString(style)];
+        CGSize size = CGSizeMake(width, height);
+        button.frame = CGRectMake(0, 0, size.width, size.height);
+        
+        UnityAppController* unityController = (UnityAppController*)UIApplication.sharedApplication.delegate;
+        [unityController.rootView insertSubview:button atIndex:0];
+        
+        // Take snapshot of the Apple Pay button
+        UIGraphicsBeginImageContextWithOptions(size, NO, [UIScreen mainScreen].scale);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        [button.layer renderInContext:context];
+        UIImage* snapshot = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        
+        [button removeFromSuperview];
+        
+        // Convert to bytes and pass to Unity
+        NSString *byteArray = [UIImagePNGRepresentation(snapshot) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+        return cStringCopy([byteArray UTF8String]);
+    }
+#ifdef __cplusplus
+}
+#endif
+

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm.meta
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm.meta
@@ -1,0 +1,39 @@
+fileFormatVersion: 2
+guid: cf91b986d8ad847bdb8c0eff757aa4d9
+timeCreated: 1507917928
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+    data:
+      first:
+        iPhone: iOS
+      second:
+        enabled: 1
+        settings: {}
+    data:
+      first:
+        tvOS: tvOS
+      second:
+        enabled: 1
+        settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -165,7 +165,7 @@ module GraphQLGenerator
         SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver
         SDK/iOS/ApplePayPayment
         SDK/NativePayment
-        UI/ApplePayButtonUI
+        UI/NativePayButtonUI
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -163,7 +163,9 @@ module GraphQLGenerator
         SDK/iOS/iOSWebCheckout
         SDK/iOS/iOSNativeCheckout
         SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver
+        SDK/iOS/ApplePayPayment
         SDK/NativePayment
+        UI/ApplePayButtonUI
       ).each do |class_file_name|
         directory = "#{path}/#{File.dirname(class_file_name)}"
 

--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -163,7 +163,6 @@ module GraphQLGenerator
         SDK/iOS/iOSWebCheckout
         SDK/iOS/iOSNativeCheckout
         SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver
-        SDK/iOS/ApplePayPayment
         SDK/NativePayment
         UI/NativePayButtonUI
       ).each do |class_file_name|

--- a/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/Editor/BuildPipeline/iOSPostProcessor.cs.erb
@@ -18,6 +18,7 @@ namespace <%= namespace %>.Editor.BuildPipeline {
                 return;
 
             var project = new ExtendedPBXProject(buildPath);
+            SetCorrectTestsTarget(project);
             SetBuildProperties(project);
             SetSwiftInterfaceHeader(project);
             project.Save();
@@ -65,6 +66,18 @@ namespace <%= namespace %>.Editor.BuildPipeline {
                 }
 
                 File.WriteAllLines (swiftInterfaceHeaderPath, lines);
+            }
+        }
+
+        /// Sets the correct target for Shopify Tests
+        private static void SetCorrectTestsTarget(ExtendedPBXProject project) {
+            string testPath = Path.Combine(project.BuildPath, "Libraries/Shopify/Plugins/iOS/Shopify/BuyTests/");
+            var testDirectory = new DirectoryInfo(testPath);
+
+            try {
+                project.SetFilesInDirectoryToTestTarget(testDirectory);
+            } catch (Exception e) {
+                Debug.Log(e.Message);
             }
         }
     }

--- a/scripts/generator/graphql_generator/csharp/UI/ApplePayButtonUI.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/UI/ApplePayButtonUI.cs.erb
@@ -1,0 +1,58 @@
+namespace <%= namespace %>.UI {
+    using UnityEngine;
+    using UnityEngine.UI;
+
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    public enum ApplePayButtonStyle {
+        plain
+    }
+
+    public enum ApplePayButtonType {
+        pay
+    }
+
+    public class ApplePayButtonUI : MonoBehaviour {
+        public ApplePayButtonStyle buttonStyle;
+
+        public ApplePayButtonType buttonType;
+
+        [DllImport ("__Internal")]
+        private static extern string _GenerateApplePayButtonImage(string type, string style, float width, float height);
+
+        private Image buttonImage;
+
+        public void Start() {
+            buttonImage = this.gameObject.GetComponent<Image>();
+
+            var rectTransform = this.gameObject.GetComponent<RectTransform>();
+            UpdateImage(rectTransform);
+        }
+
+        public void UpdateImage(RectTransform transform) {
+            // Ask iOS to generate us an image of the native Apple Pay button.
+            var base64ImageString = _GenerateApplePayButtonImage(
+                buttonType.ToString(), 
+                buttonStyle.ToString(), 
+                transform.rect.width, 
+                transform.rect.height
+            );
+
+            byte[] imageBytes = System.Convert.FromBase64String(base64ImageString);
+
+            // Create a Texture2D object from the raw byte data from iOS
+            var imageTexture = new Texture2D((int)transform.rect.width, (int)transform.rect.height, TextureFormat.RGBA32, false);
+            imageTexture.LoadRawTextureData(imageBytes);
+            imageTexture.Apply();
+
+            // Create Sprite and assign to the image component.
+            buttonImage.sprite = Sprite.Create(
+                imageTexture, 
+                new Rect(0, 0, imageTexture.width, imageTexture.height), 
+                new Vector2(0.5f, 0.5f), 
+                100.0f
+            );
+        }
+    }
+}

--- a/scripts/generator/graphql_generator/csharp/UI/ApplePayButtonUI.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/UI/ApplePayButtonUI.cs.erb
@@ -4,24 +4,57 @@ namespace <%= namespace %>.UI {
 
     using System.Runtime.InteropServices;
     using System.Text;
+    using System;
 
+    /// <summary>
+    /// The Apple Pay payment button style C# enum. See https://developer.apple.com/documentation/passkit/pkpaymentbuttonstyle
+    /// for all available options.
+    /// </summary>
     public enum ApplePayButtonStyle {
-        plain
+        white,
+        whiteOutline,
+        black
     }
 
+    /// <summary>
+    /// The Apple Pay payment button type C# enum. See https://developer.apple.com/documentation/passkit/pkpaymentbuttontype
+    /// for all available options.
+    /// </summary>
     public enum ApplePayButtonType {
-        pay
+        plain,
+        buy,
+        setUp,
+        inStore,
+        donate
     }
 
+    /// <summary>
+    /// UI Script that fills in an attached UI Image component with a platform-rendered Apple Pay button.
+    /// </summary>
     public class ApplePayButtonUI : MonoBehaviour {
+        /// <summary>
+        /// The Apple Pay payment button style. See https://developer.apple.com/documentation/passkit/pkpaymentbuttonstyle
+        /// for all available options.
+        /// </summary>
         public ApplePayButtonStyle buttonStyle;
 
+        /// <summary>
+        /// The Apple Pay payment button type. See https://developer.apple.com/documentation/passkit/pkpaymentbuttontype
+        /// for all available options.
+        /// </summary>
         public ApplePayButtonType buttonType;
 
+        /// <summary>
+        /// When set to true, the the Apple Pay button image will include the 10% minimum spacing around the 
+        /// button image required by Apple's design guidelines.
+        /// </summary>
+        public bool includeMinimumSpacing;
+
         [DllImport ("__Internal")]
-        private static extern string _GenerateApplePayButtonImage(string type, string style, float width, float height);
+        private static extern IntPtr _GenerateApplePayButtonImage(string type, string style, float width, float height);
 
         private Image buttonImage;
+        private Texture2D imageTexture;
 
         public void Start() {
             buttonImage = this.gameObject.GetComponent<Image>();
@@ -30,21 +63,25 @@ namespace <%= namespace %>.UI {
             UpdateImage(rectTransform);
         }
 
-        public void UpdateImage(RectTransform transform) {
+        private void UpdateImage(RectTransform transform) {
             // Ask iOS to generate us an image of the native Apple Pay button.
-            var base64ImageString = _GenerateApplePayButtonImage(
+            var imageStringPtr = _GenerateApplePayButtonImage(
                 buttonType.ToString(), 
                 buttonStyle.ToString(), 
                 transform.rect.width, 
                 transform.rect.height
             );
 
-            byte[] imageBytes = System.Convert.FromBase64String(base64ImageString);
+            string managedBase64ImageString = Marshal.PtrToStringAnsi(imageStringPtr);
+            byte[] imageBytes = System.Convert.FromBase64String(managedBase64ImageString);
 
             // Create a Texture2D object from the raw byte data from iOS
-            var imageTexture = new Texture2D((int)transform.rect.width, (int)transform.rect.height, TextureFormat.RGBA32, false);
-            imageTexture.LoadRawTextureData(imageBytes);
+            imageTexture = new Texture2D(1, 1);
+            imageTexture.LoadImage(imageBytes);
             imageTexture.Apply();
+
+            // Free malloced base64 string from iOS
+            Marshal.FreeHGlobal(imageStringPtr);
 
             // Create Sprite and assign to the image component.
             buttonImage.sprite = Sprite.Create(
@@ -55,4 +92,4 @@ namespace <%= namespace %>.UI {
             );
         }
     }
-}
+    }

--- a/scripts/generator/graphql_generator/csharp/UI/NativePayButtonUI.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/UI/NativePayButtonUI.cs.erb
@@ -28,30 +28,29 @@ namespace <%= namespace %>.UI {
         donate
     }
 
-    /// <summary>
-    /// UI Script that fills in an attached UI Image component with a platform-rendered Apple Pay button.
-    /// </summary>
-    public class ApplePayButtonUI : MonoBehaviour {
+    public class NativePayButtonUI : MonoBehaviour {
         /// <summary>
         /// The Apple Pay payment button style. See https://developer.apple.com/documentation/passkit/pkpaymentbuttonstyle
         /// for all available options.
         /// </summary>
-        public ApplePayButtonStyle buttonStyle;
+        public ApplePayButtonStyle applePayButtonStyle;
 
         /// <summary>
         /// The Apple Pay payment button type. See https://developer.apple.com/documentation/passkit/pkpaymentbuttontype
         /// for all available options.
         /// </summary>
-        public ApplePayButtonType buttonType;
+        public ApplePayButtonType applePayButtonType;
 
         /// <summary>
         /// When set to true, the the Apple Pay button image will include the 10% minimum spacing around the 
         /// button image required by Apple's design guidelines.
         /// </summary>
-        public bool includeMinimumSpacing;
+        public bool includeMinimumSpacingForIOS;
 
         [DllImport ("__Internal")]
-        private static extern IntPtr _GenerateApplePayButtonImage(string type, string style, float width, float height);
+        private static extern IntPtr _GenerateApplePayButtonImage(string type, string style, 
+                                                                  float width, float height, 
+                                                                  bool includeMinimumSpacingForIOS);
 
         private Image buttonImage;
         private Texture2D imageTexture;
@@ -59,17 +58,20 @@ namespace <%= namespace %>.UI {
         public void Start() {
             buttonImage = this.gameObject.GetComponent<Image>();
 
-            var rectTransform = this.gameObject.GetComponent<RectTransform>();
-            UpdateImage(rectTransform);
+            #if UNITY_IOS
+            GenerateApplePayImage();
+            #endif            
         }
 
-        private void UpdateImage(RectTransform transform) {
+        private void GenerateApplePayImage() {
+            var rectTransform = this.gameObject.GetComponent<RectTransform>();
             // Ask iOS to generate us an image of the native Apple Pay button.
             var imageStringPtr = _GenerateApplePayButtonImage(
-                buttonType.ToString(), 
-                buttonStyle.ToString(), 
-                transform.rect.width, 
-                transform.rect.height
+                applePayButtonType.ToString(), 
+                applePayButtonStyle.ToString(), 
+                rectTransform.rect.width, 
+                rectTransform.rect.height,
+                includeMinimumSpacingForIOS
             );
 
             string managedBase64ImageString = Marshal.PtrToStringAnsi(imageStringPtr);
@@ -80,7 +82,7 @@ namespace <%= namespace %>.UI {
             imageTexture.LoadImage(imageBytes);
             imageTexture.Apply();
 
-            // Free malloced base64 string from iOS
+            // Free malloc'ed base64 string from iOS
             Marshal.FreeHGlobal(imageStringPtr);
 
             // Create Sprite and assign to the image component.
@@ -91,5 +93,9 @@ namespace <%= namespace %>.UI {
                 100.0f
             );
         }
+
+        private void GenerateAndroidPayImage() {
+            // TODO: Get a render of the Android Pay button for use in Unity.
+        }
     }
-    }
+}

--- a/scripts/generator/graphql_generator/csharp/UI/NativePayButtonUI.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/UI/NativePayButtonUI.cs.erb
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace <%= namespace %>.UI {
     using UnityEngine;
     using UnityEngine.UI;
@@ -11,9 +12,9 @@ namespace <%= namespace %>.UI {
     /// for all available options.
     /// </summary>
     public enum ApplePayButtonStyle {
-        white,
-        whiteOutline,
-        black
+        WHITE,
+        WHITE_OUTLINE,
+        BLACK
     }
 
     /// <summary>
@@ -21,11 +22,11 @@ namespace <%= namespace %>.UI {
     /// for all available options.
     /// </summary>
     public enum ApplePayButtonType {
-        plain,
-        buy,
-        setUp,
-        inStore,
-        donate
+        PLAIN,
+        BUY,
+        SETUP,
+        IN_STORE,
+        DONATE 
     }
 
     public class NativePayButtonUI : MonoBehaviour {
@@ -47,11 +48,6 @@ namespace <%= namespace %>.UI {
         /// </summary>
         public bool includeMinimumSpacingForIOS;
 
-        [DllImport ("__Internal")]
-        private static extern IntPtr _GenerateApplePayButtonImage(string type, string style, 
-                                                                  float width, float height, 
-                                                                  bool includeMinimumSpacingForIOS);
-
         private Image buttonImage;
         private Texture2D imageTexture;
 
@@ -60,8 +56,16 @@ namespace <%= namespace %>.UI {
 
             #if UNITY_IOS
             GenerateApplePayImage();
+            #elif UNITY_ANDROID
+            GenerateAndroidPayImage();
             #endif            
         }
+
+        #if UNITY_IOS
+        [DllImport ("__Internal")]
+        private static extern IntPtr _GenerateApplePayButtonImage(string type, string style, 
+                                                                  float width, float height, 
+                                                                  bool includeMinimumSpacingForIOS);
 
         private void GenerateApplePayImage() {
             var rectTransform = this.gameObject.GetComponent<RectTransform>();
@@ -93,9 +97,13 @@ namespace <%= namespace %>.UI {
                 100.0f
             );
         }
+        #endif
 
+        #if UNITY_ANDROID
         private void GenerateAndroidPayImage() {
             // TODO: Get a render of the Android Pay button for use in Unity.
         }
+        #endif
     }
 }
+#endif

--- a/scripts/test_iOS.sh
+++ b/scripts/test_iOS.sh
@@ -31,7 +31,7 @@ xcodebuild test \
     -project "$IOS_PROJECT_PATH" \
     -sdk iphonesimulator \
     -scheme Unity-iPhone \
-    -destination 'platform=iOS Simulator,OS=11.0,name=iPhone 6'
+    -destination 'platform=iOS Simulator,OS=11.0.1,name=iPhone 6'
 
 IOS_TEST_RESULT=$?
 


### PR DESCRIPTION
Adds a `NativePayButtonUI` script and associated native plugin code for IOS to generate the Apple Pay button from system frameworks.