### PR TITLE
Product pagination

### DIFF
--- a/Assets/Editor/MockLoaderProducts.cs
+++ b/Assets/Editor/MockLoaderProducts.cs
@@ -21,9 +21,9 @@ namespace Shopify.Tests {
 
                 DefaultQueries.products.ShopProducts(
                     query: query,
-                    first: DefaultQueries.MaxProductsSize,
+                    first: DefaultQueries.MaxProductPageSize,
                     imageResolutions: ShopifyClient.DefaultImageResolutions,
-                    after: i > 0 ? (i * DefaultQueries.MaxProductsSize - 1).ToString() : null
+                    after: i > 0 ? (i * DefaultQueries.MaxProductPageSize - 1).ToString() : null
                 );
 
                 string response = String.Format(@"{{
@@ -48,8 +48,8 @@ namespace Shopify.Tests {
         private string GetProductEdges(int page) {
             StringBuilder edges = new StringBuilder();
 
-            for(int i = 0; i < DefaultQueries.MaxProductsSize; i++) {
-                int product = page * DefaultQueries.MaxProductsSize + i;
+            for(int i = 0; i < DefaultQueries.MaxProductPageSize; i++) {
+                int product = page * DefaultQueries.MaxProductPageSize + i;
                 bool imagesHasNextPage = product == 1 || product == 2;
                 bool variantsHasNextPage = product == 2;
 
@@ -127,7 +127,7 @@ namespace Shopify.Tests {
                 GetCollectionsOnProduct(0, product, 1),
                 UtilsMockLoader.GetJSONBool(false),
                 resolutionImageResponses.ToString(),
-                i < DefaultQueries.MaxProductsSize - 1 ? "," : ""));
+                i < DefaultQueries.MaxProductPageSize - 1 ? "," : ""));
             }
 
             return edges.ToString();

--- a/Assets/Editor/MockLoaderProducts.cs
+++ b/Assets/Editor/MockLoaderProducts.cs
@@ -21,9 +21,9 @@ namespace Shopify.Tests {
 
                 DefaultQueries.products.ShopProducts(
                     query: query,
-                    first: DefaultQueries.MaxPageSize,
+                    first: DefaultQueries.MaxProductsSize,
                     imageResolutions: ShopifyClient.DefaultImageResolutions,
-                    after: i > 0 ? (i * DefaultQueries.MaxPageSize - 1).ToString() : null
+                    after: i > 0 ? (i * DefaultQueries.MaxProductsSize - 1).ToString() : null
                 );
 
                 string response = String.Format(@"{{
@@ -48,8 +48,8 @@ namespace Shopify.Tests {
         private string GetProductEdges(int page) {
             StringBuilder edges = new StringBuilder();
 
-            for(int i = 0; i < DefaultQueries.MaxPageSize; i++) {
-                int product = page * DefaultQueries.MaxPageSize + i;
+            for(int i = 0; i < DefaultQueries.MaxProductsSize; i++) {
+                int product = page * DefaultQueries.MaxProductsSize + i;
                 bool imagesHasNextPage = product == 1 || product == 2;
                 bool variantsHasNextPage = product == 2;
 
@@ -127,7 +127,7 @@ namespace Shopify.Tests {
                 GetCollectionsOnProduct(0, product, 1),
                 UtilsMockLoader.GetJSONBool(false),
                 resolutionImageResponses.ToString(),
-                i < DefaultQueries.MaxPageSize - 1 ? "," : ""));
+                i < DefaultQueries.MaxProductsSize - 1 ? "," : ""));
             }
 
             return edges.ToString();

--- a/Assets/Editor/TestShopify.cs
+++ b/Assets/Editor/TestShopify.cs
@@ -5,6 +5,7 @@ namespace Shopify.Tests
     using Shopify.Unity;
     using Shopify.Unity.GraphQL;
     using System.Text.RegularExpressions;
+    using Shopify.Unity.SDK;
 
     [TestFixture]
     public class TestShopify {
@@ -93,17 +94,18 @@ namespace Shopify.Tests
         }
 
         [Test]
-        public void TestProductsAll() {
+        public void TestProducts() {
             List<Product> products = null;
 
             ShopifyBuy.Init(new MockLoader());
 
-            ShopifyBuy.Client().products(callback: (p, error) => {
+            ShopifyBuy.Client().products(callback: (p, error, after) => {
                 products = p;
                 Assert.IsNull(error);
+                Assert.AreEqual((DefaultQueries.MaxProductsSize - 1).ToString(), after);
             });
 
-            Assert.AreEqual(MockLoaderProducts.CountProductsPages * MockLoader.PageSize, products.Count);
+            Assert.AreEqual(DefaultQueries.MaxProductsSize, products.Count);
             Assert.AreEqual("Product0", products[0].title());
             Assert.AreEqual("Product1", products[1].title());
 
@@ -126,12 +128,13 @@ namespace Shopify.Tests
 
             ShopifyBuy.Init(new MockLoader());
 
-            ShopifyBuy.Client().products(callback: (p, error) => {
+            ShopifyBuy.Client().products(callback: (p, error, after) => {
                 products = p;
                 Assert.IsNull(error);
-            }, first: 250);
+                Assert.AreEqual((DefaultQueries.MaxProductsSize - 1).ToString(), after);
+            }, first: DefaultQueries.MaxProductsSize);
 
-            Assert.AreEqual(250, products.Count);
+            Assert.AreEqual(DefaultQueries.MaxProductsSize, products.Count);
         }
 
         [Test]
@@ -154,33 +157,20 @@ namespace Shopify.Tests
         }
 
         [Test]
-        public void TestCollectionsFirst() {
-            List<Product> products = null;
-
-            ShopifyBuy.Init(new MockLoader());
-
-            ShopifyBuy.Client().products(callback: (p, error) => {
-                products = p;
-                Assert.IsNull(error);
-            }, first: 250);
-
-            Assert.AreEqual(250, products.Count);
-        }
-
-        [Test]
         public void TestProductsAfter() {
             List<Product> products = null;
 
             ShopifyBuy.Init(new MockLoader());
 
-            ShopifyBuy.Client().products(callback: (p, error) => {
+            ShopifyBuy.Client().products(callback: (p, error, after) => {
                 products = p;
                 Assert.IsNull(error);
-            }, first: 250, after: "249");
+                Assert.AreEqual((DefaultQueries.MaxProductsSize * 2 - 1).ToString(), after);
+            }, first: DefaultQueries.MaxProductsSize, after: (DefaultQueries.MaxProductsSize - 1).ToString());
 
-            Assert.AreEqual(250, products.Count);
-            Assert.AreEqual("250", products[0].id());
-            Assert.AreEqual("499", products[products.Count - 1].id());
+            Assert.AreEqual(DefaultQueries.MaxProductsSize, products.Count);
+            Assert.AreEqual(DefaultQueries.MaxProductsSize.ToString(), products[0].id());
+            Assert.AreEqual((DefaultQueries.MaxProductsSize * 2 - 1).ToString(), products[products.Count - 1].id());
         }
 
         [Test]
@@ -188,9 +178,10 @@ namespace Shopify.Tests
             ShopifyBuy.Init(new MockLoader());
 
             // when after is set to 3 MockLoader will return a graphql error
-            ShopifyBuy.Client().products(callback: (p, error) => {
+            ShopifyBuy.Client().products(callback: (p, error, after) => {
                 Assert.IsNull(p);
                 Assert.IsNotNull(error);
+                Assert.IsNull(after);
                 Assert.AreEqual("[\"GraphQL error from mock loader\"]", error.Description);
             }, first: 250, after: "666");
         }
@@ -200,9 +191,10 @@ namespace Shopify.Tests
             ShopifyBuy.Init(new MockLoader());
 
             // when after is set to 404 MockLoader loader will return an httpError
-            ShopifyBuy.Client().products(callback: (p, error) => {
+            ShopifyBuy.Client().products(callback: (p, error, after) => {
                 Assert.IsNull(p);
                 Assert.IsNotNull(error);
+                Assert.IsNull(after);
                 Assert.AreEqual("404 from mock loader", error.Description);
             }, first: 250, after: "404");
         }

--- a/Assets/Editor/TestShopify.cs
+++ b/Assets/Editor/TestShopify.cs
@@ -102,10 +102,10 @@ namespace Shopify.Tests
             ShopifyBuy.Client().products(callback: (p, error, after) => {
                 products = p;
                 Assert.IsNull(error);
-                Assert.AreEqual((DefaultQueries.MaxProductsSize - 1).ToString(), after);
+                Assert.AreEqual((DefaultQueries.MaxProductPageSize - 1).ToString(), after);
             });
 
-            Assert.AreEqual(DefaultQueries.MaxProductsSize, products.Count);
+            Assert.AreEqual(DefaultQueries.MaxProductPageSize, products.Count);
             Assert.AreEqual("Product0", products[0].title());
             Assert.AreEqual("Product1", products[1].title());
 
@@ -131,10 +131,10 @@ namespace Shopify.Tests
             ShopifyBuy.Client().products(callback: (p, error, after) => {
                 products = p;
                 Assert.IsNull(error);
-                Assert.AreEqual((DefaultQueries.MaxProductsSize - 1).ToString(), after);
-            }, first: DefaultQueries.MaxProductsSize);
+                Assert.AreEqual((DefaultQueries.MaxProductPageSize - 1).ToString(), after);
+            }, first: DefaultQueries.MaxProductPageSize);
 
-            Assert.AreEqual(DefaultQueries.MaxProductsSize, products.Count);
+            Assert.AreEqual(DefaultQueries.MaxProductPageSize, products.Count);
         }
 
         [Test]
@@ -165,12 +165,12 @@ namespace Shopify.Tests
             ShopifyBuy.Client().products(callback: (p, error, after) => {
                 products = p;
                 Assert.IsNull(error);
-                Assert.AreEqual((DefaultQueries.MaxProductsSize * 2 - 1).ToString(), after);
-            }, first: DefaultQueries.MaxProductsSize, after: (DefaultQueries.MaxProductsSize - 1).ToString());
+                Assert.AreEqual((DefaultQueries.MaxProductPageSize * 2 - 1).ToString(), after);
+            }, first: DefaultQueries.MaxProductPageSize, after: (DefaultQueries.MaxProductPageSize - 1).ToString());
 
-            Assert.AreEqual(DefaultQueries.MaxProductsSize, products.Count);
-            Assert.AreEqual(DefaultQueries.MaxProductsSize.ToString(), products[0].id());
-            Assert.AreEqual((DefaultQueries.MaxProductsSize * 2 - 1).ToString(), products[products.Count - 1].id());
+            Assert.AreEqual(DefaultQueries.MaxProductPageSize, products.Count);
+            Assert.AreEqual(DefaultQueries.MaxProductPageSize.ToString(), products[0].id());
+            Assert.AreEqual((DefaultQueries.MaxProductPageSize * 2 - 1).ToString(), products[products.Count - 1].id());
         }
 
         [Test]

--- a/Assets/Editor/TestUnityEditorLoader.cs
+++ b/Assets/Editor/TestUnityEditorLoader.cs
@@ -1,4 +1,5 @@
-﻿namespace Shopify.Tests {
+﻿#if !SHOPIFY_MONO_UNIT_TEST
+namespace Shopify.Tests {
     using NUnit.Framework;
     using UnityEngine.TestTools;
     using UnityEngine;
@@ -31,3 +32,4 @@
         }
     }
 }
+#endif

--- a/Assets/IntegrationTests/TestUnityLoader.cs
+++ b/Assets/IntegrationTests/TestUnityLoader.cs
@@ -1,3 +1,4 @@
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace Shopify.Unity.Tests
 {
     using UnityEngine;
@@ -28,3 +29,4 @@ namespace Shopify.Unity.Tests
         }
     }   
 }
+#endif

--- a/Assets/NativeTesting/iOS/ApplePayFlowTester.cs
+++ b/Assets/NativeTesting/iOS/ApplePayFlowTester.cs
@@ -77,7 +77,7 @@
         }
 
         private void SetDefaultCartProducts(Action completion) {
-            Client.products((products, error) => {
+            Client.products((products, error, after) => {
                 List<ProductVariant> productVariants = (List<ProductVariant>) products[0].variants();
                 CurrentCart.LineItems.AddOrUpdate(productVariants[0], 1);
                 completion();

--- a/Assets/Shopify/Examples/Scripts/Helpers/ShopifyHelper.cs
+++ b/Assets/Shopify/Examples/Scripts/Helpers/ShopifyHelper.cs
@@ -28,7 +28,7 @@ namespace Shopify.Examples.Helpers {
             // For more information on querying products visit
             // https://help.shopify.com/api/sdks/custom-storefront/unity-buy-sdk/getting-started#query-all-products
 
-            ShopifyBuy.Client().products((products, error) => {
+            ShopifyBuy.Client().products((products, error, after) => {
                 if (error != null) {
                     failureCallback();
 

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultProductQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultProductQueries.cs.erb
@@ -7,7 +7,7 @@ namespace Shopify.Unity.SDK {
     /// Generates default queries for <see ref="ShopifyClient.products">ShopifyClient.products </see>.
     /// </summary>
     public class DefaultProductQueries {
-        public void ShopProducts(QueryRootQuery query, Dictionary<string,int> imageResolutions, int first = 250, string after = null) {
+        public void ShopProducts(QueryRootQuery query, Dictionary<string,int> imageResolutions, int first = 20, string after = null) {
             query.shop(s => s
                 .products(pc => pc
                     .edges(e => e

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
@@ -8,7 +8,7 @@ namespace Shopify.Unity.SDK {
     /// </summary>
     public class DefaultQueries {
         public static readonly int MaxPageSize = 250;
-        public static readonly int MaxProductsSize = 20;
+        public static readonly int MaxProductPageSize = 20;
 
         public static DefaultProductQueries products = new DefaultProductQueries();
         public static DefaultCollectionQueries collections = new DefaultCollectionQueries();

--- a/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/DefaultQueries.cs.erb
@@ -8,6 +8,7 @@ namespace Shopify.Unity.SDK {
     /// </summary>
     public class DefaultQueries {
         public static readonly int MaxPageSize = 250;
+        public static readonly int MaxProductsSize = 20;
 
         public static DefaultProductQueries products = new DefaultProductQueries();
         public static DefaultCollectionQueries collections = new DefaultCollectionQueries();

--- a/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/Delegates.cs.erb
@@ -18,6 +18,7 @@ namespace Shopify.Unity.SDK {
     public delegate void MergeFieldDelegate(string field, Dictionary<string, object> into, Dictionary<string, object> responseA, Dictionary<string, object> responseB);
 
     public delegate void ProductsHandler(List<Product> products, ShopifyError error);
+    public delegate void ProductsPaginatedHandler(List<Product> products, ShopifyError error, string after);
     public delegate void CollectionsHandler(List<Collection> collections, ShopifyError error);
     public delegate void QueryRootHandler(<%= schema.query_root_name %> queryRoot, ShopifyError error);
     public delegate void MutationRootHandler(<%= schema.mutation_root_name %> mutationRoot, ShopifyError error);

--- a/scripts/generator/graphql_generator/csharp/SDK/WebCheckoutMessageReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/WebCheckoutMessageReceiver.cs.erb
@@ -64,7 +64,9 @@ namespace Shopify.Unity.SDK {
                     var checkout = (Checkout) response.node();
                     if (checkout.completedAt() != null) {
                         OnSuccess();
+                        #if !SHOPIFY_MONO_UNIT_TEST
                         Destroy(this);
+                        #endif
                     } else {
                         OnCancelled();
                     }

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -41,6 +41,7 @@ namespace Shopify.Unity {
         /// 	Debug.Log(products.Count);
         /// });
         /// \endcode
+
         public static ShopifyClient Client() {
             return DefaultClient;
         }
@@ -287,18 +288,24 @@ namespace Shopify.Unity {
         /// </param>
         /// \code
         /// // Example usage querying all products
-        /// ShopifyBuy.Client().products((products, error) => {
+        /// ShopifyBuy.Client().products((products, error, after) => {
         /// 	Debug.Log(products[0].title());
         /// 	Debug.Log(products[1].title());
         /// 	Debug.Log(products.Count);
         /// });
         /// \endcode
-        public void products(ProductsHandler callback, int? first = null, string after = null) {
-            GetProductsList((products, error) => {
+        public void products(ProductsPaginatedHandler callback, int? first = 20, string after = null) {
+            GetProductsList((products, error, afterProductsList) => {
                 if (error != null) {
-                    callback(null, error);
+                    callback(null, error, null);
                 } else {
-                    GetConnectionsForProducts(products, callback);
+                    GetConnectionsForProducts(products, (List<Product> productsWithSubConnections, ShopifyError errorForSubConnections) => {
+                        if (error != null) {
+                            callback(null, error, null);
+                        } else {
+                            callback(productsWithSubConnections, errorForSubConnections, afterProductsList);
+                        }
+                    });
                 }
             }, first: first, after: after);
         }
@@ -815,7 +822,7 @@ namespace Shopify.Unity {
             );
         }
 
-        private void GetProductsList(ProductsHandler callback, int? first = null, string after = null) {
+        private void GetProductsList(ProductsPaginatedHandler callback, int? first = null, string after = null) {
             ConnectionLoader loader = new ConnectionLoader(Loader);
             int countToLoad = first == null ? int.MaxValue : (int) first;
 
@@ -836,7 +843,7 @@ namespace Shopify.Unity {
                         DefaultQueries.products.ShopProducts(
                             query: query,
                             imageResolutions: DefaultImageResolutions,
-                            first: countToLoad > DefaultQueries.MaxPageSize ? DefaultQueries.MaxPageSize : countToLoad,
+                            first: countToLoad > DefaultQueries.MaxProductsSize ? DefaultQueries.MaxProductsSize : countToLoad,
                             after: edges != null ? edges[edges.Count - 1].cursor() : after
                         );
                     }
@@ -849,9 +856,17 @@ namespace Shopify.Unity {
                 (response) => {
                     var error = (ShopifyError)response;
                     if (error != null) {
-                        callback(null, error);
+                        callback(null, error, null);
                     } else {
-                        callback((List<Product>) response.data.shop().products(), null);
+                        string lastCursor = null;
+
+                        if (response.data.shop().products().pageInfo().hasNextPage()) {
+                            List<ProductEdge> productEdges = response.data.shop().products().edges();
+
+                            lastCursor = productEdges[productEdges.Count - 1].cursor();
+                        }
+                        
+                        callback((List<Product>) response.data.shop().products(), error, lastCursor);
                     }
                 }
             );

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -843,7 +843,7 @@ namespace Shopify.Unity {
                         DefaultQueries.products.ShopProducts(
                             query: query,
                             imageResolutions: DefaultImageResolutions,
-                            first: countToLoad > DefaultQueries.MaxProductsSize ? DefaultQueries.MaxProductsSize : countToLoad,
+                            first: countToLoad > DefaultQueries.MaxProductPageSize ? DefaultQueries.MaxProductPageSize : countToLoad,
                             after: edges != null ? edges[edges.Count - 1].cursor() : after
                         );
                     }

--- a/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/ShopifyBuy.cs.erb
@@ -295,7 +295,7 @@ namespace Shopify.Unity {
         /// });
         /// \endcode
         public void products(ProductsPaginatedHandler callback, int? first = 20, string after = null) {
-            GetProductsList((products, error, afterProductsList) => {
+            GetProductsList((products, error, afterGetProductsList) => {
                 if (error != null) {
                     callback(null, error, null);
                 } else {
@@ -303,7 +303,7 @@ namespace Shopify.Unity {
                         if (error != null) {
                             callback(null, error, null);
                         } else {
-                            callback(productsWithSubConnections, errorForSubConnections, afterProductsList);
+                            callback(productsWithSubConnections, errorForSubConnections, afterGetProductsList);
                         }
                     });
                 }


### PR DESCRIPTION
This PR does the following:
+ Forces pagination. You can no longer load all products
+ Drops the maximum amount of products loaded per page to 20 (this arbitrary and I wonder if we should think about it more)
+ Forces the user to make callbacks that accept `after` eg. `(products, errors, after)`
+ `after` will be `null` if there are no more pages