### PR TITLE
add load more to multi product

### DIFF
--- a/Assets/Shopify/UIToolkit/Components/ProductCache.cs
+++ b/Assets/Shopify/UIToolkit/Components/ProductCache.cs
@@ -1,0 +1,46 @@
+namespace Shopify.UIToolkit {
+    using System;
+    using System.Collections.Generic;
+    using Shopify.Unity;
+
+    public class ProductCache {
+        private string _cursor = null;
+        private bool _complete = false;
+
+        private List<Product> _products;
+
+        public ProductCache() {
+            _products = new List<Product> ();
+        }
+
+        public string Cursor {
+          get {
+            return _cursor;
+          }
+        }
+
+        public bool Complete {
+          get {
+            return _complete;
+          }
+        }
+
+        public int Count {
+          get {
+            return _products.Count;
+          }
+        }
+
+        public void Add(Product[] products, string after) {
+            if (string.IsNullOrEmpty(after)) {
+                _complete = true;
+            }
+
+            _cursor = after;
+
+            foreach (var product in products) {
+                _products.Add(product);
+            }
+        }
+    }
+}

--- a/Assets/Shopify/UIToolkit/ShopControllers/MultiProductShopController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/MultiProductShopController.cs
@@ -5,14 +5,17 @@
     using UnityEngine;
 
     public class MultiProductShopController : ShopControllerBase {
-        public new IMultiProductShop Shop { 
-            get { 
-                return base.Shop as IMultiProductShop; 
+        private string cursor = null;
+        private bool allProductsLoaded = false;
+
+        public new IMultiProductShop Shop {
+            get {
+                return base.Shop as IMultiProductShop;
             }
 
             set {
                 base.Shop = value;
-            } 
+            }
         }
 
         public override void OnHide() {
@@ -20,7 +23,15 @@
         }
 
         public override void OnShow() {
-            Client.products(OnProductsLoaded);
+            LoadMoreProducts ();
+        }
+
+        public void LoadMoreProducts() {
+            if (allProductsLoaded) {
+                return;
+            }
+
+            Client.products(OnProductsLoaded, after: cursor);
         }
 
         private void OnProductsLoaded(List<Product> products, ShopifyError error, string after) {
@@ -32,6 +43,12 @@
             if (products.Count == 0) {
                 Shop.OnError(new ShopifyError(ShopifyError.ErrorType.UserError, "Product not found"));
                 return;
+            }
+
+            if (string.IsNullOrEmpty(after)) {
+                allProductsLoaded = true;
+            } else {
+                cursor = after;
             }
 
             Shop.OnProductsLoaded(products.ToArray(), after);

--- a/Assets/Shopify/UIToolkit/ShopControllers/MultiProductShopController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/MultiProductShopController.cs
@@ -5,9 +5,6 @@
     using UnityEngine;
 
     public class MultiProductShopController : ShopControllerBase {
-        private string cursor = null;
-        private bool allProductsLoaded = false;
-
         public new IMultiProductShop Shop {
             get {
                 return base.Shop as IMultiProductShop;
@@ -23,14 +20,10 @@
         }
 
         public override void OnShow() {
-            LoadMoreProducts ();
+            LoadMoreProducts();
         }
 
-        public void LoadMoreProducts() {
-            if (allProductsLoaded) {
-                return;
-            }
-
+        public void LoadMoreProducts(string cursor = null) {
             Client.products(OnProductsLoaded, after: cursor);
         }
 
@@ -43,12 +36,6 @@
             if (products.Count == 0) {
                 Shop.OnError(new ShopifyError(ShopifyError.ErrorType.UserError, "Product not found"));
                 return;
-            }
-
-            if (string.IsNullOrEmpty(after)) {
-                allProductsLoaded = true;
-            } else {
-                cursor = after;
             }
 
             Shop.OnProductsLoaded(products.ToArray(), after);

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
@@ -13,11 +13,19 @@
     [RequireComponent(typeof(MultiProductShopController))]
     public class GenericMultiProductShop : MonoBehaviour, IMultiProductShop, IGenericMultiProductShop {
         private MultiProductShopController _controller;
+        private ProductCache _productCache;
+
+        public ProductCache ProductCache {
+            get {
+                return _productCache;
+            }
+        }
 
         #region MonoBehaviour
 
         private void Awake() {
             _controller = GetComponent<MultiProductShopController>();
+            _productCache = new ProductCache();
         }
 
         private void Start() {
@@ -61,6 +69,7 @@
         }
 
         void IMultiProductShop.OnProductsLoaded(Product[] products, string after) {
+            _productCache.Add(products, after);
             _productListView.OnProductsLoaded(products);
         }
 
@@ -154,7 +163,7 @@
         }
 
         public void LoadMoreProducts() {
-            _controller.LoadMoreProducts ();
+            _controller.LoadMoreProducts (_productCache.Cursor);
         }
     }
 }

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
@@ -152,5 +152,9 @@
             CloseButton.gameObject.SetActive(!canNavigateBack);
             BackButton.gameObject.SetActive(canNavigateBack);
         }
+
+        public void LoadMoreProducts() {
+            _controller.LoadMoreProducts ();
+        }
     }
 }

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestProductCache.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestProductCache.cs
@@ -1,0 +1,60 @@
+#if !SHOPIFY_MONO_UNIT_TEST
+namespace Shopify.UIToolkit.Test.Unit {
+    using System;
+    using Shopify.UIToolkit;
+	using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using Shopify.Unity;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    public class TestProductCache {
+        private ProductCache _productCache;
+
+        [SetUp]
+        public void Setup() {
+            _productCache = new ProductCache();
+        }
+
+        [Test]
+        public void TestInit() {
+            Assert.Null(_productCache.Cursor);
+            Assert.AreEqual(_productCache.Complete, false);
+            Assert.AreEqual(_productCache.Count, 0);
+        }
+
+        [Test]
+        public void TestAdd() {
+            Dictionary<string, object> dataJSON = new Dictionary<string, object>();
+
+            Product[] products = new Product[] {
+                new Product(dataJSON),
+                new Product(dataJSON),
+                new Product(dataJSON)
+            };
+
+            _productCache.Add(products, "afterafterafter");
+
+            Assert.AreEqual(_productCache.Cursor, "afterafterafter");
+            Assert.AreEqual(_productCache.Complete, false);
+            Assert.AreEqual(_productCache.Count, 3);
+        }
+
+        [Test]
+        public void TestAddFinal() {
+            Dictionary<string, object> dataJSON = new Dictionary<string, object>();
+
+            Product[] products = new Product[] {
+                new Product(dataJSON)
+            };
+
+            _productCache.Add(products, null);
+
+            Assert.Null(_productCache.Cursor);
+            Assert.AreEqual(_productCache.Complete, true);
+            Assert.AreEqual(_productCache.Count, 1);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Splitting this off from my main infinite pagination PR. 

Adds a method to the `MultiProductShopController` which exposes triggering fetching more products. Handles dealing with storing the cursor and eventually setting `allProductsLoaded` to prevent more network calls once the entire product list is loaded. 

The `ProductListView` inherits from `GenericMultiProductShopView` which has a reference to the  `IGenericMultiProductShop` which, in turn, has a reference to `MultiProductShopController`, so adding a method in order to delegate. 