### PR TITLE
Adds dev configuration file for shopify employees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+source 'https://rubygems.org'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   1.16.0

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,23 @@
+name: unity-buy-sdk
+
+up:
+  - homebrew:
+    - openssl
+  - ruby: 2.3.3
+  - bundler
+
+commands:
+  generate:
+    syntax:
+      argument: type
+    desc:   'generate classes from erb class templates'
+    run:    scripts/generate.sh
+  package:
+    syntax:
+      argument: type
+    desc:   'Publish a new unitypackage for the sdk'
+    run:    scripts/publish.sh
+  test:
+    run: scripts/test.sh
+  unitytest:
+    run: scripts/test_unity.sh


### PR DESCRIPTION
This adds a dev.yml and a gemfile which helps shopify employees
configure their environment faster. It is not required and won't affect
anything if you are not a shopify employee and don't have dev installed.