### PR TITLE
[UI Toolkit] Remove View Oriented callbacks from shop theme

### DIFF
--- a/Assets/Shopify/UIToolkit/ShopControllers/SingleProductShopController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/SingleProductShopController.cs
@@ -41,7 +41,7 @@
 
             var product = products[0];
             var variants = product.variants().edges().Select((x) => x.node()).ToArray();
-            Shop.OnShouldShowProduct(product, variants);
+            Shop.OnProductLoaded(product, variants);
         }
     }
 }

--- a/Assets/Shopify/UIToolkit/Shops/Debug/DebugSingleProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Debug/DebugSingleProductShop.cs
@@ -36,8 +36,8 @@
             LogEvent("OnPurchaseFailed", error);
         }
 
-        public void OnShouldShowProduct(Product product, ProductVariant[] variants) {
-            LogEvent("OnShouldShowProduct", product, variants);
+        public void OnProductLoaded(Product product, ProductVariant[] variants) {
+            LogEvent("OnProductLoaded", product, variants);
         }
 
         public void OnCartQuantityChanged(int newQuantity) {

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
@@ -5,14 +5,6 @@
     using UnityEngine;
 
     public class GenericMultiProductShop : MonoBehaviour, IMultiProductShop {
-        void IMultiProductShop.OnCartItemsChanged(CheckoutLineItem[] lineItems) {
-            throw new System.NotImplementedException();
-        }
-
-        void IMultiProductShop.OnCollectionFilterChanged(Collection collection) {
-            throw new System.NotImplementedException();
-        }
-
         void IShop.OnCartQuantityChanged(int newQuantity) {
             throw new System.NotImplementedException();
         }
@@ -26,10 +18,6 @@
         }
 
         void IShop.OnLoadingStarted() {
-            throw new System.NotImplementedException();
-        }
-
-        void IMultiProductShop.OnProductListChanged(Product[] products) {
             throw new System.NotImplementedException();
         }
 
@@ -49,19 +37,11 @@
             throw new System.NotImplementedException();
         }
 
-        void IMultiProductShop.OnShouldShowCart(CheckoutLineItem[] lineItems) {
+        void IMultiProductShop.OnCartItemsChanged(CheckoutLineItem[] lineItems) {
             throw new System.NotImplementedException();
         }
 
-        void IMultiProductShop.OnShouldShowCollectionList(Collection[] collections) {
-            throw new System.NotImplementedException();
-        }
-
-        void IMultiProductShop.OnShouldShowProductDetails(Product product, ProductVariant[] variants) {
-            throw new System.NotImplementedException();
-        }
-
-        void IMultiProductShop.ShouldShowProductList(Product[] products) {
+        void IMultiProductShop.OnProductsLoaded(Product[] products, int cursor) {
             throw new System.NotImplementedException();
         }
     }

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericSingleProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericSingleProductShop.cs
@@ -37,7 +37,7 @@
             throw new System.NotImplementedException();
         }
 
-        void ISingleProductShop.OnShouldShowProduct(Product product, ProductVariant[] variants) {
+        void ISingleProductShop.OnProductLoaded(Product product, ProductVariant[] variants) {
             throw new System.NotImplementedException();
         }
     }

--- a/Assets/Shopify/UIToolkit/Shops/Interfaces/IMultiProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Interfaces/IMultiProductShop.cs
@@ -2,50 +2,25 @@
     using Shopify.Unity;
 
     public interface IMultiProductShop : IShop {
-         /// <summary>
-        /// Called when the implementor should show the UI for selecting products from a list.
+        /// <summary>
+        /// Called when products have been loaded by the controller.
+        /// This usually happens asynchronously after you have told the controller to load products via
+        /// `ShopController.LoadProducts()`
         /// </summary>
-        /// <param name="products">The products that the UI should list</param>
-        void ShouldShowProductList(Product[] products);
+        /// <param name="products">
+        /// The products that were loaded, the length of the array will match the count sent to `ShopController.LoadProducts()`
+        /// </param>
+        /// <param name="cursor">
+        /// Because products load in pages, the cursor is the index of the first product in the returned list.
+        /// It will match the cursor you send to `ShopController.LoadProducts()` and is there to help you position
+        /// the newly loaded products in your UI.
+        /// </param>
+        void OnProductsLoaded(Product[] products, int cursor);
 
         /// <summary>
-        /// Called when the implementor should show the UI for a particular product and its associated variants.
-        /// </summary>
-        /// <param name="product">The product to show details for</param>
-        /// <param name="variants">The variants of the product</param>
-        void OnShouldShowProductDetails(Product product, ProductVariant[] variants);
-
-        /// <summary>
-        /// Called when the implementor should show the cart UI with the provided line items.
-        /// </summary>
-        /// <param name="lineItems">The line items to display in the cart</param>
-        void OnShouldShowCart(CheckoutLineItem[] lineItems);
-
-        /// <summary>
-        /// Called when the Items in the cart are updated. 
-        /// Useful if your cart is always displayed, for example, if it is in a sidebar.
+        /// Called when the Items in the cart have updated. 
         /// </summary>
         /// <param name="lineItems">The new line items in the cart</param>
         void OnCartItemsChanged(CheckoutLineItem[] lineItems);
-
-        /// <summary>
-        /// Called when the items in the product list changed because a filter was applied. 
-        /// The implementor should update the products in the product list to match the supplied products.
-        /// </summary>
-        /// <param name="products">The new products to display in the list</param>
-        void OnProductListChanged(Product[] products);
-
-        /// <summary>
-        /// Called when the selected collection filter for the product list has been changed
-        /// </summary>
-        /// <param name="collection">The collection that is now selected as a filter, null if no collection is selected.</param>
-        void OnCollectionFilterChanged(Collection collection);
-
-        /// <summary>
-        /// Called when the list of available collections is loaded and the implementor should make them available as selections to the user.
-        /// For example, populating a dropdown with the names or displaying them in a sidebar.
-        /// </summary>
-        /// <param name="collections">The collections that should be displayed</param>
-        void OnShouldShowCollectionList(Collection[] collections);
     }
 }

--- a/Assets/Shopify/UIToolkit/Shops/Interfaces/ISingleProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Interfaces/ISingleProductShop.cs
@@ -6,10 +6,10 @@
     /// </summary>
     public interface ISingleProductShop : IShop {
         /// <summary>
-        /// Called when the shop should show information about the product it's selling
+        /// Called when the controller is finished loading the product that the shop is selling.
         /// </summary>
-        /// <param name="product">The product that should be displayed</param>
-        /// <param name="variants">The variants of the product that should be displayed</param>
-        void OnShouldShowProduct(Product product, ProductVariant[] variants);
+        /// <param name="product">The product that was loaded</param>
+        /// <param name="variants">The variants of the product that was loaded</param>
+        void OnProductLoaded(Product product, ProductVariant[] variants);
     }
 }

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductShopController.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductShopController.cs
@@ -41,7 +41,7 @@
             var waiter = new EditorTimeoutWaiter();
 
             _shop.When((x) => {
-                x.OnShouldShowProduct(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
+                x.OnProductLoaded(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
             }).Do((x) => {
                 var product = x.Args()[0] as Product;
                 var productVariants = x.Args()[1] as ProductVariant[];
@@ -79,7 +79,7 @@
                yield return null;
             }
 
-            _shop.DidNotReceive().OnShouldShowProduct(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
+            _shop.DidNotReceive().OnProductLoaded(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
         }
 
         [UnityTest]
@@ -101,7 +101,7 @@
                yield return null;
             }
 
-            _shop.DidNotReceive().OnShouldShowProduct(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
+            _shop.DidNotReceive().OnProductLoaded(Arg.Any<Product>(), Arg.Any<ProductVariant[]>());
         }
     }
 }


### PR DESCRIPTION
We are moving towards not handling view concerns from our theme
controllers, so the interface from theme controller to theme only
requires the data that drives the theme. This reduces the interface
surface of the shop theme significantly.