### PR TITLE
[Fix] Fixes bug where npe occurs when loading a node that doesn't exist

### DIFF
--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeController.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductThemeController.cs
@@ -57,7 +57,6 @@
             }
         }
 
-        /* TODO: Fix bug where exception is thrown when productGID is valid but not found on shop
         [UnityTest]
         public IEnumerator TestShowCallsOnErrorWhenProductDoesntExist() {
             _controller.ProductGID = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEzNTI1NDIzOQ==";
@@ -70,8 +69,8 @@
             }).Do((x) => {
                 var error = x.Args()[0] as ShopifyError;
 
-                Assert.AreEqual(ShopifyError.ErrorType.GraphQL, error.Type);
-                Assert.AreEqual("", error.Description);
+                Assert.AreEqual(ShopifyError.ErrorType.UserError, error.Type);
+                Assert.AreEqual("Product not found", error.Description);
 
                 callbackCalled = true;
             });
@@ -82,7 +81,6 @@
 
             _theme.DidNotReceive().OnShouldShowProduct(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
         }
-        */
 
         [UnityTest]
         public IEnumerator TestShowPropogatesErrorsToThemeOnError() {

--- a/Assets/Shopify/UIToolkit/Theme Controllers/SingleProductThemeController.cs
+++ b/Assets/Shopify/UIToolkit/Theme Controllers/SingleProductThemeController.cs
@@ -1,9 +1,9 @@
 ﻿namespace Shopify.UIToolkit {
-    using System.Collections;
     using System.Collections.Generic;
+    using System.Collections;
     using System.Linq;
-    using Shopify.Unity;
     using Shopify.Unity.SDK;
+    using Shopify.Unity;
     using UnityEngine;
 
     [AddComponentMenu("Shopify/Theme Controllers/Single Product Theme Controller")]
@@ -22,6 +22,11 @@
         private void OnProductsLoaded(List<Product> products, ShopifyError error) {
             if (error != null) {
                 Theme.OnError(error);
+                return;
+            }
+
+            if (products.Count == 0) {
+                Theme.OnError(new ShopifyError(ShopifyError.ErrorType.UserError, "Product not found"));
                 return;
             }
 

--- a/scripts/generator/graphql_generator/csharp/type_response.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type_response.cs.erb
@@ -181,6 +181,7 @@ namespace Shopify.Unity {
             var nodes = new List<Node>();
 
             foreach (var obj in objects) {
+                if (obj == null) continue;
                 nodes.Add(UnknownNode.Create((Dictionary<string,object>) obj));
             }
 


### PR DESCRIPTION
When you load a node by id that doesn't exist, shopify returns `null` in
the response. This skips the null nodes which returns a normal looking
empty list in the query result.