### PR TITLE
Create sanity checks + folder structure for UI Toolkit

### DIFF
--- a/Assets/Shopify/UIToolkit.meta
+++ b/Assets/Shopify/UIToolkit.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 15d3d88af4f4740b0a2fa5edcd585f35
+folderAsset: yes
+timeCreated: 1510757628
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test.meta
+++ b/Assets/Shopify/UIToolkit/Test.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ffad489d449f348daa4404dcca9ef43e
+folderAsset: yes
+timeCreated: 1510757648
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Integration.meta
+++ b/Assets/Shopify/UIToolkit/Test/Integration.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2320c433453e4488882c046fd7a564db
+folderAsset: yes
+timeCreated: 1510758025
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Integration/TestSanity.cs
+++ b/Assets/Shopify/UIToolkit/Test/Integration/TestSanity.cs
@@ -1,0 +1,10 @@
+﻿namespace Shopify.UIToolkit.Test.Integration {
+	using UnityEngine;
+
+	[IntegrationTest.DynamicTest("UIToolkitIntegrationTests")]
+    public class TestSanity : MonoBehaviour {
+        public void Start() {
+            IntegrationTest.Pass();
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Test/Integration/TestSanity.cs.meta
+++ b/Assets/Shopify/UIToolkit/Test/Integration/TestSanity.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b7cc0f5581265480d94bf7f6b711996a
+timeCreated: 1510758045
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Integration/UIToolkitIntegrationTests.unity
+++ b/Assets/Shopify/UIToolkit/Test/Integration/UIToolkitIntegrationTests.unity
@@ -1,0 +1,151 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.3731316, g: 0.38074902, b: 0.3587254, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 8
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 3
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_ShadowMaskMode: 2
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1317015745
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1317015747}
+  - component: {fileID: 1317015746}
+  m_Layer: 0
+  m_Name: TestRunner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1317015746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1317015745}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c3afc1c624179749bcdecf7b0224902, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentTest: {fileID: 0}
+--- !u!4 &1317015747
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1317015745}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Shopify/UIToolkit/Test/Integration/UIToolkitIntegrationTests.unity.meta
+++ b/Assets/Shopify/UIToolkit/Test/Integration/UIToolkitIntegrationTests.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 448b4344150c247bdaa5dd2bb343a6df
+timeCreated: 1510757722
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Unit.meta
+++ b/Assets/Shopify/UIToolkit/Test/Unit.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6b80381e900bb4e7cba54cc9ee905062
+folderAsset: yes
+timeCreated: 1510759599
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor.meta
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a1fa9d03396f04c6a905a33b25c2f7e1
+folderAsset: yes
+timeCreated: 1510759608
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSanity.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSanity.cs
@@ -1,0 +1,11 @@
+﻿namespace Shopify.UIToolkit.Test.Unit {
+	using NUnit.Framework;
+
+    [TestFixture]
+    public class TestSanity {
+		[Test]
+		public void TestShouldPass() {
+            Assert.True(true);
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSanity.cs.meta
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSanity.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6a9db09d111684750a65b92bf7f513e7
+timeCreated: 1510759899
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds some future-disposable sanity tests into the folder structure I want to use for the UI Toolkit project. This wont be packaged into the unitypackage just yet and I double checked that unity is running the tests that I care about in ci.

