### PR TITLE
Dont overwrite unity executable with unitypackage on publish

### DIFF
--- a/Assets/Editor/Publishing.cs
+++ b/Assets/Editor/Publishing.cs
@@ -74,7 +74,7 @@ public class Publishing {
     }
 
     public static void PublishFromCommandLine() {
-        var packageName = System.Environment.GetCommandLineArgs().First();
+        var packageName = System.Environment.GetEnvironmentVariable("UNITY_PACKAGE");
         Publish(packageName);
     }
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -78,6 +78,7 @@ fi
 printf "Exporting the unitypackage at: %s\n" "$UNITY_PACKAGE"
 
 # create the new unitypackage
+UNITY_PACKAGE=$UNITY_PACKAGE \
 "$UNITY_PATH" \
     -gvh_disable \
     -batchmode \


### PR DESCRIPTION
The first element of System.Environment.GetCommandLineArgs() is the executable itself, so running publish resulted in a borked install of unity because its internal executable was just a silly gzipped file