### PR TITLE
add string version of AddOrUpdate

### DIFF
--- a/Assets/Editor/MockLoaderProducts.cs
+++ b/Assets/Editor/MockLoaderProducts.cs
@@ -13,6 +13,7 @@ namespace Shopify.Tests {
             SetupQueriesOnShopProducts();
             SetupQueriesOnNodeForImageConnections();
             SetupQueriesOnNodesForProducts();
+            SetupQueriesOnNodeForProductVariant();
         }
 
         private void SetupQueriesOnShopProducts() {
@@ -226,6 +227,64 @@ namespace Shopify.Tests {
                     }}
                 }}
             }}", GetImageNodes(2, DefaultQueries.MaxPageSize), UtilsMockLoader.GetJSONBool(false));
+
+            AddResponse(query, response);
+        }
+
+        public void SetupQueriesOnNodeForProductVariant() {
+            // OK response
+            QueryRootQuery query = new QueryRootQuery();
+
+            query.node(n => n
+                .onProductVariant(p => p
+                    .id()
+                    .price()
+                ),
+                id: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMTI0Mzc="
+            );
+
+            string response = String.Format(@"{{
+                  ""data"": {{
+                    ""node"": {{
+                      ""__typename"": ""ProductVariant"",
+                      ""id"": ""Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMTI0Mzc="",
+                      ""price"": ""399.00""
+                    }}
+                  }}
+                }}"
+            );
+
+            AddResponse(query, response);
+
+            // Error response
+            query = new QueryRootQuery();
+
+            query.node(n => n
+                .onProductVariant(p => p
+                    .id()
+                    .price()
+                ),
+                id: "error"
+            );
+
+            response = String.Format(@"{{
+              ""errors"": [
+                {{
+                  ""message"": ""Argument 'id' on Field 'node' has an invalid value. Expected type 'ID!'."",
+                  ""locations"": [
+                    {{
+                      ""line"": 3,
+                      ""column"": 2
+                    }}
+                  ],
+                  ""fields"": [
+                    ""query"",
+                    ""node"",
+                    ""id""
+                  ]
+                }}
+              ]
+            }}");
 
             AddResponse(query, response);
         }

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -232,6 +232,30 @@ namespace Shopify.Tests
         }
 
         [Test]
+        public void AddOrUpdateWithVariantId() {
+            ShopifyBuy.Init(new MockLoader());
+
+            string variantId1 = "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMTI0Mzc=";
+
+            Cart cart = ShopifyBuy.Client().Cart();
+
+            cart.LineItems.AddOrUpdate(variantId1, 100);
+
+            Assert.AreEqual(100, cart.LineItems.Get(variantId1).Quantity, "variant 20756129155 Quantity is 100 after change");
+
+            NoMatchingVariantException exception = null;
+
+            try {
+                cart.LineItems.AddOrUpdate("error", 100);
+            } catch (NoMatchingVariantException e) {
+                exception = e;
+            }
+
+            Assert.IsNotNull(exception);
+            Assert.AreEqual("Could not `AddOrUpdate` line item as no matching variant could be found for given id", exception.Message);
+        }
+
+        [Test]
         public void AddEditRemoveViaSelectedOptions() {
             ShopifyBuy.Init(new MockLoader());
 

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -194,6 +194,20 @@ namespace Shopify.Unity.SDK {
             }
         }
 
+        /// <summary>
+        /// Adds or updates a line item using a <see ref="ProductVariant">ProductVariant </see> id. Note that a remote
+        /// query will be used to verify the string based variantId.
+        /// </summary>
+        /// <param name="variantId">id of a <see ref="ProductVariant">ProductVariant </see> which will be used to create or update a line item</param>
+        /// <param name="quantity">the number of items you'd like to order for variantId</param>
+        /// <param name="customAttributes">can be used to define extra information for this line item</param>
+        /// \code
+        /// // Example that updates the quantity of items to be purchased to 3.
+        /// // If no line item exists for `variantId`, then a new line item is created
+        /// Cart cart = ShopifyBuy.Client().Cart();
+        ///
+        /// cart.LineItems.AddOrUpdate("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMTI0Mzc=", 3);
+        /// \endcode
         public void AddOrUpdate(string variantId, long? quantity = null, Dictionary<string, string> customAttributes = null) {
             QueryRoot response = null;
 

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -58,10 +58,13 @@ namespace Shopify.Unity.SDK {
         private ObservableDictionary<string, string> _CustomAttributes;
         private OnCartLineItemChange OnChange;
 
-        public CartLineItem(ProductVariant variant, OnCartLineItemChange onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
-            _VariantId = variant.id();
+        public CartLineItem(ProductVariant variant, OnCartLineItemChange onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) :
+            this(variant.id(), variant.price(), onChange, quantity, customAttributes) { }
+
+        public CartLineItem(string variantId, decimal variantPrice, OnCartLineItemChange onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
+            _VariantId = variantId;
             _Quantity = quantity;
-            _Price = variant.price();
+            _Price = variantPrice;
             OnChange = onChange;
 
             if (customAttributes != null) {
@@ -168,7 +171,11 @@ namespace Shopify.Unity.SDK {
         /// cart.LineItems.AddOrUpdate(variant, 3);
         /// \endcode
         public void AddOrUpdate(ProductVariant variant, long? quantity = null, Dictionary<string, string> customAttributes = null) {
-            CartLineItem input = Get(variant.id());
+            AddOrUpdate(variant.id(), variant.price(), quantity, customAttributes);
+        }
+
+        public void AddOrUpdate(string variantId, decimal variantPrice, long? quantity = null, Dictionary<string, string> customAttributes = null) {
+            CartLineItem input = Get(variantId);
 
             if (input != null) {
                 if (quantity != null) {
@@ -185,7 +192,8 @@ namespace Shopify.Unity.SDK {
 
                 LineItems.Add(
                     new CartLineItem(
-                        variant: variant,
+                        variantId: variantId,
+                        variantPrice: variantPrice,
                         onChange: OnLineItemChange,
                         quantity: (long) quantity,
                         customAttributes : customAttributes


### PR DESCRIPTION
Adds an overload of `AddOrUpdate` which takes a `string`:`variantId`. 

In order to ensure that the ID is **a)** valid and **b)** we get the correct price, the overload works by querying the ID and, if a successful result is found, the main `AddOrUpdate` is called.

related: https://github.com/Shopify/unity-buy-sdk/issues/414