### PR TITLE
Publish unitypackage from the editor

### DIFF
--- a/Assets/Editor/Publishing.cs
+++ b/Assets/Editor/Publishing.cs
@@ -1,0 +1,86 @@
+#if !SHOPIFY_MONO_UNIT_TEST
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+public class Publishing {
+    public static string[] DirectoriesInPackage = new string[] {
+        "Assets/PlayServicesResolver/",
+        "Assets/PlayServicesResolver/Editor/",
+        "Assets/Shopify/",
+        "Assets/Shopify/Examples/",
+        "Assets/Shopify/Examples/3DAssets/",
+        "Assets/Shopify/Examples/3DAssets/Environment/",
+        "Assets/Shopify/Examples/3DAssets/Environment/Materials/",
+        "Assets/Shopify/Examples/3DAssets/Environment/Textures/",
+        "Assets/Shopify/Examples/3DAssets/VendingMachine/",
+        "Assets/Shopify/Examples/3DAssets/VendingMachine/Materials/",
+        "Assets/Shopify/Examples/3DAssets/VendingMachine/Textures/",
+        "Assets/Shopify/Examples/Animation/",
+        "Assets/Shopify/Examples/Animation/Camera/",
+        "Assets/Shopify/Examples/Animation/Canvas/",
+        "Assets/Shopify/Examples/Animation/Error Panel/",
+        "Assets/Shopify/Examples/Editor/",
+        "Assets/Shopify/Examples/Font/",
+        "Assets/Shopify/Examples/Images/",
+        "Assets/Shopify/Examples/Images/HomeScreen/",
+        "Assets/Shopify/Examples/Images/NewIcons/",
+        "Assets/Shopify/Examples/PostEffects/",
+        "Assets/Shopify/Examples/Prefabs/",
+        "Assets/Shopify/Examples/Scenes/",
+        "Assets/Shopify/Examples/Scenes/Vending Machine Example/",
+        "Assets/Shopify/Examples/Scripts/",
+        "Assets/Shopify/Examples/Scripts/Components/",
+        "Assets/Shopify/Examples/Scripts/Helpers/",
+        "Assets/Shopify/Examples/Scripts/LineItems/",
+        "Assets/Shopify/Examples/Scripts/Panels/",
+        "Assets/Shopify/Plugins/",
+        "Assets/Shopify/Plugins/Android/",
+        "Assets/Shopify/Plugins/Android/libs/",
+        "Assets/Shopify/Plugins/Editor/",
+        "Assets/Shopify/Plugins/iOS/",
+        "Assets/Shopify/Plugins/iOS/Shopify/",
+        "Assets/Shopify/Plugins/iOS/Shopify/Deserializable/",
+        "Assets/Shopify/Plugins/iOS/Shopify/PaymentAuthorizationControlling/",
+        "Assets/Shopify/Plugins/iOS/Shopify/Serializable/",
+        "Assets/Shopify/Plugins/iOS/Shopify/String/",
+        "Assets/Shopify/Unity/",
+        "Assets/Shopify/Unity/Editor/",
+        "Assets/Shopify/Unity/Editor/BuildPipeline/",
+        "Assets/Shopify/Unity/Generated/",
+        "Assets/Shopify/Unity/Generated/GraphQL/",
+        "Assets/Shopify/Unity/SDK/",
+        "Assets/Shopify/Unity/SDK/Android/",
+        "Assets/Shopify/Unity/SDK/Editor/",
+        "Assets/Shopify/Unity/SDK/iOS/",
+        "Assets/Shopify/Unity/Static/",
+        "Assets/Shopify/Unity/Static/Editor/",
+        "Assets/Shopify/Unity/Static/Editor/Resources/",
+        "Assets/Shopify/Unity/UI/",
+        "Assets/Shopify/Unity/Vendor/"
+    };
+
+    public static void Publish(string packageName) {
+        var filesToIncludeInPackage = new List<string>();
+
+        foreach(var dir in DirectoriesInPackage) {
+            var files = Directory.GetFiles(dir);
+            filesToIncludeInPackage.AddRange(files);
+        }
+
+        AssetDatabase.ExportPackage(filesToIncludeInPackage.ToArray(), packageName, ExportPackageOptions.Default);
+    }
+
+    public static void PublishFromCommandLine() {
+        var packageName = System.Environment.GetCommandLineArgs().First();
+        Publish(packageName);
+    }
+
+    [MenuItem("Build/Publish Unitypackage")]
+    public static void PublishFromUnityMenu() {
+        Publish("shopify-buy.unitypackage");
+    }
+}
+#endif

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -86,8 +86,9 @@ printf "Exporting the unitypackage at: %s\n" "$UNITY_PACKAGE"
     -logFile "$UNITY_LOG_PATH" \
     -importPackage "ThirdParty/play-services-resolver-1.2.54.0.unitypackage" \
     -projectPath "$PROJECT_ROOT" \
-    -exportPackage Assets/Shopify Assets/PlayServicesResolver "$UNITY_PACKAGE" \
-    -quit
+    -executeMethod "Publishing.PublishFromCommandLine" \
+    -quit \
+    $UNITY_PACKAGE
 
 PUBLISH_SUCCESS=$?
 


### PR DESCRIPTION
Includes configurations so that we only package directories included in
the whitelist, as well as the ability to package files from the editor.