### PR TITLE
Adds UseCache flag to RemoteImageLoader

### DIFF
--- a/Assets/Shopify/UIToolkit/Components/HTTPUtils.cs
+++ b/Assets/Shopify/UIToolkit/Components/HTTPUtils.cs
@@ -1,0 +1,26 @@
+namespace Shopify.UIToolkit {
+    using System;
+    using System.Text.RegularExpressions;
+
+    public static class HTTPUtils {
+        /// <summary>
+        /// Parses the 'Status XXX' HTTP header field for the status code number.
+        /// </summary>
+        /// <param name="statusLine">HTTP STATUS field</param>
+        /// <returns>HTTP Status code</returns>
+        public static int ParseResponseCode(string statusLine) {
+            int ret = 0;
+            var regex = new Regex("HTTP\\/1.1 (\\d*)");
+            var match = regex.Match(statusLine);
+            if (match.Success && match.Groups.Count >= 2) {
+                Group g = match.Groups[1];
+                CaptureCollection cc = g.Captures;
+                if (cc.Count > 0) {
+                    Capture c = cc[0];
+                    int.TryParse(c.ToString(), out ret);
+                }
+            }
+            return ret;
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Components/HTTPUtils.cs.meta
+++ b/Assets/Shopify/UIToolkit/Components/HTTPUtils.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bcebd1303ccd540c4a7133fcfefb387d
+timeCreated: 1512413673
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Components/RemoteImageLoader.cs
+++ b/Assets/Shopify/UIToolkit/Components/RemoteImageLoader.cs
@@ -118,7 +118,7 @@ namespace Shopify.UIToolkit {
             var responseHeaders = www.responseHeaders;
             if (responseHeaders.ContainsKey("STATUS")) {
                 string statusCodeLine = responseHeaders["STATUS"];
-                if (ParseResponseCode(statusCodeLine) == 304) {
+                if (HTTPUtils.ParseResponseCode(statusCodeLine) == 304) {
                     if (cachedResource != null) {
                         completion(cachedResource.texture, null);
                     } else {
@@ -137,19 +137,6 @@ namespace Shopify.UIToolkit {
             _imageCache.SetTextureForURL(url, texture, lastModifiedString);
             completion(texture, null);
         }
-
-        /// <summary>
-        /// Parses the 'Status XXX' HTTP header field for the status code number.
-        /// </summary>
-        /// <param name="statusLine">HTTP STATUS field</param>
-        /// <returns>HTTP Status code</returns>
-        private static int ParseResponseCode(string statusLine) {
-            int ret = 0;
-            string[] components = statusLine.Split(' ');
-            int.TryParse(components[1], out ret);
-            return ret;
-        }
-
     }
 }
 

--- a/Assets/Shopify/UIToolkit/Components/RemoteImageLoader.cs
+++ b/Assets/Shopify/UIToolkit/Components/RemoteImageLoader.cs
@@ -12,9 +12,9 @@ namespace Shopify.UIToolkit {
     public class RemoteImageLoader : MonoBehaviour {
 
         /// <summary>
-        /// When true, downloaded images will be cached.
+        /// When true, downloaded images will be cached. Defaults to true.
         /// </summary>
-        public bool UseCache;
+        public bool UseCache = true;
 
         private Image _image;
 
@@ -96,13 +96,6 @@ namespace Shopify.UIToolkit {
             completion(www.texture, null);
         }
 
-        /// <summary>
-        /// Loads an image from the provided URL if we don't have one in the cache or if it's new. Results are cached
-        /// so subsequent images are not downloaded from the web.
-        /// </summary>
-        /// <param name="url">URL to fetch image from.</param>
-        /// <param name="completion">Callback invoked with the cached or downloaded texture.</param>
-        /// <returns></returns>
         private IEnumerator CachedLoadImageURLRoutine(string url, RemoteImageCompletionDelegate completion) {
             var requestHeaders = new Dictionary<string, string>();
             var cachedResource = _imageCache.TextureResourceForURL(url);

--- a/Assets/Shopify/UIToolkit/Components/WebImageCache.cs
+++ b/Assets/Shopify/UIToolkit/Components/WebImageCache.cs
@@ -14,7 +14,7 @@
             }
         }
 
-        public readonly DateTime Timestamp;
+        public readonly string LastModified;
 
         public object Data {
             get {
@@ -24,9 +24,9 @@
 
         private object _data;
 
-        public CacheableWebImage(Texture2D data, DateTime timestamp) {
+        public CacheableWebImage(Texture2D data, string timestamp) {
             _data = data;
-            Timestamp = timestamp;
+            LastModified = timestamp;
         }
 
         public int SizeInBytes() {
@@ -74,9 +74,9 @@
         /// </summary>
         /// <param name="url">URL the image was fetched from.</param>
         /// <param name="texture">Texture2D instance of the downloaded image.</param>
-        /// <param name="timestamp">Timestamp of when the image as last modified.</param>
-        public void SetTextureForURL(string url, Texture2D texture, DateTime timestamp) {
-            var webImage = new CacheableWebImage(texture, timestamp);
+        /// <param name="lastModified">Timestamp of when the image as last modified.</param>
+        public void SetTextureForURL(string url, Texture2D texture, string lastModified) {
+            var webImage = new CacheableWebImage(texture, lastModified);
             SetResourceForKey(url, webImage);
         }
 

--- a/Assets/Shopify/UIToolkit/Test/Integration/TestRemoteImageLoaderIntegration.cs
+++ b/Assets/Shopify/UIToolkit/Test/Integration/TestRemoteImageLoaderIntegration.cs
@@ -9,6 +9,11 @@ namespace Shopify.UIToolkit.Test.Integration {
 
     public class TestRemoteImageLoaderIntegration : MonoBehaviour {
 
+        [TearDown]
+        public void Cleanup() {
+            WebImageCache.SharedCache.Clear();
+        }
+
         [UnityTest] 
         public IEnumerator TestDownloadImage() {
             var gameObject = new GameObject();
@@ -28,6 +33,44 @@ namespace Shopify.UIToolkit.Test.Integration {
 
             var image = gameObject.GetComponent<Image>();
             Assert.NotNull(image.sprite);
+        }
+
+        [UnityTest] 
+        public IEnumerator TestDownloadImageThatsCached() {
+            var imageURL = "https://cdn.shopify.com/s/files/1/2094/7261/products/product-image-305453751.jpg?v=1497377691";  
+            var gameObject = new GameObject();
+            var loader = gameObject.AddComponent<RemoteImageLoader>();
+            loader.UseCache = true;
+
+            bool requestFinished = false;
+
+            loader.LoadImage(
+                imageURL: imageURL,
+                success: () => { requestFinished = true; },
+                failure: (e) =>  { requestFinished = true; }
+            );
+
+            while (!requestFinished) {
+                yield return null;
+            }
+
+            var image = gameObject.GetComponent<Image>();
+            Assert.NotNull(image.sprite);
+
+            var cachedResource = WebImageCache.SharedCache.TextureResourceForURL(imageURL);
+            Assert.NotNull(cachedResource);
+
+            requestFinished = false;
+
+            // Load the image again but this time it should be cached.
+            loader.LoadImage(
+                imageURL: imageURL,
+                success: () => { requestFinished = true; },
+                failure: (e) =>  { requestFinished = true; }
+            );
+
+            var spriteTexture = gameObject.GetComponent<Image>().sprite.texture;
+            Assert.AreEqual(spriteTexture, cachedResource.texture);
         }
     }
 }

--- a/Assets/Shopify/UIToolkit/Test/Integration/TestWebImageCacheIntegration.cs
+++ b/Assets/Shopify/UIToolkit/Test/Integration/TestWebImageCacheIntegration.cs
@@ -30,7 +30,7 @@ namespace Shopify.UIToolkit.Test.Integration {
             foreach (var imageURL in TenMBInImages) {
                 WWW www = new WWW(imageURL);
                 yield return www;
-                cache.SetTextureForURL(imageURL, www.texture, DateTime.Now);
+                cache.SetTextureForURL(imageURL, www.texture, "");
             }
 
             Assert.AreEqual(cache.Count, 6);
@@ -45,7 +45,7 @@ namespace Shopify.UIToolkit.Test.Integration {
             foreach (var imageURL in TenMBInImages) {
                 WWW www = new WWW(imageURL);
                 yield return www;
-                cache.SetTextureForURL(imageURL, www.texture, DateTime.Now);
+                cache.SetTextureForURL(imageURL, www.texture, "");
             }
 
             Assert.AreEqual(cache.Count, 3);

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestHTTPUtils.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestHTTPUtils.cs
@@ -1,0 +1,24 @@
+namespace Shopify.UIToolkit.Test.Unit {
+    using System.Collections;
+    using NUnit.Framework;
+    using Shopify.UIToolkit;
+
+    [TestFixture]
+    public class TestHTTPUtils {
+
+        [Test]
+        public void TestParseStatusCode() {
+            var input = "HTTP/1.1 200";
+            Assert.AreEqual(200, HTTPUtils.ParseResponseCode(input));
+
+            var input2 = "HTTP/1.1 304";
+            Assert.AreEqual(304, HTTPUtils.ParseResponseCode(input2));
+        }
+
+        [Test]
+        public void TestParseGarbageStatusCode() {
+            var input = "HTTP/1.1 asdf";
+            Assert.AreEqual(0, HTTPUtils.ParseResponseCode(input));
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestHTTPUtils.cs.meta
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestHTTPUtils.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6f864cf92099d406fb66c9056fd060e1
+timeCreated: 1512413673
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestWebImageCache.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestWebImageCache.cs
@@ -27,7 +27,7 @@ namespace Shopify.UIToolkit.Test.Unit {
             WebImageCache cache = WebImageCache.SharedCache;
             string mockURL = "myimage.com/image";
             Texture2D mockTexture = new Texture2D(100, 100);
-            cache.SetTextureForURL(mockURL, mockTexture, DateTime.Now);
+            cache.SetTextureForURL(mockURL, mockTexture, "");
 
             Assert.NotNull(cache.TextureResourceForURL(mockURL));
             Assert.AreEqual(cache.EstimatedMemorySize, 40000);
@@ -38,7 +38,7 @@ namespace Shopify.UIToolkit.Test.Unit {
             WebImageCache cache = WebImageCache.SharedCache;
             string mockURL = "myimage.com/image";
             Texture2D mockTexture = new Texture2D(100, 100);
-            cache.SetTextureForURL(mockURL, mockTexture, DateTime.Now);
+            cache.SetTextureForURL(mockURL, mockTexture, "");
 
             Assert.NotNull(cache.TextureResourceForURL(mockURL).texture);
             Assert.AreEqual(cache.EstimatedMemorySize, 40000);
@@ -56,9 +56,9 @@ namespace Shopify.UIToolkit.Test.Unit {
             var textureA = new Texture2D(100, 100);
             var textureB = new Texture2D(100, 100);
 
-            cache.SetTextureForURL(url, textureA, DateTime.Now);
+            cache.SetTextureForURL(url, textureA, "");
             Assert.AreEqual(cache.TextureResourceForURL(url).texture, textureA);
-            cache.SetTextureForURL(url, textureB, DateTime.Now);
+            cache.SetTextureForURL(url, textureB, "");
             Assert.AreEqual(cache.TextureResourceForURL(url).texture, textureB);
 
             Assert.AreEqual(cache.EstimatedMemorySize, 40000);
@@ -77,14 +77,14 @@ namespace Shopify.UIToolkit.Test.Unit {
             var textureB = new Texture2D(100, 100);
             var textureC = new Texture2D(100, 100);
 
-            cache.SetTextureForURL(urlA, textureA, DateTime.Now);
-            cache.SetTextureForURL(urlB, textureB, DateTime.Now);
+            cache.SetTextureForURL(urlA, textureA, "");
+            cache.SetTextureForURL(urlB, textureB, "");
 
             Assert.NotNull(cache.TextureResourceForURL(urlA));
             Assert.NotNull(cache.TextureResourceForURL(urlB));
             Assert.AreEqual(cache.EstimatedMemorySize, 80000);
 
-            cache.SetTextureForURL(urlC, textureC, DateTime.Now);
+            cache.SetTextureForURL(urlC, textureC, "");
 
             // Make sure we're still at our limit and that url A got evicted.
             Assert.AreEqual(cache.EstimatedMemorySize, 80000);
@@ -104,8 +104,8 @@ namespace Shopify.UIToolkit.Test.Unit {
             var textureA = new Texture2D(100, 100);
             var textureB = new Texture2D(100, 100);
 
-            cache.SetTextureForURL(urlA, textureA, DateTime.Now);
-            cache.SetTextureForURL(urlB, textureB, DateTime.Now);
+            cache.SetTextureForURL(urlA, textureA, "");
+            cache.SetTextureForURL(urlB, textureB, "");
 
             Assert.NotNull(cache.TextureResourceForURL(urlA));
             Assert.NotNull(cache.TextureResourceForURL(urlB));
@@ -132,8 +132,8 @@ namespace Shopify.UIToolkit.Test.Unit {
             var textureA = new Texture2D(100, 100);
             var textureB = new Texture2D(100, 100);
 
-            cache.SetTextureForURL(urlA, textureA, DateTime.Now);
-            cache.SetTextureForURL(urlB, textureB, DateTime.Now);
+            cache.SetTextureForURL(urlA, textureA, "");
+            cache.SetTextureForURL(urlB, textureB, "");
 
             Assert.NotNull(cache.TextureResourceForURL(urlA));
             Assert.NotNull(cache.TextureResourceForURL(urlB));
@@ -164,7 +164,7 @@ namespace Shopify.UIToolkit.Test.Unit {
             string url = "myimage.com/imageA";
             var texture = new Texture2D(100, 100);
 
-            cache.SetTextureForURL(url, texture, DateTime.Now);
+            cache.SetTextureForURL(url, texture, "");
 
             Assert.NotNull(cache.TextureResourceForURL(url));
             Assert.AreEqual(cache.EstimatedMemorySize, 40000);


### PR DESCRIPTION
* Adds boolean flag `UseCache` to `RemoteImageLoader` to cache
downloaded images into the shared WebImageCache instance.

* Images downloaded are cached alongside their "Last Modified" timestamp
to prevent re-downloads of cached data and cache invalidation when they
are updated on the API side.