### PR TITLE
[UI Toolkit] Single product editor testing

### DIFF
--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeControllerEditor.cs
@@ -1,0 +1,47 @@
+namespace Shopify.UIToolkit.Test.Unit {
+    using UnityEngine.TestTools;
+    using UnityEditor;
+    using UnityEngine;
+    using NUnit.Framework;
+    using Shopify.UIToolkit.Editor;
+    using Shopify.UIToolkit.Themes;
+    using NSubstitute;
+    using Shopify.Unity.SDK;
+
+    [TestFixture]
+    public class TestSingleProductThemeControllerEditor {
+        private SingleProductThemeControllerEditor _editor;
+        private SingleProductThemeController _controller;
+
+        [SetUp]
+        public void Setup() {
+            _controller = GlobalGameObject.AddComponent<SingleProductThemeController>();
+            _editor = Editor.CreateEditor(_controller) as SingleProductThemeControllerEditor;
+
+            _editor.View = Substitute.For<ISingleProductThemeControllerEditorView>();
+        }
+
+        [Test]
+        public void TestBindsThemeOnEnable() {
+            var theme = GlobalGameObject.AddComponent<DebugSingleProductTheme>();
+            Assert.IsNull(_controller.Theme);
+            _editor.OnEnable();
+            Assert.AreEqual(_controller.Theme, theme);
+        }
+
+        [Test]
+        public void TestNullThemeDrawsHelpBox() {
+            Assert.IsNull(_controller.Theme);
+            _editor.OnInspectorGUI();
+            _editor.View.Received().ShowThemeHelp();
+        }
+
+        [Test]
+        public void TestBoundThemeDoesNotDrawHelpBox() {
+            _controller.Theme = GlobalGameObject.AddComponent<DebugSingleProductTheme>();
+            Assert.IsNotNull(_controller.Theme);
+            _editor.OnInspectorGUI();
+            _editor.View.DidNotReceive().ShowThemeHelp();
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeControllerEditor.cs
@@ -21,6 +21,11 @@ namespace Shopify.UIToolkit.Test.Unit {
             _editor.View = Substitute.For<ISingleProductThemeControllerEditorView>();
         }
 
+        [TearDown]
+        public void TearDown() {
+            GlobalGameObject.Destroy();
+        }
+
         [Test]
         public void TestBindsThemeOnEnable() {
             var theme = GlobalGameObject.AddComponent<DebugSingleProductTheme>();
@@ -39,7 +44,6 @@ namespace Shopify.UIToolkit.Test.Unit {
         [Test]
         public void TestBoundThemeDoesNotDrawHelpBox() {
             _controller.Theme = GlobalGameObject.AddComponent<DebugSingleProductTheme>();
-            Assert.IsNotNull(_controller.Theme);
             _editor.OnInspectorGUI();
             _editor.View.DidNotReceive().ShowThemeHelp();
         }

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeControllerEditor.cs.meta
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeControllerEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b122fd8b2ee2848e49d89ae93a3ebf6c
+timeCreated: 1511804788
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Theme Controllers/Editor/SingleProductThemeControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Theme Controllers/Editor/SingleProductThemeControllerEditor.cs
@@ -5,6 +5,7 @@
 
     [CustomEditor(typeof(SingleProductThemeController))]
     public class SingleProductThemeControllerEditor : Editor {
+        public ISingleProductThemeControllerEditorView View;
         public SingleProductThemeController Target {
             get {
                 return target as SingleProductThemeController;
@@ -12,24 +13,17 @@
         }
 
         public void OnEnable() {
+            if (Target == null) return;
+
+            View = new SingleProductThemeControllerEditorView();
             BindThemeIfPresent();
         }
 
         public override void OnInspectorGUI() {
             if (Target.Theme == null) {
-                ShowThemeHelp();
+                View.ShowThemeHelp();
                 return;
             }
-        }
-
-        private void ShowThemeHelp() {
-            var message = @"
-Theme Controllers require a theme to function.
-
-Override SingleProductTheme with your own custom script and add it to this class to continue.
-            ";
-
-            EditorGUILayout.HelpBox(message, MessageType.Warning);
         }
 
         private void BindThemeIfPresent() {

--- a/Assets/Shopify/UIToolkit/Theme Controllers/Editor/SingleProductThemeControllerEditorView.cs
+++ b/Assets/Shopify/UIToolkit/Theme Controllers/Editor/SingleProductThemeControllerEditorView.cs
@@ -1,0 +1,18 @@
+namespace Shopify.UIToolkit.Editor {
+    using UnityEditor;
+
+    public interface ISingleProductThemeControllerEditorView {
+        void ShowThemeHelp();
+    }
+
+    public class SingleProductThemeControllerEditorView : ISingleProductThemeControllerEditorView {
+        public void ShowThemeHelp() {
+            var message = @"
+Theme Controllers require a theme to function.
+Implement ISingleProductTheme with your own custom script and add it to this gameObject to continue.
+            ";
+
+            EditorGUILayout.HelpBox(message, MessageType.Warning);
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Theme Controllers/Editor/SingleProductThemeControllerEditorView.cs.meta
+++ b/Assets/Shopify/UIToolkit/Theme Controllers/Editor/SingleProductThemeControllerEditorView.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 017ac06668b09478bba41b190ba190d1
+timeCreated: 1511804788
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/Unity/SDK/GlobalGameObject.cs
+++ b/Assets/Shopify/Unity/SDK/GlobalGameObject.cs
@@ -15,7 +15,11 @@ namespace Shopify.Unity.SDK {
             }
         }
 
-        public static T AddComponent<T>() where T : Component {
+        public static void Destroy() {
+            MonoBehaviour.DestroyImmediate(GameObject);
+        }
+
+        public static T AddComponent<T>() where T: Component {
             if (GameObject == null) {
                 GameObject = new GameObject("Shopify");
             }


### PR DESCRIPTION
Separates the view layer from the editor layer in the single product
editor, which allows us to mock the calls to EditorGUI and effectively
test states that the editor is rendering.

This view layer also implements an interface, which allows us to mock the behaviour in the tests and avoid calling EditorGUI functions, which would crash the scripts because they are being called outside of the normal editor inspector rendering flow.