### PR TITLE
Use image aliases for transformedSrc properties instead of image queries

### DIFF
--- a/Assets/Editor/MockLoaderProducts.cs
+++ b/Assets/Editor/MockLoaderProducts.cs
@@ -139,7 +139,7 @@ namespace Shopify.Tests {
             query.node(n => n
                 .onProduct(p => p
                     .id()
-                    .images(ic => DefaultQueries.products.ImageConnection(ic),
+                    .images(ic => DefaultQueries.products.ImageConnection(ic, ShopifyClient.DefaultImageResolutions),
                         first: DefaultQueries.MaxPageSize, after: "image249"
                     )
                 ),
@@ -149,7 +149,7 @@ namespace Shopify.Tests {
             query.node(n => n
                 .onProduct(p => p
                     .id()
-                    .images(ic => DefaultQueries.products.ImageConnection(ic),
+                    .images(ic => DefaultQueries.products.ImageConnection(ic, ShopifyClient.DefaultImageResolutions),
                         first: DefaultQueries.MaxPageSize, after: "image249"
                     )
                     .variants(
@@ -203,7 +203,7 @@ namespace Shopify.Tests {
             query.node(n => n
                 .onProduct(p => p
                     .id()
-                    .images(ic => DefaultQueries.products.ImageConnection(ic),
+                    .images(ic => DefaultQueries.products.ImageConnection(ic, ShopifyClient.DefaultImageResolutions),
                         first: DefaultQueries.MaxPageSize, after: "image499"
                     )
                 ),

--- a/Assets/IntegrationTests/TestShopifyProducts.cs
+++ b/Assets/IntegrationTests/TestShopifyProducts.cs
@@ -27,18 +27,14 @@ namespace Shopify.Unity.Tests
                     Assert.AreEqual("Neptune Boot", products[1].title(), "Title product 1: Neptune Boot");
 
                     List<string> aliases = Utils.GetImageAliases();
-                    
+
+                    var productImages = (List<Image>)products[0].images();
                     foreach(string imageAlias in aliases) {
-                        Assert.IsNotNull(products[0].images(imageAlias), string.Format("images alias {0} was queried", imageAlias));
+                        Assert.IsNotNull(productImages[0].transformedSrc(imageAlias), string.Format("images alias {0} was queried", imageAlias));
                     }
 
                     List<ProductVariant> variants = (List<ProductVariant>) products[0].variants();
                     
-                    foreach(string imageAlias in aliases) {
-                        // this will throw an exception if not queried
-                        variants[0].image(imageAlias);
-                    }
-
                     // this will throw an exception if not queried
                     variants[0].image();
 
@@ -66,16 +62,12 @@ namespace Shopify.Unity.Tests
 
                     List<string> aliases = Utils.GetImageAliases();
 
+                    var productImages = (List<Image>)products[0].images();
                     foreach(string imageAlias in aliases) {
-                        Assert.IsNotNull(products[0].images(imageAlias), string.Format("images alias {0} was queried", imageAlias));
+                        Assert.IsNotNull(productImages[0].transformedSrc(imageAlias), string.Format("images alias {0} was queried", imageAlias));
                     }
 
                     List<ProductVariant> variants = (List<ProductVariant>) products[0].variants();
-
-                    foreach(string imageAlias in aliases) {
-                        // this will throw an exception if not queried
-                        variants[0].image(imageAlias);
-                    }
 
                     // this will throw an exception if not queried
                     variants[0].image();

--- a/Assets/IntegrationTests/Utils.cs
+++ b/Assets/IntegrationTests/Utils.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace Shopify.Unity.Tests {
     public class Utils {
         public const float MaxQueryDuration = 3f;
-        public const string MaxQueryMessage = "Query failed to run in 1 seconds";
+        public const string MaxQueryMessage = "Query failed to run in 3 seconds";
 
         public static StoppableWaitForTime GetWaitQuery() {
             return new StoppableWaitForTime (MaxQueryDuration);
@@ -13,7 +13,6 @@ namespace Shopify.Unity.Tests {
 
         public static List<string> GetImageAliases() {
             return new List<string>() {
-                "pico",
                 "pico",
                 "icon",
                 "thumb",

--- a/Assets/IntegrationTests/Utils.cs
+++ b/Assets/IntegrationTests/Utils.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Shopify.Unity.Tests {
     public class Utils {
-        public const float MaxQueryDuration = 1f;
+        public const float MaxQueryDuration = 3f;
         public const string MaxQueryMessage = "Query failed to run in 1 seconds";
 
         public static StoppableWaitForTime GetWaitQuery() {

--- a/Assets/Shopify/Examples/Scripts/Panels/ProductsPanelCell.cs
+++ b/Assets/Shopify/Examples/Scripts/Panels/ProductsPanelCell.cs
@@ -58,7 +58,7 @@ namespace Shopify.Examples.Panels {
             ClickRegionButton.onClick.AddListener(() => OnClick.Invoke());
 
             if (images.Count > 0) {
-                _imageSrc = images.First().transformedSrc();
+                _imageSrc = images.First().transformedSrc("compact");
             }
         }
     }

--- a/Assets/Shopify/Unity/SDK/DefaultCollectionQueries.cs
+++ b/Assets/Shopify/Unity/SDK/DefaultCollectionQueries.cs
@@ -41,10 +41,11 @@ namespace Shopify.Unity.SDK {
                 collection
                     .image(pci => pci
                         .altText()
-                        .transformedSrc(),
-                        maxWidth : imageResolutions[alias],
-                        maxHeight : imageResolutions[alias],
-                        alias : alias
+                        .transformedSrc(
+                            maxWidth : imageResolutions[alias],
+                            maxHeight : imageResolutions[alias],
+                            alias : alias
+                        )
                     );
             }
         }

--- a/Assets/Shopify/Unity/SDK/DefaultProductQueries.cs
+++ b/Assets/Shopify/Unity/SDK/DefaultProductQueries.cs
@@ -41,30 +41,28 @@ namespace Shopify.Unity.SDK {
                     first : DefaultQueries.MaxPageSize
                 )
                 .images(
-                    ic => ImageConnection(ic),
+                    ic => ImageConnection(ic, imageResolutions),
                     first : DefaultQueries.MaxPageSize
                 );
-
-            foreach (string alias in imageResolutions.Keys) {
-                product.images(
-                    ic => ImageConnection(ic),
-                    first : DefaultQueries.MaxPageSize,
-                    maxWidth : imageResolutions[alias],
-                    maxHeight : imageResolutions[alias],
-                    alias : alias
-                );
-            }
         }
 
-        public void ImageConnection(ImageConnectionQuery imageConnection) {
-            imageConnection
-                .edges(ie => ie
-                    .node(imn => Image(imn))
-                    .cursor()
-                )
-                .pageInfo(pi => pi
-                    .hasNextPage()
-                );
+        public void ImageConnection(ImageConnectionQuery imageConnection, Dictionary<string, int> imageResolutions) {
+            foreach (string alias in imageResolutions.Keys) {
+                imageConnection
+                    .edges(ie => ie
+                        .node(i => i
+                            .transformedSrc(
+                                maxWidth: imageResolutions[alias],
+                                maxHeight: imageResolutions[alias],
+                                alias: alias
+                            )
+                        )
+                        .cursor()
+                    )
+                    .pageInfo(pi => pi
+                        .hasNextPage()
+                    );
+            }
         }
 
         public void ProductVariantConnection(ProductVariantConnectionQuery variantConnection, Dictionary<string, int> imageResolutions) {
@@ -116,8 +114,11 @@ namespace Shopify.Unity.SDK {
                 variant.image(
                     pnvi => pnvi
                     .altText()
-                    .transformedSrc(),
-                    maxWidth : imageResolutions[alias], maxHeight : imageResolutions[alias], alias : alias
+                    .transformedSrc(
+                        maxWidth : imageResolutions[alias],
+                        maxHeight : imageResolutions[alias],
+                        alias: alias
+                    )
                 );
             }
         }

--- a/Assets/Shopify/Unity/SDK/DefaultProductQueries.cs
+++ b/Assets/Shopify/Unity/SDK/DefaultProductQueries.cs
@@ -47,21 +47,23 @@ namespace Shopify.Unity.SDK {
         }
 
         public void ImageConnection(ImageConnectionQuery imageConnection, Dictionary<string, int> imageResolutions) {
+            imageConnection
+                .edges(ie => ie
+                    .node(i => AliasedTransformedSrcImages(i.altText().transformedSrc(), imageResolutions))
+                    .cursor()
+                )
+                .pageInfo(pi => pi
+                    .hasNextPage()
+                );
+        }
+
+        public void AliasedTransformedSrcImages(ImageQuery imageQuery, Dictionary<string, int> imageResolutions) {
             foreach (string alias in imageResolutions.Keys) {
-                imageConnection
-                    .edges(ie => ie
-                        .node(i => i
-                            .transformedSrc(
-                                maxWidth: imageResolutions[alias],
-                                maxHeight: imageResolutions[alias],
-                                alias: alias
-                            )
-                        )
-                        .cursor()
-                    )
-                    .pageInfo(pi => pi
-                        .hasNextPage()
-                    );
+                imageQuery.transformedSrc(
+                    maxWidth: imageResolutions[alias],
+                    maxHeight: imageResolutions[alias],
+                    alias: alias
+                );
             }
         }
 
@@ -97,10 +99,7 @@ namespace Shopify.Unity.SDK {
             variant
                 .id()
                 .availableForSale()
-                .image(pnvi => pnvi
-                    .altText()
-                    .transformedSrc()
-                )
+                .image(i => AliasedTransformedSrcImages(i.altText().transformedSrc(), imageResolutions))
                 .price()
                 .title()
                 .weight()
@@ -109,18 +108,6 @@ namespace Shopify.Unity.SDK {
                     .value()
                 )
                 .weightUnit();
-
-            foreach (string alias in imageResolutions.Keys) {
-                variant.image(
-                    pnvi => pnvi
-                    .altText()
-                    .transformedSrc(
-                        maxWidth : imageResolutions[alias],
-                        maxHeight : imageResolutions[alias],
-                        alias: alias
-                    )
-                );
-            }
         }
 
         public void Collection(CollectionQuery collection) {

--- a/Assets/Shopify/Unity/ShopifyBuy.cs
+++ b/Assets/Shopify/Unity/ShopifyBuy.cs
@@ -136,10 +136,10 @@ namespace Shopify.Unity {
         ///
         /// \code{.cs}
         /// // Returns an image source url whose dimensions are never greater than 100px
-        /// string srcSmallImage = productVariant.image("small").transformedSrc();
+        /// string srcSmallImage = productVariant.image().transformedSrc("small");
         ///
         /// // Returns an image source url whose dimensions are never greater than 1024px
-        /// string src1024Image = productVariant.image("resolution_1024").transformedSrc();
+        /// string src1024Image = productVariant.image().transformedSrc("resolution_1024");
         /// \endcode
         /// </summary>
         public static Dictionary<string, int> DefaultImageResolutions = new Dictionary<string, int> () { { "pico", 16 }, { "icon", 32 }, { "thumb", 50 }, { "small", 100 }, { "compact", 160 }, { "medium", 240 }, { "large", 480 }, { "grande", 600 }, { "resolution_1024", 1024 }, { "resolution_2048", 2048 }
@@ -825,47 +825,31 @@ namespace Shopify.Unity {
         private void GetConnectionsForProducts (List<Product> products, ProductsHandler callback) {
             List<ConnectionQueryInfo> connectionInfos = new List<ConnectionQueryInfo> () {
                 new ConnectionQueryInfo (
-                        getConnection: (p) => ((Product) p).images (),
-                        query: (p, imagesAfter) => {
-                            ((ProductQuery) p).images (ic => DefaultQueries.products.ImageConnection (ic),
-                                first : DefaultQueries.MaxPageSize, after : imagesAfter
-                            );
-                        }
-                    ),
-                    new ConnectionQueryInfo (
-                        getConnection: (p) => ((Product) p).variants (),
-                        query: (p, variantsAfter) => {
-                            ((ProductQuery) p).variants (vc => DefaultQueries.products.ProductVariantConnection (vc, DefaultImageResolutions),
-                                first : DefaultQueries.MaxPageSize, after : variantsAfter
-                            );
-                        }
-                    ),
-                    new ConnectionQueryInfo (
-                        getConnection: (p) => ((Product) p).collections (),
-                        query: (p, collectionsAfter) => {
-                            ((ProductQuery) p).collections (cc => DefaultQueries.products.CollectionConnection (cc),
-                                first : DefaultQueries.MaxPageSize, after : collectionsAfter
-                            );
-                        }
-                    )
-            };
-
-            foreach (string alias in DefaultImageResolutions.Keys) {
-                string currentAlias = alias;
-
-                connectionInfos.Add (new ConnectionQueryInfo (
-                    getConnection: (p) => ((Product) p).images (currentAlias),
+                    getConnection: (p) => ((Product) p).images (),
                     query: (p, imagesAfter) => {
-                        ((ProductQuery) p).images (ic => DefaultQueries.products.ImageConnection (ic),
+                        ((ProductQuery) p).images (ic => DefaultQueries.products.ImageConnection (ic, DefaultImageResolutions),
                             first : DefaultQueries.MaxPageSize,
-                            after : imagesAfter,
-                            maxWidth : DefaultImageResolutions[currentAlias],
-                            maxHeight : DefaultImageResolutions[currentAlias],
-                            alias : currentAlias
+                            after : imagesAfter
                         );
                     }
-                ));
-            }
+                ),
+                new ConnectionQueryInfo (
+                    getConnection: (p) => ((Product) p).variants (),
+                    query: (p, variantsAfter) => {
+                        ((ProductQuery) p).variants (vc => DefaultQueries.products.ProductVariantConnection (vc, DefaultImageResolutions),
+                            first : DefaultQueries.MaxPageSize, after : variantsAfter
+                        );
+                    }
+                ),
+                new ConnectionQueryInfo (
+                    getConnection: (p) => ((Product) p).collections (),
+                    query: (p, collectionsAfter) => {
+                        ((ProductQuery) p).collections (cc => DefaultQueries.products.CollectionConnection (cc),
+                            first : DefaultQueries.MaxPageSize, after : collectionsAfter
+                        );
+                    }
+                )
+            };
 
             ConnectionLoader loader = new ConnectionLoader (Loader);
             List<Node> nodes = products.ConvertAll (p => (Node) p);


### PR DESCRIPTION
For loading different image resolutions, we were sending aliased `image` fields to the Storefront API and relying on the Image's `src` property for the sized URL. Using `src` directly has now been deprecated and `transformedSrc` should be used instead.

`transformedSrc` now takes in an alias to be used so instead of having a query that looks like this:

```graphql
    image___pico: image(maxWidth: 16, maxHeight: 16) {
        altText
        transformedSrc
    }
    image___icon: image(maxWidth: 32, maxHeight: 32) {
         altText
         transformedSrc
    }
```

Querying for different image sizes looks like this:

```graphql
    image {
        altText
        transformedSrc
        transformedSrc___pico: transformedSrc(maxWidth: 16, maxHeight: 16)
        transformedSrc___icon: transformedSrc(maxWidth: 32, maxHeight: 32)
    }
```

This means the client side API has changed from `product.image("pico").src` to `product.image().transformedSrc("pico")`