### PR TITLE
fix pagination in examples

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -50,6 +50,8 @@ using Shopify.Unity;
 using Shopify.Unity.SDK;
 
 void Start () {
+    const int productsPerPage = 10;
+
     string accessToken = "b8d417759a62f7b342f3735dbe86b322";
     string shopDomain = "unity-buy-sdk.myshopify.com";
 
@@ -90,12 +92,12 @@ void Start () {
                         Debug.Log("Product Description: " + product.descriptionHtml());
                         Debug.Log("--------");
                     }
-                }, after);
+                }, productsPerPage, after);
             } else {
                 Debug.Log("There was only one page of products.");
             }
         }
-    });
+    }, productsPerPage);
 }
 ```
 
@@ -283,7 +285,7 @@ start a web view that contains the checkout for the cart.
 
 ...
 
-ShopifyBuy.Client().products((products, error) => {
+ShopifyBuy.Client().products((products, error, after) => {
     var cart = ShopifyBuy.Client().Cart();
     var firstProduct = products[0];
     var firstProductVariants = (List<ProductVariant>) firstProduct.variants();

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -50,8 +50,6 @@ using Shopify.Unity;
 using Shopify.Unity.SDK;
 
 void Start () {
-    const int productsPerPage = 10;
-
     string accessToken = "b8d417759a62f7b342f3735dbe86b322";
     string shopDomain = "unity-buy-sdk.myshopify.com";
 
@@ -92,12 +90,12 @@ void Start () {
                         Debug.Log("Product Description: " + product.descriptionHtml());
                         Debug.Log("--------");
                     }
-                }, productsPerPage, after);
+                }, after: after);
             } else {
                 Debug.Log("There was only one page of products.");
             }
         }
-    }, productsPerPage);
+    });
 }
 ```
 


### PR DESCRIPTION
Went through all the EXAMPLES.md, except for the Native Pay section, and found a few small issues. 

First change is because the compiler picks the wrong overload when the page size is not given.

Second change is just a missing after.

Checked on: 
<img width="108" alt="screen shot 2017-12-19 at 11 46 40 am" src="https://user-images.githubusercontent.com/1041278/34168363-549737e8-e4b2-11e7-880e-f2876db2c38a.png">
