### PR TITLE
Variant/Selection Option Lookups

### DIFF
--- a/Assets/Shopify/UIToolkit/Components/VariantSelector.cs
+++ b/Assets/Shopify/UIToolkit/Components/VariantSelector.cs
@@ -2,7 +2,6 @@ namespace Shopify.UIToolkit {
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Collections.Specialized;
     using System.Linq;
     using Shopify.Unity;
 

--- a/Assets/Shopify/UIToolkit/Components/VariantSelector.cs
+++ b/Assets/Shopify/UIToolkit/Components/VariantSelector.cs
@@ -1,0 +1,101 @@
+namespace Shopify.UIToolkit {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.Linq;
+    using Shopify.Unity;
+
+    using UnityEngine;
+
+    /// <summary>
+    /// Converts the list of product variant and their respective selectable options that looks like:
+    /// [{
+    ///    "selectedOptions": [{
+    ///       "name": "optionName1",
+    ///       "value": "value1"
+    ///     }, {
+    ///       "name": "optionName2",
+    ///       "value": "value1"
+    ///     }]
+    /// },
+    /// {
+    ///    "selectedOptions": [{
+    ///       "name": "optionName1",
+    ///       "value": "value2"
+    ///     }, {
+    ///       "name": "optionName2",
+    ///       "value": "value2"
+    ///     }]
+    /// }]
+    /// into a map that looks like:
+    /// {
+    ///   "optionName1": ["value1", "value2", ...],
+    ///   "optionName2": ["value1", "value2", ...],
+    /// }
+    ///
+    /// </summary>
+    public class VariantSelector {
+        private const string SingleVariantTitle = "Default Title";
+
+        private List<ProductVariant> _variants;
+
+        public VariantSelector(List<ProductVariant> variants) {
+            _variants = variants;
+        }
+
+        public Dictionary<string, List<string>> AllOptions() {
+            return ValidOptionsForSelections(new Dictionary<string, string>());
+        }
+
+        public Dictionary<string, List<string>> ValidOptionsForSelections(Dictionary<string, string> selections) {
+            if (IsSingleOrEmpty()) {
+                return null;
+            }
+
+            var allOptions = new Dictionary<string, List<string>>();
+            foreach (var variant in _variants) {
+                var options = variant.selectedOptions();
+
+                var containsSelections = selections.Aggregate(true, (accum, entry) => {
+                    return accum && options.Find(o => {
+                        return o.name().Equals(entry.Key) && o.value().Equals(entry.Value);
+                    }) != null;
+                });
+
+                // Skip this variant if it's not valid with the selections.
+                if (containsSelections) {
+                    options.Aggregate(allOptions, (accum, option) => {
+                        List<string> values;
+                        if (!accum.ContainsKey(option.name())) {
+                            accum.Add(option.name(), new List<string>());
+                        }
+                        values = accum[option.name()];
+
+                        // Avoid duplicates.
+                        if (values.Find(v => v.Equals(option.value())) == null) {
+                            values.Add(option.value());
+                        }
+
+                        return accum;
+                    });
+                }
+            }
+            return allOptions;
+        }
+
+        private bool IsSingleOrEmpty() {
+            if (_variants.Count == 0)  {
+                return true;
+            }
+
+            // This is what the Storefront API returns back to us when there are no variants...
+            if (_variants.Count == 1 && _variants[0].title() == SingleVariantTitle) {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+

--- a/Assets/Shopify/UIToolkit/Components/VariantSelector.cs.meta
+++ b/Assets/Shopify/UIToolkit/Components/VariantSelector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 618d4efe973fd4c589ee259c89e98955
+timeCreated: 1513287700
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestVariantSelector.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestVariantSelector.cs
@@ -1,0 +1,152 @@
+namespace Shopify.UIToolkit.Test.Unit {
+    using System.Collections;
+    using System.Collections.Generic;
+    using UnityEngine;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+    using Shopify.Unity;
+    using Shopify.Unity.MiniJSON;
+
+    [TestFixture]
+    public class TestVariantSelector {
+
+        [Test]
+        public void TestDefaultVariant() {
+            string oneVariantProduct = @"
+            [
+                {
+                    ""node"": {
+                      ""title"": ""Default Title"",
+                      ""selectedOptions"": [
+                        {
+                          ""name"": ""Title"",
+                          ""value"": ""Default Title""
+                        }
+                      ]
+                    }
+                }
+            ]";
+
+            var selector = new VariantSelector(VariantsFromString(oneVariantProduct));
+            var options = selector.AllOptions();
+            Assert.IsNull(options);
+        }
+
+        [Test]
+        public void TestCoupleOfVariants() {
+            string twoVariantProduct = @"
+            [
+                {
+                    ""node"": {
+                      ""title"": ""Black / Small"",
+                      ""selectedOptions"": [
+                        {
+                          ""name"": ""Color"",
+                          ""value"": ""Black""
+                        },
+                        {
+                          ""name"": ""Size"",
+                          ""value"": ""Small""
+                        }
+                      ]
+                    }
+                }
+            ]";
+
+            var selector = new VariantSelector(VariantsFromString(twoVariantProduct));
+            var options = selector.AllOptions();
+            Assert.AreEqual(options.Count, 2);
+            Assert.AreEqual(options["Color"], new List<string>{ "Black" });
+            Assert.AreEqual(options["Size"], new List<string>{ "Small" });
+        }
+
+        [Test]
+        public void TestAllOptions() {
+            var selector = new VariantSelector(ManyVariants());
+            var options = selector.AllOptions();
+            Assert.AreEqual(options.Count, 3);
+            Assert.AreEqual(options["Color"], new List<string>{ "Blue" });
+            Assert.AreEqual(options["Size"], new List<string>{ "Small", "Medium" });
+            Assert.AreEqual(options["Language"], new List<string>{ "English", "French" });
+        }
+
+        [Test]
+        public void TestSelectingOptionsExcludesInvalidChoices() {
+            var selector = new VariantSelector(ManyVariants());
+            var colorSelected = selector.ValidOptionsForSelections(new Dictionary<string, string>() {
+              {"Color", "Blue"}
+            });
+
+            Assert.AreEqual(new List<string>() {"Blue"}, colorSelected["Color"]);
+            Assert.AreEqual(new List<string>() {"Small", "Medium"}, colorSelected["Size"]);
+            Assert.AreEqual(new List<string>() {"English", "French"}, colorSelected["Language"]);
+
+
+            var sizeColorSelected = selector.ValidOptionsForSelections(new Dictionary<string, string>() {
+              {"Color", "Blue"},
+              {"Size", "Medium"}
+            });
+            Assert.AreEqual(new List<string>() {"Blue"}, sizeColorSelected["Color"]);
+            Assert.AreEqual(new List<string>() {"Medium"}, sizeColorSelected["Size"]);
+
+            // Only French should be available since "Blue/Medium/English" isn't a valid product variant.
+            Assert.AreEqual(new List<string>() {"French"}, sizeColorSelected["Language"]);
+        }
+
+        private List<ProductVariant> VariantsFromString(string input) {
+            var objects = (List<object>)Json.Deserialize(input);
+            List<ProductVariant> variants = new List<ProductVariant>();
+            foreach (var obj in objects) {
+                var dict = (Dictionary<string, object>)obj;
+                variants.Add(new ProductVariant((Dictionary<string, object>)dict["node"]));
+            }
+            return variants;
+        }
+
+        private List<ProductVariant> ManyVariants() {
+            string threeVariantProduct = @"
+            [
+                {
+                    ""node"": {
+                      ""title"": ""Blue / Small / English"",
+                      ""selectedOptions"": [
+                        {
+                          ""name"": ""Color"",
+                          ""value"": ""Blue""
+                        },
+                        {
+                          ""name"": ""Size"",
+                          ""value"": ""Small""
+                        },
+                        {
+                          ""name"": ""Language"",
+                          ""value"": ""English""
+                        }
+                      ]
+                    }
+                },
+                {
+                    ""node"": {
+                      ""title"": ""Blue / Medium / French"",
+                      ""selectedOptions"": [
+                        {
+                          ""name"": ""Color"",
+                          ""value"": ""Blue""
+                        },
+                        {
+                          ""name"": ""Size"",
+                          ""value"": ""Medium""
+                        },
+                        {
+                          ""name"": ""Language"",
+                          ""value"": ""French""
+                        }
+                      ]
+                    }
+                }
+            ]";
+
+            return VariantsFromString(threeVariantProduct);
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestVariantSelector.cs.meta
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestVariantSelector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b33bb99fe56b34084ba3a2dd06d8ca0a
+timeCreated: 1513287318
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ProductVariants on a product give us a set of selectable options but doesn't do a good job of seperating those options. For some of the UI we're looking to build for the UI Toolkit, we'll want to be able to select options independently of options. For example, select the Color of the shirt, then select the Size. This PR adds a class named `VariantOptionLookup` that takes in the variants on Product and builds an initial list of SelectionOptions to choose from. Once a user selects an option, you can pass this option back into the lookup class to get a set of the next selectable options.