### PR TITLE
[Fix] Removed Wallet services from Google Resolver dependencies

### DIFF
--- a/Assets/Shopify/Plugins/Editor/ShopifyDependencies.xml
+++ b/Assets/Shopify/Plugins/Editor/ShopifyDependencies.xml
@@ -1,6 +1,5 @@
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.google.android.gms:play-services-wallet:9.8.0" />
     <androidPackage spec="com.android.support:appcompat-v7:26.0.0" />
     <androidPackage spec="com.android.support:customtabs:26.0.0" />
     <androidPackage spec="com.android.support:design:26.0.0" />


### PR DESCRIPTION
https://github.com/Shopify/unity-buy-sdk/issues/418

Removes the dependency so GooglePlayServicesResolver doesn't fetch Wallet Services. The meta tag is removed as it's part of the game-buy-android-sdk library.