### PR TITLE
Connected checkout methods to Cart Panel and added Apple Merchant ID to base controller

### DIFF
--- a/Assets/Shopify/UIToolkit/ShopControllers/BaseShopController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/BaseShopController.cs
@@ -28,7 +28,6 @@ namespace Shopify.UIToolkit {
                 InvalidateClient();
             }
         }
-        [Header("Store Properties")]
         [SerializeField] private string _shopDomain;
 
         /// <summary>
@@ -43,14 +42,6 @@ namespace Shopify.UIToolkit {
         }
         [SerializeField] private string _accessToken;
 
-        /// <summary>
-        /// The Apple Merchant ID for processing Apple Pay payments.
-        /// </summary>
-        public string AppleMerchantID {
-            set { Cart.AppleMerchantID = value; } 
-            get { return Cart.AppleMerchantID; }
-        }
-        [Header("Payment Properties")]
         [SerializeField] private string _appleMerchantID;
 
         /// <summary>
@@ -104,7 +95,7 @@ namespace Shopify.UIToolkit {
 
         private void SetupClientAndCart() {
             _cachedClient = new ShopifyClient(LoaderProvider.GetLoader(AccessToken, ShopDomain));
-            _cachedCart = new CartController(_cachedClient.Cart());
+            _cachedCart = new CartController(_cachedClient.Cart(), _appleMerchantID);
             
             _cachedCart.OnPurchaseStarted.AddListener(Shop.OnPurchaseStarted);
             _cachedCart.OnPurhcaseCancelled.AddListener(Shop.OnPurchaseCancelled);

--- a/Assets/Shopify/UIToolkit/ShopControllers/BaseShopController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/BaseShopController.cs
@@ -28,6 +28,7 @@ namespace Shopify.UIToolkit {
                 InvalidateClient();
             }
         }
+        [Header("Store Properties")]
         [SerializeField] private string _shopDomain;
 
         /// <summary>
@@ -41,6 +42,16 @@ namespace Shopify.UIToolkit {
             }
         }
         [SerializeField] private string _accessToken;
+
+        /// <summary>
+        /// The Apple Merchant ID for processing Apple Pay payments.
+        /// </summary>
+        public string AppleMerchantID {
+            set { Cart.AppleMerchantID = value; } 
+            get { return Cart.AppleMerchantID; }
+        }
+        [Header("Payment Properties")]
+        [SerializeField] private string _appleMerchantID;
 
         /// <summary>
         /// What loader provider this controller uses to create the loader.

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -40,13 +40,12 @@ namespace Shopify.UIToolkit {
         public UnityEvent OnPurhcaseCancelled = new UnityEvent();
         public PurchaseFailedEvent OnPurhchaseFailed = new PurchaseFailedEvent();
 
-        [HideInInspector]
-        public string AppleMerchantID;
-
         private Dictionary<string, ProductVariant> _idsToVariants = new Dictionary<string, ProductVariant>();
+        private string _appleMerchantID;
 
-        public CartController(Cart cart) {
+        public CartController(Cart cart, string appleMerchantID) {
             SetCart(cart);
+            _appleMerchantID = appleMerchantID;
         }
 
         public void SetCart(Cart cart) {
@@ -171,7 +170,7 @@ namespace Shopify.UIToolkit {
 
         private string NativePayKeyForCurrentPlatform() {
             #if UNITY_IOS
-            return AppleMerchantID;
+            return _appleMerchantID;
             #else
             return null;
             #endif

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -1,7 +1,9 @@
 namespace Shopify.UIToolkit {
+    using UnityEngine;
     using UnityEngine.Events;
     using Shopify.Unity;
     using Shopify.Unity.SDK;
+    using System;
     using System.Linq;
     using System.Collections.Generic;
 
@@ -37,6 +39,9 @@ namespace Shopify.UIToolkit {
         public UnityEvent OnPurchaseComplete = new UnityEvent();
         public UnityEvent OnPurhcaseCancelled = new UnityEvent();
         public PurchaseFailedEvent OnPurhchaseFailed = new PurchaseFailedEvent();
+
+        [HideInInspector]
+        public string AppleMerchantID;
 
         private Dictionary<string, ProductVariant> _idsToVariants = new Dictionary<string, ProductVariant>();
 
@@ -132,10 +137,17 @@ namespace Shopify.UIToolkit {
         /// Start a purchase with the current cart.
         /// </summary>
         /// <param name="mode">How do you want to make the purchase? Native, Web or Auto</param>
-        /// <param name="nativePayKey">Vendor-specific key to be passed to Native purchase methods</param>
-        public void StartPurchase(CheckoutMode mode, string nativePayKey = null) {
+        public void StartPurchase(CheckoutMode mode) {
+
+            // Validate that the developer has given us the proper native payment key for the platform.
+            var nativePayKey = NativePayKeyForCurrentPlatform();
+            if ((mode == CheckoutMode.Native || mode == CheckoutMode.Auto) && nativePayKey == null) {
+                throw new ArgumentException("Missing native payment key for current platform or platform does not support native pay.");
+                return;
+            }
+
             OnPurchaseStarted.Invoke();
-            
+
             switch (mode) {
                 case CheckoutMode.Native:
                     Cart.CheckoutWithNativePay(nativePayKey, OnPurchaseComplete.Invoke, OnPurhcaseCancelled.Invoke, OnPurhchaseFailed.Invoke);
@@ -155,6 +167,14 @@ namespace Shopify.UIToolkit {
                     });
                     break;
             }
+        }
+
+        private string NativePayKeyForCurrentPlatform() {
+            #if UNITY_IOS
+            return AppleMerchantID;
+            #else
+            return null;
+            #endif
         }
 
         private int TotalItemsInCart() {

--- a/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
@@ -10,6 +10,7 @@
     public interface IShopControllerBaseEditorView {
         void DrawShopCredentialsVerifier();
         void DrawShopHelp();
+        void DrawPaymentProperties();
     }
 
     public abstract class ShopControllerBaseEditor : Editor, IShopControllerBaseEditorView {
@@ -35,17 +36,12 @@
                 View.DrawShopHelp();
             }
 
-            EditorGUILayout.LabelField("Store Properties", EditorStyles.boldLabel);
-
             View.DrawShopCredentialsVerifier();
             if (_verifier.HasVerifiedCredentials()) {
                 OnShowConfiguration();
             }
 
-            #if UNITY_IOS
-            EditorGUILayout.LabelField("Payment Properties", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_appleMerchantID"));
-            #endif
+            View.DrawPaymentProperties();
 
             serializedObject.ApplyModifiedProperties();
         }
@@ -72,6 +68,7 @@
         private ShopifyClient _cachedClient;
 
         void IShopControllerBaseEditorView.DrawShopCredentialsVerifier() {
+            EditorGUILayout.LabelField("Store Properties", EditorStyles.boldLabel);
             _credentialsVerifierView.DrawInspectorGUI(serializedObject);
         }
 
@@ -82,6 +79,13 @@ Implement ISingleProductShop with your own custom script and add it to this game
             ";
 
             EditorGUILayout.HelpBox(message, MessageType.Warning);
+        }
+
+        void IShopControllerBaseEditorView.DrawPaymentProperties() {
+            #if UNITY_IOS
+            EditorGUILayout.LabelField("Payment Properties", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_appleMerchantID"));
+            #endif
         }
     }
 }

--- a/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
@@ -40,6 +40,8 @@
                 OnShowConfiguration();
             }
 
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_appleMerchantID"));
+
             serializedObject.ApplyModifiedProperties();
         }
 

--- a/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Editor/ShopControllerBaseEditor.cs
@@ -35,12 +35,17 @@
                 View.DrawShopHelp();
             }
 
+            EditorGUILayout.LabelField("Store Properties", EditorStyles.boldLabel);
+
             View.DrawShopCredentialsVerifier();
             if (_verifier.HasVerifiedCredentials()) {
                 OnShowConfiguration();
             }
 
+            #if UNITY_IOS
+            EditorGUILayout.LabelField("Payment Properties", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(serializedObject.FindProperty("_appleMerchantID"));
+            #endif
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
@@ -35,6 +35,14 @@ namespace Shopify.UIToolkit.Shops.Generic {
             UpdateCartList(cartItems);
         }
 
+        public void PerformWebCheckout() {
+            Shop.PerformWebCheckout();
+        }
+
+        public void PerformNativeCheckout() {
+            Shop.PerformNativeCheckout();
+        }
+
         #endregion
 
         #region Helpers

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
@@ -165,6 +165,14 @@
             _controller.Cart.AddVariant(variant);
         }
 
+        public void PerformWebCheckout() {
+            _controller.Cart.StartPurchase(CheckoutMode.Web);
+        }
+
+        public void PerformNativeCheckout() {
+            _controller.Cart.StartPurchase(CheckoutMode.Native);
+        }
+
         private void OnViewChanged() {
             var canNavigateBack = ViewSwitcher.CanNavigateBack();
             CloseButton.gameObject.SetActive(!canNavigateBack);

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Views/Cart Panel.prefab
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Views/Cart Panel.prefab
@@ -1371,7 +1371,18 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 114766531265860302}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 114083855067137410}
+        m_MethodName: PerformWebCheckout
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!114 &114766531265860302
@@ -1620,7 +1631,18 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 114575240088011100}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 114083855067137410}
+        m_MethodName: PerformNativeCheckout
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!114 &114867848034116052

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestBaseShopControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestBaseShopControllerEditor.cs
@@ -58,5 +58,11 @@ namespace Shopify.UIToolkit.Test.Unit {
             _editor.OnInspectorGUI();
             _editor.View.Received().DrawShopCredentialsVerifier();
         }
+
+        [Test]
+        public void TestPaymentPropertiesViewDraw() {
+            _editor.OnInspectorGUI();
+            _editor.View.Received().DrawPaymentProperties();
+        }
     }
 }


### PR DESCRIPTION
Small PR that connects the buttons to the `StartPurchase` method in the CartController. I've also abstracted the NativePayKey into a property that lives on the ShopController and can be edited from the editor.

Instead of exposing a 'Native Pay Key' which seems pretty ambigious I've exposed a 'Apple Merchant ID' field for Apple Pay instead. When Android Pay is supported we can add another optional field named Android Key or something. This way it's a lot more clear.