### PR TITLE
[Fix] Destroy web checkout message receiver after we've successfully completed a checkout

### DIFF
--- a/scripts/generator/graphql_generator/csharp/SDK/WebCheckoutMessageReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/WebCheckoutMessageReceiver.cs.erb
@@ -64,6 +64,7 @@ namespace <%= namespace %>.SDK {
                     var checkout = (Checkout) response.node();
                     if (checkout.completedAt() != null) {
                         OnSuccess();
+                        Destroy(this);
                     } else {
                         OnCancelled();
                     }


### PR DESCRIPTION
Fixes https://github.com/Shopify/unity-buy-sdk/issues/364