### PR TITLE
move ShopifyError up from SDK

### DIFF
--- a/Assets/Shopify/UIToolkit/Themes/IThemeBase.cs
+++ b/Assets/Shopify/UIToolkit/Themes/IThemeBase.cs
@@ -2,6 +2,7 @@
     using System.Collections;
     using System.Collections.Generic;
     using Shopify.Unity.SDK;
+    using Shopify.Unity;
     using UnityEngine;
 
     public interface IThemeBase {

--- a/Assets/Shopify/Unity/ShopifyError.cs
+++ b/Assets/Shopify/Unity/ShopifyError.cs
@@ -1,5 +1,6 @@
-namespace Shopify.Unity.SDK {
+namespace Shopify.Unity {
     using System.Collections.Generic;
+    using Shopify.Unity.SDK;
     using MiniJSON;
 
     /// <summary>


### PR DESCRIPTION
related: https://github.com/Shopify/unity-buy-sdk/issues/414#issuecomment-352101457

Moves ShopifyError up from Shopify.Unity.SDK to Shopify.Unity namespace.