### PR TITLE
Use C# "decimal" type for GraphQL "Decimal" one

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -74,6 +74,10 @@ module GraphQLGenerator
         graph_type: 'ID',
         csharp_type: 'string',
       ),
+      Scalar.new(
+        graph_type: 'Decimal',
+        csharp_type: 'decimal',
+      ),
     ]
 
 


### PR DESCRIPTION
Fixes C# type generation after schema change on server side.