### PR TITLE
[WIP] Refactored WebImageCache into DataCache interface and LRUCache abstract class

### DIFF
--- a/Assets/Shopify/UIToolkit/Components/DataCache.cs
+++ b/Assets/Shopify/UIToolkit/Components/DataCache.cs
@@ -1,0 +1,60 @@
+ namespace Shopify.UIToolkit {
+    using UnityEngine;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// An interface for defining a data cache.
+    /// </summary>
+    public interface DataCache<T> {
+        /// <summary>
+        /// The estimated size limit in bytes of how much memory we want to use for the cache (readonly).
+        /// </summary>
+        /// <returns></returns>
+        int MemorySizeLimit { get; }
+
+        /// <summary>
+        /// The current estimated size the cache takes up in memory (readonly).
+        /// </summary>
+        /// <returns></returns>
+        int EstimatedMemorySize { get; }
+
+        /// <summary>
+        /// Returns the number of entries in the cache (readonly).
+        /// </summary>
+        /// <returns>Number of entries in the cache.</returns>
+        int Count { get; }
+
+        /// <summary>
+        /// Sets the size limit in bytes that we can store in the cache.
+        /// </summary>
+        /// <param name="newLimit">New size limit in bytes.</param>
+        void SetMemorySizeLimit(int newLimit);
+
+        /// <summary>
+        /// Returns the cached resource saved against the given url.
+        /// </summary>
+        /// <param name="key">Key mapping to a resource.</param>
+        /// <returns>The cached resource associated with the given key.</returns>
+        T ResourceForKey(string key);
+
+        /// <summary>
+        /// Associates the given key with the given resource in the cache.
+        /// </summary>
+        /// <param name="key">Key to cache with.</param>
+        /// <param name="resource">A resource to cache in memory.</param>
+        void SetResourceForKey(string key, T resource);
+
+        /// <summary>
+        /// Removes the key and associated resource instance from the cache.
+        /// </summary>
+        /// <param name="key">Key to remove from the cache.</param>
+        void RemoveKey(string key);
+
+        /// <summary>
+        /// Clears the cache. 
+        /// </summary>
+        void Clear();
+    }
+}

--- a/Assets/Shopify/UIToolkit/Components/DataCache.cs.meta
+++ b/Assets/Shopify/UIToolkit/Components/DataCache.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ddd12af30e0e04b099173305d9dc8f51
+timeCreated: 1511902118
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Components/LRUCache.cs
+++ b/Assets/Shopify/UIToolkit/Components/LRUCache.cs
@@ -1,0 +1,199 @@
+ namespace Shopify.UIToolkit {
+    using UnityEngine;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A web resource that is cached against a Last-Modified timestamp.
+    /// </summary>
+    public abstract class CachedWebResource {
+        /// <summary>
+        /// The Last-Modified timestamp from a HTTP header field.
+        /// </summary>
+        public readonly string LastModifiedTimestamp;
+
+        /// <summary>
+        /// Data instance to cache.
+        /// </summary>
+        public readonly object Data;
+
+        /// <summary>
+        /// Returns the size of the associated Data object in bytes.
+        /// </summary>
+        /// <returns>Size of Data property in bytes.</returns>
+        public virtual int SizeOnDisk() {
+            return 0;
+        }
+
+        public CachedWebResource(string lastModifiedTimestamp, object data) {
+            LastModifiedTimestamp = lastModifiedTimestamp;
+            Data = data;
+        }
+    }
+
+    /// <summary>
+    /// A cache that uses a Least Recently Used (LRU) heurstic for evicting items.
+    /// </summary>
+    public abstract class LRUCache<T> : DataCache<T> where T: CachedWebResource {
+        /// <summary>
+        /// The default estimated memory size limit in bytes.
+        /// </summary>
+        public const int DEFAULT_MEMORY_SIZE_LIMIT = 20971520; // 20 MB in bytes
+
+        private Dictionary<string, T> _memoryCache = 
+            new Dictionary<string, T>();
+
+        private LinkedList<string> _recentlyUsed = new LinkedList<string>();
+
+        /// <summary>
+        /// The estimated size limit in bytes of how much memory we want to use for the cache (readonly).
+        /// </summary>
+        /// <returns></returns>
+        public int MemorySizeLimit { get; private set; }
+
+        /// <summary>
+        /// The current estimated size the cache takes up in memory (readonly)
+        /// </summary>
+        /// <returns></returns>
+        public int EstimatedMemorySize { get; private set; }
+
+        /// <summary>
+        /// Returns the number of entries in the cache.
+        /// </summary>
+        /// <returns>Number of entries in the cache.</returns>
+        public int Count {
+            get {
+                return _memoryCache.Count;
+            }
+        }
+
+        protected LRUCache(int memorySizeLimit) {
+            MemorySizeLimit = memorySizeLimit;
+        }
+
+        /// <summary>
+        /// Sets the size limit in bytes that we can store in the cache.
+        /// </summary>
+        /// <param name="newLimit">New size limit in bytes.</param>
+        public void SetMemorySizeLimit(int newLimit) {
+            Debug.Assert(newLimit >= 0, "Size limit must be greater or equal to 0.");
+
+            // If we're bigger than the new limit then make some room by evicting all of the oldest resources
+            // from the cache.
+            while (EstimatedMemorySize > newLimit) {
+                var oldestNode = _recentlyUsed.Last;
+                var oldestUsedResource = _memoryCache[oldestNode.Value];
+                var oldestUsedDataSize = oldestUsedResource.SizeOnDisk();
+
+                _memoryCache.Remove(oldestNode.Value);
+                _recentlyUsed.RemoveLast();
+                EstimatedMemorySize -= oldestUsedDataSize;
+            }
+
+            MemorySizeLimit = newLimit;
+        }
+
+        /// <summary>
+        /// Returns the cached resource saved against the given url.
+        /// </summary>
+        /// <param name="url">URL mapping to a texture.</param>
+        /// <returns>The cached resource associated with the given url.</returns>
+        public T ResourceForURL(string url) {
+            return ResourceForKey(url);
+        }
+
+        /// <summary>
+        /// Associates the given URL with the given resource in the cache.
+        /// </summary>
+        /// <param name="url">URL to key the cache with.</param>
+        /// <param name="resource">A CachedWebResource<Texture2D> instance to cache in memory.</param>
+        public void SetResourceForURL(string url, T resource) {
+            SetResourceForKey(url, resource);
+        }
+
+        /// <summary>
+        /// Removes the URL and associated resource instance from the cache.
+        /// </summary>
+        /// <param name="url">URL key to remove from the cache.</param>
+        public void RemoveURL(string url) {
+            RemoveKey(url);
+        }
+
+        /// <summary>
+        /// Clears the cache. 
+        /// </summary>
+        public void Clear() {
+            _memoryCache.Clear();
+            _recentlyUsed.Clear();
+            EstimatedMemorySize = 0;
+        }
+
+        public T ResourceForKey(string key) {
+            var resource = ResourceFromCacheForURL(key);
+            if (resource != null) {
+                PromoteURL(key);
+            }
+            return resource;
+        }
+
+        public void SetResourceForKey(string key, T resource) {
+            // If we already have it in the list, promote it. If not then we'll need to add it.
+            if (ResourceFromCacheForURL(key) != null) {
+                PromoteURL(key);
+                RemoveURLFromCache(key);
+            } else {
+                _recentlyUsed.AddFirst(new LinkedListNode<string>(key));
+            }
+
+            var size = resource.SizeOnDisk();
+            int nextMemoryFootprint = EstimatedMemorySize + size;
+
+            // Evict the least recently used resources from the cache until we can fit the new one in.
+            while (nextMemoryFootprint > MemorySizeLimit) {
+                var oldestNode = _recentlyUsed.Last;
+                var oldestUsedResource = _memoryCache[oldestNode.Value];
+                var oldestUsedDataSize = oldestUsedResource.SizeOnDisk();
+
+                _memoryCache.Remove(oldestNode.Value);
+                _recentlyUsed.RemoveLast();
+                nextMemoryFootprint -= oldestUsedDataSize;
+            }
+
+            EstimatedMemorySize = nextMemoryFootprint;
+            _memoryCache[key] = resource;
+        }
+
+        public void RemoveKey(string key) {
+            RemoveURLFromCache(key);
+
+            var node =_recentlyUsed.Find(key);
+            if (node != null) {
+                _recentlyUsed.Remove(node);
+            }
+        }
+
+        private void PromoteURL(string url) {
+            var node =_recentlyUsed.Find(url);
+            if (node != null) {
+                _recentlyUsed.Remove(node);
+                _recentlyUsed.AddFirst(new LinkedListNode<string>(url));
+            }
+        }
+
+        private T ResourceFromCacheForURL(string url) {
+            try {
+                return _memoryCache[url];
+            } catch {
+                return null;
+            }
+        }
+
+        private void RemoveURLFromCache(string url) {
+            var resource = _memoryCache[url];
+            var dataSize = resource.SizeOnDisk();
+            _memoryCache.Remove(url);
+            EstimatedMemorySize -= dataSize;
+        }
+    }
+ }

--- a/Assets/Shopify/UIToolkit/Components/LRUCache.cs.meta
+++ b/Assets/Shopify/UIToolkit/Components/LRUCache.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1a7fea0168436432aa71bff5733b23e0
+timeCreated: 1511897043
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Components/WebImageCache.cs
+++ b/Assets/Shopify/UIToolkit/Components/WebImageCache.cs
@@ -5,162 +5,18 @@
     using System.Collections.Generic;
 
     /// <summary>
-    /// A web resource that is cached against a Last-Modified timestamp.
+    /// A cacheable image downloaed from the web stored as a Texture2D object.
     /// </summary>
-    public struct CachedWebResource<T> {
-        public readonly string LastModifiedTimestamp;
-        public readonly T Data;
-
-        public CachedWebResource(string lastModifiedTimestamp, T data) {
-            LastModifiedTimestamp = lastModifiedTimestamp;
-            Data = data;
-        }
-    }
-
-    /// <summary>
-    /// This class implements a LRU cache for images (PNG/JPEG) that were downloaded from the web.
-    /// </summary>
-    public class WebImageCache {
-        /// <summary>
-        /// The default estimated memory size limit in bytes.
-        /// </summary>
-        public const int DEFAULT_MEMORY_SIZE_LIMIT = 20971520; // 20 MB in bytes
-
-        private Dictionary<string, CachedWebResource<Texture2D>> _urlTextureCache = 
-            new Dictionary<string, CachedWebResource<Texture2D>>();
-
-        private LinkedList<string> _recentlyUsed = new LinkedList<string>();
-
-        private static WebImageCache _sharedCache;
-
-        /// <summary>
-        /// Shared WebImageCache instanced.
-        /// </summary>
-        /// <returns>A singleton instance of the WebImageCache.</returns>
-        public static WebImageCache SharedCache {
+    public class CachedWebImage : CachedWebResource {
+        Texture2D texture {
             get {
-                _sharedCache = _sharedCache ?? new WebImageCache(DEFAULT_MEMORY_SIZE_LIMIT);
-                return _sharedCache;
+                return (Texture2D) Data;
             }
         }
 
-        /// <summary>
-        /// The estimated size limit in bytes of how much memory we want to use for the cache (readonly).
-        /// </summary>
-        /// <returns></returns>
-        public int MemorySizeLimit { get; private set; }
+        public CachedWebImage(string lastModifiedTimestamp, Texture2D data) : base(lastModifiedTimestamp, data) {}
 
-        /// <summary>
-        /// The current estimated size the cache takes up in memory (readonly)
-        /// </summary>
-        /// <returns></returns>
-        public int EstimatedMemorySize { get; private set; }
-
-        /// <summary>
-        /// Returns the number of entries in the cache.
-        /// </summary>
-        /// <returns>Number of entries in the cache.</returns>
-        public int Count {
-            get {
-                return _urlTextureCache.Count;
-            }
-        }
-
-        /// <summary>
-        /// Sets the size limit in bytes that we can store in the cache.
-        /// </summary>
-        /// <param name="newLimit">New size limit in bytes.</param>
-        public void SetMemorySizeLimit(int newLimit) {
-            Debug.Assert(newLimit >= 0, "Size limit must be greater or equal to 0.");
-
-            // If we're bigger than the new limit then make some room by evicting all of the oldest resources
-            // from the cache.
-            while (EstimatedMemorySize > newLimit) {
-                var oldestNode = _recentlyUsed.Last;
-                var oldestUsedTexture = _urlTextureCache[oldestNode.Value].Data;
-                var oldestUsedTextureSize = EstimateMemoryFootprintForTexture(oldestUsedTexture);
-
-                _urlTextureCache.Remove(oldestNode.Value);
-                _recentlyUsed.RemoveLast();
-                EstimatedMemorySize -= oldestUsedTextureSize;
-            }
-
-            MemorySizeLimit = newLimit;
-        }
-
-        private WebImageCache(int memorySizeLimit) {
-            MemorySizeLimit = memorySizeLimit;
-        }
-
-        /// <summary>
-        /// Returns the cached Texture2D texture saved against the given url.
-        /// </summary>
-        /// <param name="url">URL mapping to a texture.</param>
-        /// <returns>The cached resource associated with the given url.</returns>
-        public CachedWebResource<Texture2D>? TextureResourceForURL(string url) {
-            var texture = TextureFromCacheForURL(url);
-            if (texture != null) {
-                PromoteURL(url);
-            }
-            return texture;
-        }
-
-        /// <summary>
-        /// Associates the given URL with the given texture in the cache.
-        /// </summary>
-        /// <param name="url">URL to key the cache with.</param>
-        /// <param name="textureResource">A CachedWebResource<Texture2D> instance to cache in memory.</param>
-        public void SetTextureResourceForURL(string url, CachedWebResource<Texture2D> textureResource) {
-            // If we already have it in the list, promote it. If not then we'll need to add it.
-            if (TextureFromCacheForURL(url) != null) {
-                PromoteURL(url);
-                RemoveURLFromCache(url);
-            } else {
-                _recentlyUsed.AddFirst(new LinkedListNode<string>(url));
-            }
-
-            var estimatedTextureSize = EstimateMemoryFootprintForTexture(textureResource.Data);
-            int nextMemoryFootprint = EstimatedMemorySize + estimatedTextureSize;
-
-            // Evict the least recently used textures from the cache until we can fit the new one in.
-            while (nextMemoryFootprint > MemorySizeLimit) {
-                var oldestNode = _recentlyUsed.Last;
-                var oldestUsedTexture = _urlTextureCache[oldestNode.Value].Data;
-                var oldestUsedTextureSize = EstimateMemoryFootprintForTexture(oldestUsedTexture);
-
-                _urlTextureCache.Remove(oldestNode.Value);
-                _recentlyUsed.RemoveLast();
-                nextMemoryFootprint -= oldestUsedTextureSize;
-            }
-
-            EstimatedMemorySize = nextMemoryFootprint;
-            _urlTextureCache[url] = textureResource;
-        }
-
-        /// <summary>
-        /// Removes the URL and associated Texture2D instance from the cache.
-        /// </summary>
-        /// <param name="url">URL key to remove from the cache.</param>
-        public void RemoveURL(string url) {
-            RemoveURLFromCache(url);
-
-            var node =_recentlyUsed.Find(url);
-            if (node != null) {
-                _recentlyUsed.Remove(node);
-            }
-        }
-
-        /// <summary>
-        /// Clears the cache. 
-        /// </summary>
-        public void Clear() {
-            _urlTextureCache.Clear();
-            _recentlyUsed.Clear();
-            EstimatedMemorySize = 0;
-        }
-
-        private int EstimateMemoryFootprintForTexture(Texture2D texture) {
-            // We can assume these images will only have a single mipmap level.
+        public override int SizeOnDisk() {
             return texture.width * texture.height * StrideForTextureFormat(texture.format);
         }
 
@@ -178,28 +34,33 @@
                     return 4;
             }
         }
+    }
 
-        private void PromoteURL(string url) {
-            var node =_recentlyUsed.Find(url);
-            if (node != null) {
-                _recentlyUsed.Remove(node);
-                _recentlyUsed.AddFirst(new LinkedListNode<string>(url));
+    /// <summary>
+    /// This class implements a LRU cache for images (PNG/JPEG) that were downloaded from the web.
+    /// </summary>
+    public class WebImageCache : LRUCache<CachedWebImage> {
+        private static WebImageCache _sharedCache;
+
+        /// <summary>
+        /// Shared WebImageCache instanced.
+        /// </summary>
+        /// <returns>A singleton instance of the WebImageCache.</returns>
+        public static WebImageCache SharedCache {
+            get {
+                _sharedCache = _sharedCache ?? new WebImageCache(DEFAULT_MEMORY_SIZE_LIMIT);
+                return _sharedCache;
             }
         }
 
-        private CachedWebResource<Texture2D>? TextureFromCacheForURL(string url) {
-            try {
-                return _urlTextureCache[url];
-            } catch {
-                return null;
-            }
+        private WebImageCache(int memoryLimit) : base(memoryLimit) {}
+
+        public void SetTextureResourceForURL(string url, CachedWebImage resource) {
+            SetResourceForURL(url, resource);
         }
 
-        private void RemoveURLFromCache(string url) {
-            var texture = _urlTextureCache[url].Data;
-            var textureSize = EstimateMemoryFootprintForTexture(texture);
-            _urlTextureCache.Remove(url);
-            EstimatedMemorySize -= textureSize;
+        public CachedWebImage TextureResourceForURL(string url) {
+            return ResourceForURL(url);
         }
     }
  }

--- a/Assets/Shopify/UIToolkit/Test/Integration/TestWebImageCacheIntegration.cs
+++ b/Assets/Shopify/UIToolkit/Test/Integration/TestWebImageCacheIntegration.cs
@@ -30,7 +30,7 @@ namespace Shopify.UIToolkit.Test.Integration {
                 WWW www = new WWW(imageURL);
                 yield return www;
                 var texture = www.texture;
-                var resource = new CachedWebResource<Texture2D>(DateTime.Now.ToShortTimeString(), texture);
+                var resource = new CachedWebImage(DateTime.Now.ToShortTimeString(), texture);
                 cache.SetTextureResourceForURL(imageURL, resource);
             }
 
@@ -47,7 +47,7 @@ namespace Shopify.UIToolkit.Test.Integration {
                 WWW www = new WWW(imageURL);
                 yield return www;
                 var texture = www.texture;
-                var resource = new CachedWebResource<Texture2D>(DateTime.Now.ToShortTimeString(), texture);
+                var resource = new CachedWebImage(DateTime.Now.ToShortTimeString(), texture);
                 cache.SetTextureResourceForURL(imageURL, resource);
             }
 

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestWebImageCache.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestWebImageCache.cs
@@ -26,7 +26,7 @@ namespace Shopify.UIToolkit.Test.Unit {
             WebImageCache cache = WebImageCache.SharedCache;
             string mockURL = "myimage.com/image";
             Texture2D mockTexture = new Texture2D(100, 100);
-            var mockResource = new CachedWebResource<Texture2D>("0", mockTexture);
+            var mockResource = new CachedWebImage("0", mockTexture);
 
             cache.SetTextureResourceForURL(mockURL, mockResource);
 
@@ -39,11 +39,11 @@ namespace Shopify.UIToolkit.Test.Unit {
             WebImageCache cache = WebImageCache.SharedCache;
             string mockURL = "myimage.com/image";
             Texture2D mockTexture = new Texture2D(100, 100);
-            var mockResource = new CachedWebResource<Texture2D>("0", mockTexture);
+            var mockResource = new CachedWebImage("0", mockTexture);
 
             cache.SetTextureResourceForURL(mockURL, mockResource);
 
-            Assert.NotNull(cache.TextureResourceForURL(mockURL).Value.Data);
+            Assert.NotNull(cache.TextureResourceForURL(mockURL).Data);
             Assert.AreEqual(cache.EstimatedMemorySize, 40000);
 
             cache.RemoveURL(mockURL);
@@ -56,8 +56,8 @@ namespace Shopify.UIToolkit.Test.Unit {
             WebImageCache cache = WebImageCache.SharedCache;
             cache.SetMemorySizeLimit(80000);
             string url = "myimage.com/image";
-            var textureA = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
-            var textureB = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
+            var textureA = new CachedWebImage("0", new Texture2D(100, 100));
+            var textureB = new CachedWebImage("0", new Texture2D(100, 100));
 
             cache.SetTextureResourceForURL(url, textureA);
             Assert.AreEqual(cache.TextureResourceForURL(url), textureA);
@@ -76,9 +76,9 @@ namespace Shopify.UIToolkit.Test.Unit {
             string urlB = "myimage.com/imageB";
             string urlC = "myimage.com/imageC";
 
-            var textureA = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
-            var textureB = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
-            var textureC = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
+            var textureA = new CachedWebImage("0", new Texture2D(100, 100));
+            var textureB = new CachedWebImage("0", new Texture2D(100, 100));
+            var textureC = new CachedWebImage("0", new Texture2D(100, 100));
 
             cache.SetTextureResourceForURL(urlA, textureA);
             cache.SetTextureResourceForURL(urlB, textureB);
@@ -104,8 +104,8 @@ namespace Shopify.UIToolkit.Test.Unit {
             string urlA = "myimage.com/imageA";
             string urlB = "myimage.com/imageB";
 
-            var textureA = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
-            var textureB = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
+            var textureA = new CachedWebImage("0", new Texture2D(100, 100));
+            var textureB = new CachedWebImage("0", new Texture2D(100, 100));
 
             cache.SetTextureResourceForURL(urlA, textureA);
             cache.SetTextureResourceForURL(urlB, textureB);
@@ -132,8 +132,8 @@ namespace Shopify.UIToolkit.Test.Unit {
             string urlA = "myimage.com/imageA";
             string urlB = "myimage.com/imageB";
 
-            var textureA = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
-            var textureB = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
+            var textureA = new CachedWebImage("0", new Texture2D(100, 100));
+            var textureB = new CachedWebImage("0", new Texture2D(100, 100));
 
             cache.SetTextureResourceForURL(urlA, textureA);
             cache.SetTextureResourceForURL(urlB, textureB);
@@ -165,7 +165,7 @@ namespace Shopify.UIToolkit.Test.Unit {
             WebImageCache cache = WebImageCache.SharedCache;
 
             string url = "myimage.com/imageA";
-            var texture = new CachedWebResource<Texture2D>("0", new Texture2D(100, 100));
+            var texture = new CachedWebImage("0", new Texture2D(100, 100));
 
             cache.SetTextureResourceForURL(url, texture);
 


### PR DESCRIPTION
This PR abstracts out a DataCache interface and LRUCache abstract class from WebImageCache. This will open us to using the LRU cache heuristic for request caching if we want and also gives us an interface for defining other types of caches with.
WebImageCache is implemented using the refactored abstraction and uses the same test cases.