### PR TITLE
Add non-Google dependencies to libs folder

### DIFF
--- a/android/shopify_buy_plugin/build.gradle
+++ b/android/shopify_buy_plugin/build.gradle
@@ -50,22 +50,33 @@ dependencies {
     testCompile 'org.json:json:20140107'
 }
 
-task copyAARToPlugins(type: Copy) {
-
+task copyBinariesToPlugins(type: Copy) {
+    def destination = '../../Assets/Shopify/Plugins/Android/libs'
     from('build/outputs/aar') {
         rename "shopify_buy_plugin-release.aar", "shopify_buy_plugin.aar"
         exclude '*-debug.aar'
     }
-    into '../../Assets/Shopify/Plugins/Android/libs'
-
+    into destination
+    configurations.compile.files.findAll { file ->
+        !file.name.equals("classes.jar") &&
+                !file.absolutePath.matches(".*com.android.support.*") &&
+                !file.absolutePath.matches(".*com.google.android.*") &&
+                !file.absolutePath.matches(".*android.arch.*")
+    } each {
+        println "Copying ${it} to ${destination}"
+        from(it.parent) {
+            include '*.jar'
+            include '*.aar'
+        } into destination
+    }
     outputs.upToDateWhen { false }
 }
 
 task assembleUnity {
-    dependsOn 'assembleRelease', 'copyAARToPlugins'
+    dependsOn 'assembleRelease', 'copyBinariesToPlugins'
 }
 
-copyAARToPlugins.mustRunAfter('assembleRelease')
+copyBinariesToPlugins.mustRunAfter('assembleRelease')
 
 task checkstyle(type: Checkstyle) {
     configFile = new File(rootDir, "checkstyle/config.xml")


### PR DESCRIPTION
Automatically extracts and copies any non-Google JAR or AAR dependency into the libs folder whenever `build_android.sh` is run.