### PR TITLE
[UI Toolkit] Force repaint in shop controller editor when state changes

### DIFF
--- a/Assets/Shopify/UIToolkit/Editor/ProductPicker.cs
+++ b/Assets/Shopify/UIToolkit/Editor/ProductPicker.cs
@@ -20,6 +20,9 @@
     }
 
     public class ProductPicker : IProductPickerController {
+        public delegate void ProductListUpdatedHandler();
+        public event ProductListUpdatedHandler OnProductListUpdated;
+
         public ShopifyClient Client;
         private IProductPickerView _view;
         private static Dictionary<string, string> _cachedProductNameToGIDMap;
@@ -58,6 +61,7 @@
         public void LoadProducts() {
             if (_cachedProductNameToGIDMap != null) {
                 _productNameToGIDMap = _cachedProductNameToGIDMap;
+                if (OnProductListUpdated != null) OnProductListUpdated();
             }
 
             LoadAllProducts();
@@ -106,6 +110,8 @@
             }
 
             _cachedProductNameToGIDMap = _productNameToGIDMap;
+
+            if (OnProductListUpdated != null) OnProductListUpdated();
         }
     }
 

--- a/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
@@ -51,6 +51,7 @@
         private void OnCredentialsChanged() {
             _cachedClient = null;
             OnClientChanged();
+            Repaint();
         }
 
         protected virtual void OnClientChanged() { }

--- a/Assets/Shopify/UIToolkit/ShopControllers/Editor/SingleProductShopControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Editor/SingleProductShopControllerEditor.cs
@@ -32,7 +32,13 @@
 
         private ProductPicker _productPicker {
             get {
-                _cachedPicker = _cachedPicker ?? new ProductPicker(Client);
+                if (_cachedPicker == null) {
+                    _cachedPicker = new ProductPicker(Client);
+                    _cachedPicker.OnProductListUpdated += () => {
+                        Repaint();
+                    };
+                }
+
                 return _cachedPicker;
             }
         }


### PR DESCRIPTION
Forces a repaint when the credentials verifier or the product picker
finished loading and updates the state of the editor. This fixes a bug
where some movement/UI event is required to show the state changes.