### PR TITLE
[UI Toolkit] Lazily fetch theme ref because unity wont serialize the ref

### DIFF
--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestBaseThemeControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestBaseThemeControllerEditor.cs
@@ -40,14 +40,6 @@ namespace Shopify.UIToolkit.Test.Unit {
         }
 
         [Test]
-        public void TestBindsThemeOnEnable() {
-            var theme = GlobalGameObject.AddComponent<DebugSingleProductTheme>();
-            Assert.IsNull(_controller.Theme);
-            _editor.OnEnable();
-            Assert.AreEqual(_controller.Theme, theme);
-        }
-
-        [Test]
         public void TestNullThemeDrawsHelpBox() {
             Assert.IsNull(_controller.Theme);
             _editor.OnInspectorGUI();
@@ -56,7 +48,7 @@ namespace Shopify.UIToolkit.Test.Unit {
 
         [Test]
         public void TestBoundThemeDoesNotDrawHelpBox() {
-            _controller.Theme = GlobalGameObject.AddComponent<DebugSingleProductTheme>();
+            GlobalGameObject.AddComponent<DebugSingleProductTheme>();
             _editor.OnInspectorGUI();
             _editor.View.DidNotReceive().DrawThemeHelp();
         }

--- a/Assets/Shopify/UIToolkit/Theme Controllers/Editor/BaseThemeControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Theme Controllers/Editor/BaseThemeControllerEditor.cs
@@ -28,7 +28,6 @@
             _verifier = new ShopCredentialsVerifier((IShopCredentials) Target);
             _verifier.OnCredentialsStateChanged += OnCredentialsChanged;
             _credentialsVerifierView = new ShopCredentialsView(_verifier);
-            BindThemeIfPresent();
         }
 
         public override void OnInspectorGUI() {
@@ -48,11 +47,6 @@
         /// Overriden by an implementor to add configurations under the credentials verifier.
         /// </summary>
         public abstract void OnShowConfiguration();
-
-        private void BindThemeIfPresent() {
-            if (Target.Theme != null) return;
-            Target.Theme = Target.GetComponent<IThemeBase>();
-        }
 
         private void OnCredentialsChanged() {
             _cachedClient = null;

--- a/Assets/Shopify/UIToolkit/Theme Controllers/ThemeControllerBase.cs
+++ b/Assets/Shopify/UIToolkit/Theme Controllers/ThemeControllerBase.cs
@@ -6,8 +6,18 @@
 
     public abstract class ThemeControllerBase : MonoBehaviour, IShopCredentials {
 
-        [HideInInspector]
-        public IThemeBase Theme;
+        public IThemeBase Theme {
+            get {
+                _cachedTheme = _cachedTheme ?? GetComponent<IThemeBase>();
+                return _cachedTheme;
+            }
+
+            set {
+                _cachedTheme = value;
+            }
+        }
+
+        private IThemeBase _cachedTheme;
 
         /// <summary>
         /// The Shop Domain to connect to, in the form of "myshop.myshopify.com"


### PR DESCRIPTION
Unity does not serialize references to interfaces, so while the ref persisted after it was assigned, transitioning to a state where the ref was loaded from the serialized data would result in the Theme being null in the controller. This change lazily caches a ref to the theme so that it will always work no matter the situation. 

It maintains the `set Theme` accessor to be robust when we need to do dependency injection, which is especially useful in the tests.