### PR TITLE
[Hotfix] Destroy message receiver after the checkout was cancelled so we don't get any callbacks

### DIFF
--- a/Assets/Shopify/Unity/SDK/WebCheckoutMessageReceiver.cs
+++ b/Assets/Shopify/Unity/SDK/WebCheckoutMessageReceiver.cs
@@ -63,7 +63,10 @@ namespace Shopify.Unity.SDK {
                         Destroy(this);
                         #endif
                     } else {
-                            OnCancelled();
+                        OnCancelled();
+                        #if !SHOPIFY_MONO_UNIT_TEST
+                        Destroy(this);
+                        #endif
                     }
                 }
             });

--- a/scripts/generator/graphql_generator/csharp/SDK/WebCheckoutMessageReceiver.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/SDK/WebCheckoutMessageReceiver.cs.erb
@@ -69,6 +69,9 @@ namespace Shopify.Unity.SDK {
                         #endif
                     } else {
                         OnCancelled();
+                        #if !SHOPIFY_MONO_UNIT_TEST
+                        Destroy(this);
+                        #endif
                     }
                 }
             });


### PR DESCRIPTION
Adds the same destroy logic we had after a success callback for when cancel gets fired so we never get cancelled fired twice.

Note: After this lands into master I'll do the hotfix release from the v0.4.1 tag