### PR TITLE
Xcode 9.3 beta support and warning cleanup

### DIFF
--- a/Assets/Shopify/Plugins/iOS/Shopify/ApplePayEventResponse.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/ApplePayEventResponse.swift
@@ -59,7 +59,7 @@ struct ApplePayEventResponse: Deserializable {
         
         /// Parse Authorization Status
         if let authStatusString = json[ResponseKey.authorizationStatus.rawValue] as? String {
-            authorizationStatus = PKPaymentAuthorizationStatus(rawValue: authStatusString)
+            authorizationStatus = PKPaymentAuthorizationStatus(rawStringValue: authStatusString)
         }
         
         /// Parse Summary Items

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayErrorDeserializingTests.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayErrorDeserializingTests.swift
@@ -422,6 +422,7 @@ extension ApplePayErrorDeserializingTests {
     func testEmailAddressContactInvalidError() {
         
         let field = "EmailAddress"
+        // error
         let expectedError = PKPaymentRequest.paymentContactInvalidError(withContactField: PKContactField.emailAddress, localizedDescription: expectedDescription) as NSError
         
         let createErrorExpectation = contactInvalidErrorExpectation(forField: field)

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayErrorDeserializingTests.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayErrorDeserializingTests.swift
@@ -422,7 +422,6 @@ extension ApplePayErrorDeserializingTests {
     func testEmailAddressContactInvalidError() {
         
         let field = "EmailAddress"
-        // error
         let expectedError = PKPaymentRequest.paymentContactInvalidError(withContactField: PKContactField.emailAddress, localizedDescription: expectedDescription) as NSError
         
         let createErrorExpectation = contactInvalidErrorExpectation(forField: field)

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayFlowTests.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayFlowTests.swift
@@ -36,8 +36,8 @@ class ApplePayFlowTests: XCTestCase {
     fileprivate let totalLabel = "Test Store"
     
     // These are the shipping methods expected from unity-buy-sdk.myshopify.com
-    fileprivate let standardShippingMethod  = PKShippingMethod(label: "Standard Shipping",  amount: 5.83,  identifier: "shopify-Standard%20Shipping-5.83")
-    fileprivate let expeditedShippingMethod = PKShippingMethod(label: "Expedited Shipping", amount: 15.82, identifier: "shopify-Expedited%20Shipping-15.82")
+    fileprivate let standardShippingMethod  = PKShippingMethod(label: "Standard Shipping",  amount: 5.00,  identifier: "shopify-Standard%20Shipping-5.00")
+    fileprivate let expeditedShippingMethod = PKShippingMethod(label: "Expedited Shipping", amount: 15.00, identifier: "shopify-Expedited%20Shipping-15.00")
     
     // These are part of the summary items that are expected from unity-buy-sdk.myshopify.com after adding
     // the product name "[Test] Ballooning Around Shirt" to the Cart
@@ -76,7 +76,7 @@ class ApplePayFlowTests: XCTestCase {
         let expectedSubtotal = PKPaymentSummaryItem(label: "SUBTOTAL", amount: 25.47)
         let expectedShipping = PKPaymentSummaryItem(label: "SHIPPING", amount: standardShippingMethod.amount)
         let expectedTaxes    = PKPaymentSummaryItem(label: "TAXES",    amount: 2.93)
-        let expectedTotal    = PKPaymentSummaryItem(label: totalLabel, amount: 31.30)
+        let expectedTotal    = PKPaymentSummaryItem(label: totalLabel, amount: 30.47)
         
         let method = Tester.Method.checkout.rawValue
         let checkoutMessage = UnityMessage(content: "", object: Tester.name, method: method)
@@ -140,36 +140,36 @@ class ApplePayFlowTests: XCTestCase {
     
     /// Tests that selecting a shipping method returns the proper summary items for the checkout
     func testSelectShippingMethod() {
-        
+
         let session      = Models.createPaymentSession(requiringShippingAddressFields: true, usingNonDefault: MockAuthorizationController.self)
         let dispatcher   = ApplePayEventDispatcher(receiver: Tester.name)
         session.delegate = dispatcher
         session.presentAuthorizationController()
-        
+
         let selectedMethod = expeditedShippingMethod
 
         let expectation      = self.expectation(description: "MockAuthorizationController.invokeDidSelectShippingMethod failed to complete")
         let expectedSubtotal = PKPaymentSummaryItem(label: "SUBTOTAL", amount: 25.47)
         let expectedShipping = PKPaymentSummaryItem(label: "SHIPPING", amount: expeditedShippingMethod.amount)
         let expectedTaxes    = PKPaymentSummaryItem(label: "TAXES",    amount: 2.93)
-        let expectedTotal    = PKPaymentSummaryItem(label: totalLabel,    amount: 41.29)
-        
+        let expectedTotal    = PKPaymentSummaryItem(label: totalLabel,    amount: 40.47)
+
         let method = Tester.Method.checkoutWithShippingAddress.rawValue
         let checkoutMessage = UnityMessage(content: "", object: Tester.name, method: method)
-        
+
         MessageCenter.send(checkoutMessage) { response in
             MockAuthorizationController.invokeDidSelectShippingMethod(selectedMethod) { status, items in
-                
+
                 XCTAssertEqual(status, PKPaymentAuthorizationStatus.success)
                 XCTAssertEqual(items[0], expectedSubtotal)
                 XCTAssertEqual(items[1], expectedShipping)
                 XCTAssertEqual(items[2], expectedTaxes)
                 XCTAssertEqual(items[3], expectedTotal)
-                
+
                 expectation.fulfill()
             }
         }
-        
+
         self.wait(for: [expectation], timeout: timeout)
     }
     

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
@@ -226,7 +226,7 @@ extension Models {
         json[SummaryItemField.label.rawValue]  = label
         
         if let type = type {
-            json[SummaryItemField.type.rawValue] = type.rawValue as String
+            json[SummaryItemField.type.rawValue] = type.rawStringValue
         }
         
         return json
@@ -239,7 +239,7 @@ extension Models {
         json[ShippingMethodField.identifier.rawValue]  = identifier
         
         if let type = type {
-            json[SummaryItemField.type.rawValue] = type.rawValue as String
+            json[SummaryItemField.type.rawValue] = type.rawStringValue
         }
         
         return json

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/StringTests.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/StringTests.swift
@@ -31,58 +31,25 @@ import PassKit
 
 @available(iOS 10.0, *)
 class StringTests : XCTestCase {
-
-    /// Test that all rawValues are unique
-    func testPaymentAuthorizationStatusUnique() {
-        
-        let states: [String] = [
-            PKPaymentAuthorizationStatus.failure.rawValue,
-            PKPaymentAuthorizationStatus.success.rawValue,
-            PKPaymentAuthorizationStatus.invalidBillingPostalAddress.rawValue,
-            PKPaymentAuthorizationStatus.invalidShippingPostalAddress.rawValue,
-            PKPaymentAuthorizationStatus.invalidShippingContact.rawValue,
-            PKPaymentAuthorizationStatus.pinRequired.rawValue,
-            PKPaymentAuthorizationStatus.pinLockout.rawValue,
-            PKPaymentAuthorizationStatus.pinIncorrect.rawValue]
-        
-        XCTAssertEqual(states.count, Set(states).count)
-    }
-    
-    func testPaymentSummaryItemTypeUnique() {
-        let types: [String] = [PKPaymentSummaryItemType.pending.rawValue, PKPaymentSummaryItemType.final.rawValue]
-        XCTAssertEqual(types.count, Set(types).count)
-    }
     
     /// Test that rawValues correspond to the init
     func testPaymentAuthorizationStatusInit() {
+        XCTAssertEqual(PKPaymentAuthorizationStatus.failure, PKPaymentAuthorizationStatus(rawStringValue: "Failure"))
+        XCTAssertEqual(PKPaymentAuthorizationStatus.success, PKPaymentAuthorizationStatus(rawStringValue: "Success"))
+        XCTAssertEqual(PKPaymentAuthorizationStatus.invalidShippingContact, PKPaymentAuthorizationStatus(rawStringValue: "InvalidShippingContact"))
+        XCTAssertEqual(PKPaymentAuthorizationStatus.invalidBillingPostalAddress, PKPaymentAuthorizationStatus(rawStringValue: "InvalidBillingPostalAddress"))
+        XCTAssertEqual(PKPaymentAuthorizationStatus.invalidShippingPostalAddress, PKPaymentAuthorizationStatus(rawStringValue: "InvalidShippingPostalAddress"))
         
-        let assertInitIdempotency = { (status: PKPaymentAuthorizationStatus) in
-            XCTAssertEqual(
-                status,
-                PKPaymentAuthorizationStatus(rawValue: status.rawValue as String),
-                status.rawValue as String)
+        if #available(iOS 9.2, *) {
+            XCTAssertEqual(PKPaymentAuthorizationStatus.pinRequired, PKPaymentAuthorizationStatus(rawStringValue: "PinRequired"))
+            XCTAssertEqual(PKPaymentAuthorizationStatus.pinIncorrect, PKPaymentAuthorizationStatus(rawStringValue: "PinIncorrect"))
+            XCTAssertEqual(PKPaymentAuthorizationStatus.pinLockout, PKPaymentAuthorizationStatus(rawStringValue: "PinLockout"))
         }
-        
-        assertInitIdempotency(.failure)
-        assertInitIdempotency(.success)
-        assertInitIdempotency(.invalidBillingPostalAddress)
-        assertInitIdempotency(.invalidShippingPostalAddress)
-        assertInitIdempotency(.invalidShippingContact)
-        assertInitIdempotency(.pinRequired)
-        assertInitIdempotency(.pinLockout)
-        assertInitIdempotency(.pinIncorrect)
     }
     
     func testPaymentSummaryItemTypeInit() {
-        
-        let assertInitIdempotency = { (status: PKPaymentSummaryItemType) in
-            XCTAssertEqual(
-                status,
-                PKPaymentSummaryItemType(rawValue: status.rawValue as String),
-                status.rawValue as String)
-        }
-
-        assertInitIdempotency(.pending)
-        assertInitIdempotency(.final)
+        XCTAssertEqual(PKPaymentSummaryItemType.final, PKPaymentSummaryItemType(rawStringValue: "Final"))
+        XCTAssertEqual(PKPaymentSummaryItemType.pending, PKPaymentSummaryItemType(rawStringValue: "Pending"))
     }
 }
+

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
@@ -38,7 +38,7 @@ extension PKPaymentSummaryItem: Deserializable {
         }
         
         if let typeString = json[Field.type.rawValue] as? String,
-            let type      = PKPaymentSummaryItemType(rawValue: typeString) {
+            let type      = PKPaymentSummaryItemType(rawValue: UInt(typeString)!) {
             return self.init(label: label, amount: NSDecimalNumber(string: amount), type: type)
         } else {
             return self.init(label: label, amount: NSDecimalNumber(string: amount))

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
@@ -38,7 +38,7 @@ extension PKPaymentSummaryItem: Deserializable {
         }
         
         if let typeString = json[Field.type.rawValue] as? String,
-            let type      = PKPaymentSummaryItemType(rawValue: UInt(typeString)!) {
+           let type      = PKPaymentSummaryItemType(rawStringValue: typeString) {
             return self.init(label: label, amount: NSDecimalNumber(string: amount), type: type)
         } else {
             return self.init(label: label, amount: NSDecimalNumber(string: amount))

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift
@@ -40,7 +40,7 @@ extension PKShippingMethod {
         let shippingMethod = self.init(label: label, amount: NSDecimalNumber(string: amount))
         
         if let typeString = json[Field.type.rawValue] as? String,
-            let type      = PKPaymentSummaryItemType(rawValue: UInt(typeString)!) {
+            let type      = PKPaymentSummaryItemType(rawStringValue: typeString) {
            shippingMethod.type = type
         }
         

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift
@@ -40,7 +40,7 @@ extension PKShippingMethod {
         let shippingMethod = self.init(label: label, amount: NSDecimalNumber(string: amount))
         
         if let typeString = json[Field.type.rawValue] as? String,
-            let type      = PKPaymentSummaryItemType(rawValue: typeString) {
+            let type      = PKPaymentSummaryItemType(rawValue: UInt(typeString)!) {
            shippingMethod.type = type
         }
         

--- a/Assets/Shopify/Plugins/iOS/Shopify/String/PKPaymentAuthorizationStatus+String.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/String/PKPaymentAuthorizationStatus+String.swift
@@ -27,47 +27,32 @@
 import Foundation
 import PassKit
 
-extension PKPaymentAuthorizationStatus: RawRepresentable {
-    
-    public init?(rawValue: String) {
-        switch rawValue {
-        case PKPaymentAuthorizationStatus.failure.rawValue: self = .failure
-        case PKPaymentAuthorizationStatus.success.rawValue: self = .success
-        case PKPaymentAuthorizationStatus.invalidShippingContact.rawValue:       self = .invalidShippingContact
-        case PKPaymentAuthorizationStatus.invalidBillingPostalAddress.rawValue:  self = .invalidBillingPostalAddress
-        case PKPaymentAuthorizationStatus.invalidShippingPostalAddress.rawValue: self = .invalidShippingPostalAddress
-        default:
+extension PKPaymentAuthorizationStatus {
+    public init?(rawStringValue: String) {
+        if (rawStringValue == "Failure") {
+            self = .failure
+        } else if (rawStringValue == "Success") {
+            self = .success
+        } else if (rawStringValue == "InvalidShippingContact") {
+            self = .invalidShippingContact
+        } else if (rawStringValue == "InvalidBillingPostalAddress") {
+            self = .invalidBillingPostalAddress
+        } else if (rawStringValue == "InvalidShippingPostalAddress") {
+            self = .invalidShippingPostalAddress
+        } else {
             if #available(iOS 9.2, *) {
-                switch rawValue {
-                case PKPaymentAuthorizationStatus.pinRequired.rawValue:  self = .pinRequired
-                case PKPaymentAuthorizationStatus.pinIncorrect.rawValue: self = .pinIncorrect
-                case PKPaymentAuthorizationStatus.pinLockout.rawValue:   self = .pinLockout
-                default: return nil
+                if (rawStringValue == "PinRequired") {
+                    self = .pinRequired
+                } else if (rawStringValue == "PinIncorrect") {
+                    self = .pinIncorrect
+                } else if (rawStringValue == "PinLockout") {
+                    self = .pinLockout
+                } else {
+                     return nil
                 }
             } else {
                 return nil
             }
-        }
-    }
-    
-    public var rawValue: String {
-        switch self {
-        case .failure:
-            return "Failure"
-        case .success:
-            return "Success"
-        case .invalidBillingPostalAddress:
-            return "InvalidBillingPostalAddress"
-        case .invalidShippingPostalAddress:
-            return "InvalidShippingPostalAddress"
-        case .invalidShippingContact:
-            return "InvalidShippingContact"
-        case .pinRequired:
-            return "PinRequired"
-        case .pinIncorrect:
-            return "PinIncorrect"
-        case .pinLockout:
-            return "PinLockout"
         }
     }
 }

--- a/Assets/Shopify/Plugins/iOS/Shopify/String/PKPaymentSummaryItemType+String.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/String/PKPaymentSummaryItemType+String.swift
@@ -27,17 +27,19 @@
 import Foundation
 import PassKit
 
-extension PKPaymentSummaryItemType: RawRepresentable {
-    
-    public init?(rawValue: String) {
-        switch rawValue {
-        case PKPaymentSummaryItemType.final.rawValue:   self = .final
-        case PKPaymentSummaryItemType.pending.rawValue: self = .pending
-        default: return nil
+extension PKPaymentSummaryItemType {
+
+    public init?(rawStringValue: String) {
+        if (rawStringValue == "Final") {
+            self = .final
+        } else if (rawStringValue == "Pending") {
+            self = .pending
+        } else {
+            return nil
         }
     }
-    
-    public var rawValue: String {
+
+    public var rawStringValue: String {
         switch self {
         case .final:
             return "Final"
@@ -46,3 +48,4 @@ extension PKPaymentSummaryItemType: RawRepresentable {
         }
     }
 }
+

--- a/Assets/Shopify/UIToolkit/ShopControllers/BaseShopController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/BaseShopController.cs
@@ -72,7 +72,12 @@ namespace Shopify.UIToolkit {
 
         private void SetupClientAndCart() {
             _cachedClient = new ShopifyClient(LoaderProvider.GetLoader(Credentials.AccessToken, Credentials.Domain));
+
+            #if UNITY_IOS
             _cachedCart = new CartController(_cachedClient.Cart(), _appleMerchantID);
+            #else
+            _cachedCart = new CartController(_cachedClient.Cart());
+            #endif
             
             _cachedCart.OnPurchaseStarted.AddListener(Shop.OnPurchaseStarted);
             _cachedCart.OnPurchaseCancelled.AddListener(Shop.OnPurchaseCancelled);

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -42,7 +42,9 @@ namespace Shopify.UIToolkit {
         public UnityEvent OnPurchaseCancelled = new UnityEvent();
         public PurchaseFailedEvent OnPurchaseFailed = new PurchaseFailedEvent();
 
+        #if UNITY_IOS
         private string _appleMerchantID;
+        #endif
 
         private struct ProductAndVariantPair {
             public readonly Product Product;
@@ -56,9 +58,15 @@ namespace Shopify.UIToolkit {
 
         private Dictionary<string, ProductAndVariantPair> _idsToProductPairs = new Dictionary<string, ProductAndVariantPair>();
 
+        #if UNITY_IOS
         public CartController(Cart cart, string appleMerchantID) {
             SetCart(cart);
             _appleMerchantID = appleMerchantID;
+        }
+        #endif
+
+        public CartController(Cart cart) {
+            SetCart(cart);
         }
 
         public void SetCart(Cart cart) {

--- a/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
+++ b/Assets/Shopify/UIToolkit/ShopControllers/Classes/CartController.cs
@@ -6,7 +6,6 @@ namespace Shopify.UIToolkit {
     using System;
     using System.Linq;
     using System.Collections.Generic;
-    using UnityEngine;
 
     /// <summary>
     // A wrapper struct that encapsulates the information we want from a CartLineItem (Quantity) and the

--- a/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
+++ b/Assets/Shopify/UIToolkit/Shops/Generic/Classes/CartView.cs
@@ -60,7 +60,7 @@ namespace Shopify.UIToolkit.Shops.Generic {
 
             _cartItems = cartItems;
 
-            if (gameObject.active) {
+            if (gameObject.activeSelf) {
                 UpdateList();
             }
         }

--- a/Assets/Shopify/Unity/Cart.cs
+++ b/Assets/Shopify/Unity/Cart.cs
@@ -11,10 +11,6 @@ namespace Shopify.Unity {
     using Shopify.Unity.SDK.Android;
 #endif
 
-#if UNITY_ANDROID
-    using Shopify.Unity.SDK.Android;
-#endif
-
     /// <summary>
     /// This exception is thrown when interacting with a cart to add, update, or delete line items and no matching
     /// variant could be found.

--- a/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
+++ b/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
@@ -49,7 +49,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         }
 
         public static void SetSwiftInterfaceHeader(ExtendedPBXProject project) {
-            var bundleIdentifier = PlayerSettings.iPhoneBundleIdentifier;
+            var bundleIdentifier = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.iOS);
 
             char[] separator = { '.' };
             var keywords = bundleIdentifier.Split(separator);

--- a/Assets/Shopify/Unity/UI/NativePayButtonUI.cs
+++ b/Assets/Shopify/Unity/UI/NativePayButtonUI.cs
@@ -1,4 +1,4 @@
-#if !SHOPIFY_MONO_UNIT_TEST && UNITY_IOS
+#if !SHOPIFY_MONO_UNIT_TEST
 namespace Shopify.Unity.UI {
     using System.Runtime.InteropServices;
     using System.Text;
@@ -6,6 +6,7 @@ namespace Shopify.Unity.UI {
     using UnityEngine.UI;
     using UnityEngine;
 
+    #if UNITY_IOS
     /// <summary>
     /// The Apple Pay payment button style C# enum. See https://developer.apple.com/documentation/passkit/pkpaymentbuttonstyle
     /// for all available options.
@@ -27,8 +28,10 @@ namespace Shopify.Unity.UI {
         IN_STORE,
         DONATE
     }
+    #endif
 
     public class NativePayButtonUI : MonoBehaviour {
+        #if UNITY_IOS
         /// <summary>
         /// The Apple Pay payment button style. See https://developer.apple.com/documentation/passkit/pkpaymentbuttonstyle
         /// for all available options.
@@ -40,15 +43,18 @@ namespace Shopify.Unity.UI {
         /// for all available options.
         /// </summary>
         public ApplePayButtonType applePayButtonType;
+        #endif
 
         private RectTransform rectTransform;
         private Image buttonImage;
         private Texture2D imageTexture;
 
         public void Start() {
+            #if UNITY_IOS
             buttonImage = this.gameObject.GetComponent<Image>();
             rectTransform = this.gameObject.GetComponent<RectTransform>();
             GenerateNativePayImage();
+            #endif
         }
 
         public void OnRectTransformDimensionsChange() {
@@ -59,11 +65,14 @@ namespace Shopify.Unity.UI {
             GenerateApplePayImage();
         }
 
+        #if UNITY_IOS
         [DllImport("__Internal")]
         private static extern IntPtr _GenerateApplePayButtonImage(string type, string style,
             float width, float height);
+        #endif
 
         private void GenerateApplePayImage() {
+            #if UNITY_IOS
             // Ask iOS to generate us an image of the native Apple Pay button.
             var imageStringPtr = _GenerateApplePayButtonImage(
                 applePayButtonType.ToString(),
@@ -94,6 +103,7 @@ namespace Shopify.Unity.UI {
                 new Vector2(0.5f, 0.5f),
                 100.0f
             );
+            #endif
         }
     }
 }

--- a/Assets/Shopify/Unity/UI/NativePayButtonUI.cs
+++ b/Assets/Shopify/Unity/UI/NativePayButtonUI.cs
@@ -1,4 +1,4 @@
-#if !SHOPIFY_MONO_UNIT_TEST
+#if !SHOPIFY_MONO_UNIT_TEST && UNITY_IOS
 namespace Shopify.Unity.UI {
     using System.Runtime.InteropServices;
     using System.Text;
@@ -56,12 +56,9 @@ namespace Shopify.Unity.UI {
         }
 
         private void GenerateNativePayImage() {
-        #if UNITY_IOS
             GenerateApplePayImage();
-        #endif
         }
 
-#if UNITY_IOS
         [DllImport("__Internal")]
         private static extern IntPtr _GenerateApplePayButtonImage(string type, string style,
             float width, float height);
@@ -98,7 +95,6 @@ namespace Shopify.Unity.UI {
                 100.0f
             );
         }
-#endif
     }
 }
 #endif


### PR DESCRIPTION
* Xcode 9.3 beta makes the `PKPayment*` enum types actually inherit from `RawRepresentable` thus causing a redefinition conflict with `rawValue`. Since we parse it from a string I've added a `rawStringValue` init method to most types to keep the functionality the same
* Cleaned up some unused code path warnings caused by switching between platforms
* Fixed an annoying issue in our integration tests where the standard/expedited shipping costs we changed to be rounded numbers.