### PR TITLE
Fix multi line deprecation reason breaking code generation

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -274,7 +274,8 @@ module GraphQLGenerator
     end
 
     def deprecation_doc_for(item)
-      "/// \\deprecated #{item.deprecation_reason}\n" if item.deprecated?
+      return if item.deprecation_reason.nil?
+      "/// \\deprecated #{item.deprecation_reason.split("\n").map{|part| part.strip }.join("\n/// ")}\n"
     end
 
     def summary_doc(description)

--- a/scripts/generator/graphql_generator/csharp/type.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type.cs.erb
@@ -48,7 +48,7 @@ namespace Shopify.Unity.GraphQL {
                 <%= docs_query_field(field) %>
                 public <%= type.classify_name %>Query <%= escape_reserved_word(field.name) %>(<%= field_args(field) %>) {
                     <% if field.deprecated? %>
-                    Log.DeprecatedQueryField("<%= type.name %>", "<%= field.name %>", "<%= field.deprecation_reason %>");
+                    Log.DeprecatedQueryField("<%= type.name %>", "<%= field.name %>", "<%= field.deprecation_reason.gsub(/\n/, "\\n") %>");
                     <% end %>
 
                     <%# now we we want to handle generating arguments %>


### PR DESCRIPTION
This fixes the build

Generated fields with a multi line deprecation reason would not be
properly commented out in the output, and would overflow causing syntax
errors in the log output. this pr adds the comments, and escapes the
strings when putting them in the docs.