### PR TITLE
UI CartLineItems Propagate Events

### DIFF
--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -97,6 +97,30 @@ namespace Shopify.Tests
         }
 
         [Test]
+        public void TestManualLineItemChangesCallEvents() {
+            ShopifyBuy.Init(new MockLoader());
+
+            var cart = ShopifyBuy.Client().Cart();
+            var updateTypes = new List<CartLineItems.LineItemChangeType>();
+            var id1 = "variant-id-1";
+           
+            cart.LineItems.OnChange += (eventType, lineItem) => {
+                updateTypes.Add(eventType);
+            };
+
+            cart.LineItems.AddOrUpdate(CreateProductVariant(id1), 33);
+            cart.LineItems.Get(id1).Quantity = 4;
+            cart.LineItems.Get(id1).CustomAttributes = new Dictionary<string, string>();
+            cart.LineItems.Get(id1).CustomAttributes["fancy"] = "thing";
+            
+            Assert.AreEqual(4, updateTypes.Count);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[0]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[1]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[2]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[3]);
+        }
+
+        [Test]
         public void TestLineItemEventsReset() {
             ShopifyBuy.Init(new MockLoader());
 

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -64,6 +64,70 @@ namespace Shopify.Tests
         }
 
         [Test]
+        public void TestLineItemEventsAddUpdateDelete() {
+            ShopifyBuy.Init(new MockLoader());
+
+            var cart = ShopifyBuy.Client().Cart();
+            var updateTypes = new List<CartLineItems.LineItemChangeType>();
+            var updatedLineItems = new List<CartLineItem>();
+            var id1 = "variant-id-1";
+            var id2 = "variant-id-2";
+            var variant2 = CreateProductVariant(id2);
+
+            cart.LineItems.OnChange += (eventType, lineItem) => {
+                updateTypes.Add(eventType);
+                updatedLineItems.Add(lineItem);
+            };
+
+            cart.LineItems.AddOrUpdate(CreateProductVariant(id1), 33);
+            cart.LineItems.AddOrUpdate(variant2, 2);
+            cart.LineItems.Delete(id1);
+            cart.LineItems.AddOrUpdate(variant2, 55);
+
+            Assert.AreEqual(4, updateTypes.Count);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[0]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[1]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.remove, updateTypes[2]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[3]);
+
+            Assert.AreEqual(id1, updatedLineItems[0].VariantId);
+            Assert.AreEqual(id2, updatedLineItems[1].VariantId);
+            Assert.AreEqual(id1, updatedLineItems[2].VariantId);
+            Assert.AreEqual(id2, updatedLineItems[3].VariantId);
+        }
+
+        [Test]
+        public void TestLineItemEventsReset() {
+            ShopifyBuy.Init(new MockLoader());
+
+            var cart = ShopifyBuy.Client().Cart();
+            var updateTypes = new List<CartLineItems.LineItemChangeType>();
+            var updatedLineItems = new List<CartLineItem>();
+            var id1 = "variant-id-1";
+            var id2 = "variant-id-2";
+
+            cart.LineItems.OnChange += (eventType, lineItem) => {
+                updateTypes.Add(eventType);
+                updatedLineItems.Add(lineItem);
+            };
+
+            cart.LineItems.AddOrUpdate(CreateProductVariant(id1), 33);
+            cart.LineItems.AddOrUpdate(CreateProductVariant(id2), 2);
+            cart.LineItems.Reset();
+
+            Assert.AreEqual(4, updateTypes.Count);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[0]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[1]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.remove, updateTypes[2]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.remove, updateTypes[3]);
+
+            Assert.AreEqual(id1, updatedLineItems[0].VariantId);
+            Assert.AreEqual(id2, updatedLineItems[1].VariantId);
+            Assert.AreEqual(id2, updatedLineItems[2].VariantId);
+            Assert.AreEqual(id1, updatedLineItems[3].VariantId);
+        }
+
+        [Test]
         public void TestSubtotal() {
             ShopifyBuy.Init(new MockLoader());
 

--- a/Assets/Editor/TestCart.cs
+++ b/Assets/Editor/TestCart.cs
@@ -85,10 +85,10 @@ namespace Shopify.Tests
             cart.LineItems.AddOrUpdate(variant2, 55);
 
             Assert.AreEqual(4, updateTypes.Count);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[0]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[1]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.remove, updateTypes[2]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[3]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Add, updateTypes[0]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Add, updateTypes[1]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Remove, updateTypes[2]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Update, updateTypes[3]);
 
             Assert.AreEqual(id1, updatedLineItems[0].VariantId);
             Assert.AreEqual(id2, updatedLineItems[1].VariantId);
@@ -114,10 +114,10 @@ namespace Shopify.Tests
             cart.LineItems.Get(id1).CustomAttributes["fancy"] = "thing";
             
             Assert.AreEqual(4, updateTypes.Count);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[0]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[1]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[2]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.update, updateTypes[3]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Add, updateTypes[0]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Update, updateTypes[1]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Update, updateTypes[2]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Update, updateTypes[3]);
         }
 
         [Test]
@@ -140,10 +140,10 @@ namespace Shopify.Tests
             cart.LineItems.Reset();
 
             Assert.AreEqual(4, updateTypes.Count);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[0]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.add, updateTypes[1]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.remove, updateTypes[2]);
-            Assert.AreEqual(CartLineItems.LineItemChangeType.remove, updateTypes[3]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Add, updateTypes[0]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Add, updateTypes[1]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Remove, updateTypes[2]);
+            Assert.AreEqual(CartLineItems.LineItemChangeType.Remove, updateTypes[3]);
 
             Assert.AreEqual(id1, updatedLineItems[0].VariantId);
             Assert.AreEqual(id2, updatedLineItems[1].VariantId);

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -1,4 +1,5 @@
 namespace Shopify.UIToolkit {
+    using System;
     using UnityEngine.Events;
     using Shopify.Unity;
     using Shopify.Unity.SDK;
@@ -20,10 +21,6 @@ namespace Shopify.UIToolkit {
         public PurchaseFailedEvent OnPurhchaseFailed = new PurchaseFailedEvent();
 
         public CartController(Cart cart) {
-            SetCart(cart);
-        }
-
-        public void SetCart(Cart cart) {
             Cart = cart;
             Cart.LineItems.OnChange += OnLineItemsChange;
         }

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -25,6 +25,7 @@ namespace Shopify.UIToolkit {
 
         public void SetCart(Cart cart) {
             Cart = cart;
+            Cart.LineItems.OnChange += OnLineItemsChange;
         }
 
         public CartLineItems LineItems {
@@ -41,8 +42,6 @@ namespace Shopify.UIToolkit {
             var existingItem = Cart.LineItems.Get(variant);
             var newQuantity = existingItem == null ? 1 : existingItem.Quantity + 1;
             Cart.LineItems.AddOrUpdate(variant, newQuantity);
-
-            OnQuantityChange.Invoke(TotalItemsInCart());
         }
 
         /// <summary>
@@ -56,8 +55,6 @@ namespace Shopify.UIToolkit {
             } else {
                 Cart.LineItems.AddOrUpdate(variant, quantity);
             }
-
-            OnQuantityChange.Invoke(TotalItemsInCart());
         }
 
         /// <summary>
@@ -74,8 +71,6 @@ namespace Shopify.UIToolkit {
             } else {
                 Cart.LineItems.AddOrUpdate(variant, newQuantity);
             }
-
-            OnQuantityChange.Invoke(TotalItemsInCart());
         }
 
         /// <summary>
@@ -83,8 +78,6 @@ namespace Shopify.UIToolkit {
         /// </summary>
         public void ClearCart() {
             Cart.Reset();
-
-            OnQuantityChange.Invoke(0);
         }
 
         /// <summary>
@@ -114,6 +107,10 @@ namespace Shopify.UIToolkit {
                     });
                     break;
             }
+        }
+
+        private void OnLineItemsChange(CartLineItems.LineItemChangeType type, CartLineItem lineItem) {
+            OnQuantityChange.Invoke(TotalItemsInCart());
         }
 
         private int TotalItemsInCart() {

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs.meta
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 674a4b8a66ed942849c9adb72f9975cb
+timeCreated: 1515791296
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shopify/Unity/CartState.cs
+++ b/Assets/Shopify/Unity/CartState.cs
@@ -321,7 +321,7 @@ namespace Shopify.Unity {
 
         private void OnLineItemChange(CartLineItems.LineItemChangeType type, CartLineItem lineItem) {
             switch(type) {
-                case CartLineItems.LineItemChangeType.remove:
+                case CartLineItems.LineItemChangeType.Remove:
                     DeletedLineItems.Add(lineItem.ID);
                 break;
             }

--- a/Assets/Shopify/Unity/CartState.cs
+++ b/Assets/Shopify/Unity/CartState.cs
@@ -43,11 +43,12 @@ namespace Shopify.Unity {
 
         public CartState(ShopifyClient client) {
             Client = client;
-            _LineItems = new CartLineItems(OnDeleteLineItem);
+            _LineItems = new CartLineItems();
+            _LineItems.OnChange += OnLineItemChange;
         }
 
         public void Reset() {
-            _LineItems = new CartLineItems(OnDeleteLineItem);
+            _LineItems.Reset();
             _UserErrors = null;
             DeletedLineItems.Clear();
             CurrentCheckout = null;
@@ -318,8 +319,12 @@ namespace Shopify.Unity {
             callback(error);
         }
 
-        private void OnDeleteLineItem(string lineItemId) {
-            DeletedLineItems.Add(lineItemId);
+        private void OnLineItemChange(CartLineItems.LineItemChangeType type, CartLineItem lineItem) {
+            switch(type) {
+                case CartLineItems.LineItemChangeType.remove:
+                    DeletedLineItems.Add(lineItem.ID);
+                break;
+            }
         }
 
         private delegate void CheckoutPollQuery(QueryRootQuery query, string checkoutId);

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -227,16 +227,12 @@ namespace Shopify.Unity.SDK {
             CartLineItem lineItem = Get(variant.id());
 
             if (lineItem != null) {
-                if (quantity != null) {
+                if (quantity != null && lineItem.Quantity != (long) quantity) {
                     lineItem.Quantity = (long) quantity;
                 }
 
                 if (customAttributes != null) {
                     lineItem.CustomAttributes = customAttributes;
-                }
-
-                if (OnChange != null) {
-                    OnChange(LineItemChangeType.update, lineItem);
                 }
             } else {
                 if (quantity == null) {
@@ -379,10 +375,8 @@ namespace Shopify.Unity.SDK {
                 CartLineItem lineItemRemoved = LineItems[idxToDelete];
                 LineItems.RemoveAt(idxToDelete);
 
-                if (lineItemRemoved.ID != null) {
-                    if (OnChange != null) {
-                        OnChange(LineItemChangeType.remove, lineItemRemoved);
-                    }
+                if (OnChange != null) {
+                    OnChange(LineItemChangeType.remove, lineItemRemoved);
                 }
 
                 return true;

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -57,7 +57,7 @@ namespace Shopify.Unity.SDK {
             set {
                 if (_Quantity != value) {
                     _Quantity = value;
-                    OnChange(CartLineItems.LineItemChangeType.update, this);
+                    OnChange(CartLineItems.LineItemChangeType.Update, this);
                 }
             }
         }
@@ -73,10 +73,10 @@ namespace Shopify.Unity.SDK {
 
             set {
                 if (value != null) {
-                    _CustomAttributes = new ObservableDictionary<string, string>(value, () => { OnChange(CartLineItems.LineItemChangeType.update, this); });
+                    _CustomAttributes = new ObservableDictionary<string, string>(value, () => { OnChange(CartLineItems.LineItemChangeType.Update, this); });
                 }
 
-                OnChange(CartLineItems.LineItemChangeType.update, this);
+                OnChange(CartLineItems.LineItemChangeType.Update, this);
             }
         }
 
@@ -106,7 +106,7 @@ namespace Shopify.Unity.SDK {
             OnChange = onChange;
 
             if (customAttributes != null) {
-                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, () => { OnChange(CartLineItems.LineItemChangeType.update, this); });
+                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, () => { OnChange(CartLineItems.LineItemChangeType.Update, this); });
             }
         }
 
@@ -162,9 +162,9 @@ namespace Shopify.Unity.SDK {
     /// </summary>
     public class CartLineItems {
         public enum LineItemChangeType {
-            add,
-            remove,
-            update
+            Add,
+            Remove,
+            Update
         }
 
         public event LineItemChangeHandler OnChange;
@@ -249,7 +249,7 @@ namespace Shopify.Unity.SDK {
                 LineItems.Add(lineItem);
 
                 if (OnChange != null) {
-                    OnChange(LineItemChangeType.add, lineItem);
+                    OnChange(LineItemChangeType.Add, lineItem);
                 }
             }
         }
@@ -376,7 +376,7 @@ namespace Shopify.Unity.SDK {
                 LineItems.RemoveAt(idxToDelete);
 
                 if (OnChange != null) {
-                    OnChange(LineItemChangeType.remove, lineItemRemoved);
+                    OnChange(LineItemChangeType.Remove, lineItemRemoved);
                 }
 
                 return true;
@@ -433,7 +433,7 @@ namespace Shopify.Unity.SDK {
                 var lineItem = LineItems[i];
                 LineItems.RemoveAt(i);
                 if (OnChange != null) {
-                    OnChange(LineItemChangeType.remove, lineItem);
+                    OnChange(LineItemChangeType.Remove, lineItem);
                 }
             }
         }

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -57,7 +57,7 @@ namespace Shopify.Unity.SDK {
             set {
                 if (_Quantity != value) {
                     _Quantity = value;
-                    OnChange(this);
+                    OnChange(CartLineItems.LineItemChangeType.update, this);
                 }
             }
         }
@@ -73,10 +73,10 @@ namespace Shopify.Unity.SDK {
 
             set {
                 if (value != null) {
-                    _CustomAttributes = new ObservableDictionary<string, string>(value, () => { OnChange(this); });
+                    _CustomAttributes = new ObservableDictionary<string, string>(value, () => { OnChange(CartLineItems.LineItemChangeType.update, this); });
                 }
 
-                OnChange(this);
+                OnChange(CartLineItems.LineItemChangeType.update, this);
             }
         }
 
@@ -90,7 +90,7 @@ namespace Shopify.Unity.SDK {
         private long _Quantity;
         private decimal _Price;
         private ObservableDictionary<string, string> _CustomAttributes;
-        private OnCartLineItemChange OnChange;
+        private LineItemChangeHandler OnChange;
         
         /// <summary>
         /// Used internally by the SDK to construct a CartLineItem.
@@ -99,14 +99,14 @@ namespace Shopify.Unity.SDK {
         /// <param name="onChange">This function will be called whenever the CartLineItem is modified</param>
         /// <param name="quantity">The count of items to be ordered</param>
         /// <param name="customAttributes">Custom attributes for this line item used to customize and add meta data</param>
-        public CartLineItem(ProductVariant variant, OnCartLineItemChange onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
+        public CartLineItem(ProductVariant variant, LineItemChangeHandler onChange, long quantity = 1, IDictionary<string, string> customAttributes = null) {
             _VariantId = variant.id();
             _Quantity = quantity;
             _Price = variant.price();
             OnChange = onChange;
 
             if (customAttributes != null) {
-                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, () => { OnChange(this); });
+                CustomAttributes = new ObservableDictionary<string, string>(customAttributes, () => { OnChange(CartLineItems.LineItemChangeType.update, this); });
             }
         }
 
@@ -505,11 +505,11 @@ namespace Shopify.Unity.SDK {
             return variantOut;
         }
 
-        private void OnLineItemChange(CartLineItem item) {
+        private void OnLineItemChange(LineItemChangeType type, CartLineItem item) {
             _IsSaved = false;
 
             if (OnChange != null) {
-                OnChange(LineItemChangeType.update, item);
+                OnChange(type, item);
             }
         }
     }

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -429,10 +429,10 @@ namespace Shopify.Unity.SDK {
         /// Deletes all line items
         /// </summary>
         public void Reset() {
-            if (OnChange != null) {
-                for(int i = LineItems.Count - 1; i >= 0; i--) {
-                    var lineItem = LineItems[i];
-                    LineItems.RemoveAt(i);
+            for(int i = LineItems.Count - 1; i >= 0; i--) {
+                var lineItem = LineItems[i];
+                LineItems.RemoveAt(i);
+                if (OnChange != null) {
                     OnChange(LineItemChangeType.remove, lineItem);
                 }
             }

--- a/Assets/Shopify/Unity/SDK/Delegates.cs
+++ b/Assets/Shopify/Unity/SDK/Delegates.cs
@@ -26,7 +26,6 @@ namespace Shopify.Unity.SDK {
 
     public delegate void ShopMetadataHandler(ShopMetadata? metadata, ShopifyError error);
 
-    public delegate void OnCartLineItemChange(CartLineItem lineItem);
     public delegate void LineItemChangeHandler(CartLineItems.LineItemChangeType type, CartLineItem lineItem);
 
     public delegate bool PollUpdatedHandler(QueryRoot updatedQueryRoot);

--- a/Assets/Shopify/Unity/SDK/Delegates.cs
+++ b/Assets/Shopify/Unity/SDK/Delegates.cs
@@ -26,7 +26,8 @@ namespace Shopify.Unity.SDK {
 
     public delegate void ShopMetadataHandler(ShopMetadata? metadata, ShopifyError error);
 
-    public delegate void OnCartLineItemChange();
+    public delegate void OnCartLineItemChange(CartLineItem lineItem);
+    public delegate void LineItemChangeHandler(CartLineItems.LineItemChangeType type, CartLineItem lineItem);
 
     public delegate bool PollUpdatedHandler(QueryRoot updatedQueryRoot);
 


### PR DESCRIPTION
This PR refactors event handling on cart line items. One controversial thing is that when `Reset` is called an event will be fired per item being removed from the line items list.