### PR TITLE
Updated Cart Panel to enable Apple Pay checkouts

### DIFF
--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.h
@@ -5,8 +5,7 @@
 extern "C" {
 #endif
     const char* _GenerateApplePayButtonImage(const char *type, const char* style, 
-                                             float width, float height,
-                                             bool includeMinimumSpacingForIOS);
+                                             float width, float height);
 #ifdef __cplusplus
 }
 #endif

--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayButtonGenerator.mm
@@ -54,21 +54,11 @@ extern "C" {
     
     // Generates a base64 encoded string containing the rendered image output of a PKPaymentButton from iOS.
     const char* _GenerateApplePayButtonImage(const char *type, const char* style, float width, 
-                                             float height, bool includeMinMargin,
-                                             bool includeMinimumSpacingForIOS) {
+                                             float height) {
         PKPaymentButton* button = [PKPaymentButton buttonWithType:SBPayButtonTypeFromString(type)
                                                             style:SBPayButtonStyleFromString(style)];
         CGSize size = CGSizeMake(width, height);
-                       
-        // According to Apple Design guidelines, there must be a minimum spacing around the Apple Pay button of at least 1/10 the height.
-        // We include this as an optional property when rendering the button image.
-        CGFloat minSpace = 0;
-        if (includeMinimumSpacingForIOS) {
-            minSpace = 0.10 * height;
-            button.frame = CGRectMake(0, 0, size.width - 2 * minSpace, size.height - 2 * minSpace);
-        } else {
-            button.frame = CGRectMake(0, 0, size.width, size.height);
-        }
+        button.frame = CGRectMake(0, 0, size.width, size.height);
         
         UnityAppController* unityController = (UnityAppController*)UIApplication.sharedApplication.delegate;
         [unityController.rootView insertSubview:button atIndex:0];
@@ -76,7 +66,6 @@ extern "C" {
         // Take snapshot of the Apple Pay button.
         UIGraphicsBeginImageContextWithOptions(size, NO, [UIScreen mainScreen].scale);
         CGContextRef context = UIGraphicsGetCurrentContext();
-        CGContextTranslateCTM(context, minSpace, minSpace);
         [button.layer renderInContext:context];
         UIImage* snapshot = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -150,6 +150,10 @@ namespace Shopify.UIToolkit {
             OnCartItemsChange.Invoke(CartItems);
         }
 
+        public void CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
+            Cart.CanCheckoutWithNativePay(callback);
+        }
+
         /// <summary>
         /// Start a purchase with the current cart.
         /// </summary>

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
@@ -25,7 +25,11 @@ namespace Shopify.UIToolkit.Shops.Generic {
 
         #region MonoBehaviour
 
-        void Awake() {}
+        void Awake() {
+            Shop.CanCheckoutWithNativePay((canCheckout) => {
+                NativePayButton.gameObject.SetActive(!canCheckout);
+            });
+        }
 
         void OnEnable() {
             UpdateList();

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
@@ -27,7 +27,7 @@ namespace Shopify.UIToolkit.Shops.Generic {
 
         void Awake() {
             Shop.CanCheckoutWithNativePay((canCheckout) => {
-                NativePayButton.gameObject.SetActive(!canCheckout);
+                NativePayButton.gameObject.SetActive(canCheckout);
             });
         }
 

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/GenericMultiProductShop.cs
@@ -2,6 +2,7 @@
     using System.Collections;
     using System.Collections.Generic;
     using Shopify.Unity;
+    using Shopify.Unity.SDK;
     using Shopify.UIToolkit;
     using UnityEngine;
     using UnityEngine.UI;
@@ -13,6 +14,7 @@
         void UpdateCartQuantityForVariant(ProductVariant variant, Product product, long quantity);
         void PerformNativeCheckout();
         void PerformWebCheckout();
+        void CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback);
     }
 
     [RequireComponent(typeof(MultiProductShopController))]
@@ -170,6 +172,10 @@
 
         public void UpdateCartQuantityForVariant(ProductVariant variant, Product product, long quantity) {
             _controller.Cart.UpdateVariant(variant, product, quantity);
+        }
+
+        public void CanCheckoutWithNativePay(CanCheckoutWithNativePayCallback callback) {
+            _controller.Cart.CanCheckoutWithNativePay(callback);
         }
 
         public void PerformWebCheckout() {

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Views/Cart Panel.prefab
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Views/Cart Panel.prefab
@@ -1767,7 +1767,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 743, y: -53.5}
-  m_SizeDelta: {x: 474, y: 30}
+  m_SizeDelta: {x: 474, y: 67}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224806472498420310
 RectTransform:

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Views/Cart Panel.prefab
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Views/Cart Panel.prefab
@@ -797,9 +797,9 @@ MonoBehaviour:
   m_MinWidth: -1
   m_MinHeight: -1
   m_PreferredWidth: -1
-  m_PreferredHeight: -1
+  m_PreferredHeight: 67
   m_FlexibleWidth: 1
-  m_FlexibleHeight: 1
+  m_FlexibleHeight: -1
   m_LayoutPriority: 1
 --- !u!114 &114546783565903838
 MonoBehaviour:
@@ -1511,9 +1511,9 @@ MonoBehaviour:
   m_MinWidth: -1
   m_MinHeight: -1
   m_PreferredWidth: -1
-  m_PreferredHeight: -1
+  m_PreferredHeight: 67
   m_FlexibleWidth: 1
-  m_FlexibleHeight: 1
+  m_FlexibleHeight: -1
   m_LayoutPriority: 1
 --- !u!222 &222114957431896654
 CanvasRenderer:

--- a/Assets/Shopify/Unity/UI/NativePayButtonUI.cs
+++ b/Assets/Shopify/Unity/UI/NativePayButtonUI.cs
@@ -41,12 +41,6 @@ namespace Shopify.Unity.UI {
         /// </summary>
         public ApplePayButtonType applePayButtonType;
 
-        /// <summary>
-        /// When set to true, the the Apple Pay button image will include the 10% minimum spacing around the 
-        /// button image required by Apple's design guidelines.
-        /// </summary>
-        public bool includeMinimumSpacingForIOS;
-
         private RectTransform rectTransform;
         private Image buttonImage;
         private Texture2D imageTexture;
@@ -70,8 +64,7 @@ namespace Shopify.Unity.UI {
 #if UNITY_IOS
         [DllImport("__Internal")]
         private static extern IntPtr _GenerateApplePayButtonImage(string type, string style,
-            float width, float height,
-            bool includeMinimumSpacingForIOS);
+            float width, float height);
 
         private void GenerateApplePayImage() {
             // Ask iOS to generate us an image of the native Apple Pay button.
@@ -79,8 +72,7 @@ namespace Shopify.Unity.UI {
                 applePayButtonType.ToString(),
                 applePayButtonStyle.ToString(),
                 rectTransform.rect.width,
-                rectTransform.rect.height,
-                includeMinimumSpacingForIOS
+                rectTransform.rect.height
             );
 
             string managedBase64ImageString = Marshal.PtrToStringAnsi(imageStringPtr);

--- a/ios-build/Unity-iPhone/shoppingdemo.entitlements
+++ b/ios-build/Unity-iPhone/shoppingdemo.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.in-app-payments</key>
+	<array/>
+</dict>
+</plist>

--- a/ios-build/Unity-iPhone/shoppingdemo.entitlements
+++ b/ios-build/Unity-iPhone/shoppingdemo.entitlements
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>com.apple.developer.in-app-payments</key>
-	<array/>
-</dict>
-</plist>


### PR DESCRIPTION
Adds `CanCheckoutWithNativePay` call to the Shop so the CartView can query when to show the Apple Pay button. As I was testing this patch I noticed the minimum spacing flag on the `NativePayButtonUI` script was causing problems and had an bug in it's method signature so I've decided to remove it since it's kind of pointless anyways. It wasn't clear why it existed and make it so the size of the button the developer sees in Unity matches the one rendered on iOS.