### PR TITLE
[UI Toolkit] Scaffold Single Product Theme

### DIFF
--- a/Assets/Shopify/UIToolkit/Themes/SingleProductTheme.cs
+++ b/Assets/Shopify/UIToolkit/Themes/SingleProductTheme.cs
@@ -1,0 +1,15 @@
+﻿namespace Shopify.UIToolkit {
+    using Shopify.Unity;
+
+    /// <summary>
+    /// Override this class to create a theme that sells a single product
+    /// </summary>
+    public abstract class SingleProductTheme : ThemeBase {
+        /// <summary>
+        /// Called when the theme should show information about the product it's selling
+        /// </summary>
+        /// <param name="product">The product that should be displayed</param>
+        /// <param name="variants">The variants of the product that should be displayed</param>
+        public abstract void OnShouldShowProduct(Product product, ProductVariant[] variants);
+    }
+}

--- a/Assets/Shopify/UIToolkit/Themes/SingleProductTheme.cs.meta
+++ b/Assets/Shopify/UIToolkit/Themes/SingleProductTheme.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 099c50b521cf5451f8b1a1c7476be666
+timeCreated: 1511292866
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Provides the scaffolding and docs for a single product theme

avoiding the binding methods right now because they depend on the theme controllers being around.