### PR TITLE
Added GraphQL UNION type generation support

### DIFF
--- a/scripts/generator/graphql_generator/csharp/type.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type.cs.erb
@@ -44,53 +44,57 @@ namespace Shopify.Unity.GraphQL {
             <% end %>
 
             <%# now create methods to add fields to queries %>
-            <% type.fields(include_deprecated: true).each do |field| %>
-                <%= docs_query_field(field) %>
-                public <%= type.classify_name %>Query <%= escape_reserved_word(field.name) %>(<%= field_args(field) %>) {
-                    <% if field.deprecated? %>
-                    Log.DeprecatedQueryField("<%= type.name %>", "<%= field.name %>", "<%= field.deprecation_reason.gsub(/\n/, "\\n") %>");
-                    <% end %>
 
-                    <%# now we we want to handle generating arguments %>
-                    <% if field.args.any? %>
-                        if (alias != null) {
-                            ValidationUtils.ValidateAlias(alias);
 
-                            Query.Append("<%= field.name + ALIAS_SEPARATOR %>");
-                            Query.Append(alias);
-                            Query.Append(":");
-                        }
-
-                        Query.Append("<%= field.name %> ");
-
-                        Arguments args = new Arguments();
-
-                        <%# handle adding required args to the args generator %>
-                        <% field.required_args.each do |arg| %>
-                            args.Add("<%= arg.name %>", <%= escape_reserved_word(arg.name) %>);
+            <% unless type.union? %>
+                <% type.fields(include_deprecated: true).each do |field| %>
+                    <%= docs_query_field(field) %>
+                    public <%= type.classify_name %>Query <%= escape_reserved_word(field.name) %>(<%= field_args(field) %>) {
+                        <% if field.deprecated? %>
+                        Log.DeprecatedQueryField("<%= type.name %>", "<%= field.name %>", "<%= field.deprecation_reason.gsub(/\n/, "\\n") %>");
                         <% end %>
 
-                        <% field.optional_args.each do |arg| %>
-                            if (<%= escape_reserved_word(arg.name) %> != null) {
-                                args.Add("<%= arg.name %>", <%= escape_reserved_word(arg.name) %>);
+                        <%# now we we want to handle generating arguments %>
+                        <% if field.args.any? %>
+                            if (alias != null) {
+                                ValidationUtils.ValidateAlias(alias);
+
+                                Query.Append("<%= field.name + ALIAS_SEPARATOR %>");
+                                Query.Append(alias);
+                                Query.Append(":");
                             }
+
+                            Query.Append("<%= field.name %> ");
+
+                            Arguments args = new Arguments();
+
+                            <%# handle adding required args to the args generator %>
+                            <% field.required_args.each do |arg| %>
+                                args.Add("<%= arg.name %>", <%= escape_reserved_word(arg.name) %>);
+                            <% end %>
+
+                            <% field.optional_args.each do |arg| %>
+                                if (<%= escape_reserved_word(arg.name) %> != null) {
+                                    args.Add("<%= arg.name %>", <%= escape_reserved_word(arg.name) %>);
+                                }
+                            <% end %>
+
+                            Query.Append(args.ToString());
+                        <% else %>
+                            Query.Append("<%= field.name %> ");
                         <% end %>
 
-                        Query.Append(args.ToString());
-                    <% else %>
-                        Query.Append("<%= field.name %> ");
-                    <% end %>
 
+                        <%# if this field is an OBJECT we want to be able to query subfields %>
+                        <% if field.type.subfields? %>
+                            Query.Append("{");
+                            buildQuery(new <%= field.type.unwrap.classify_name %>Query(Query));
+                            Query.Append("}");
+                        <% end %>
 
-                    <%# if this field is an OBJECT we want to be able to query subfields %>
-                    <% if field.type.subfields? %>
-                        Query.Append("{");
-                        buildQuery(new <%= field.type.unwrap.classify_name %>Query(Query));
-                        Query.Append("}");
-                    <% end %>
-
-                    return this;
-                }
+                        return this;
+                    }
+                <% end %>
             <% end %>
 
             <% unless type.object? %>

--- a/scripts/generator/graphql_generator/csharp/type_response.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type_response.cs.erb
@@ -25,6 +25,34 @@ namespace Shopify.Unity {
                 return connection.Nodes;
             }
         <% end %>
+    <% elsif type.union? %>
+        <%= docs_union(type) %>
+        public interface <%= type.classify_name %> {}
+
+        <%= docs_response_object(type) %>
+        public class Unknown<%= type.classify_name %> : AbstractResponse, ICloneable, <%= type.classify_name %> {
+            /// <summary>
+            /// Instantiate objects implementing <see cref="<%= type.classify_name %>" />. Possible types are:
+            /// <%= docs_possible_types(type).split("\n").join("\n/// ") %>
+            /// </summary>
+            public static <%= type.classify_name %> Create(Dictionary<string, object> dataJSON) {
+                string typeName = (string) dataJSON["__typename"];
+
+                switch(typeName) {
+                    <% type.possible_types.each do |possible_type| %>
+                        case "<%= possible_type.name %>":
+                            return new <%= possible_type.classify_name %>(dataJSON) as <%= type.classify_name %>;
+                    <% end %>
+
+                    default:
+                        return new Unknown<%= type.classify_name %>();
+                }
+            }
+
+            public object Clone() {
+                return new Unknown<%= type.classify_name %>();
+            }
+        }
     <% elsif type.interface? %>
         <%= docs_interface(type) %>
         public interface <%= type.classify_name %> {
@@ -54,6 +82,8 @@ namespace Shopify.Unity {
                 }
             }
     <% end %>
+
+    <% unless type.union? %>
         /// <summary>
         /// <see ref="<%= "Unknown" if type.interface? %><%= type.classify_name %>" /> Accepts deserialized json data.
         /// <see ref="<%= "Unknown" if type.interface? %><%= type.classify_name %>" /> Will further parse passed in data.
@@ -83,6 +113,8 @@ namespace Shopify.Unity {
                                     <%= response_init_object(field) %>
                                 <% when "INTERFACE" %>
                                     <%= response_init_interface(field) %>
+                                <% when "UNION" %>
+                                    <%= response_init_union(field) %>
                                 <% when "LIST" %>
                                     <% if field.name == 'nodes' %>
                                         DataToNodeList(dataJSON[key])
@@ -108,6 +140,8 @@ namespace Shopify.Unity {
                                         <%= response_init_object(field) %>
                                     <% when "INTERFACE" %>
                                         <%= response_init_interface(field) %>
+                                    <% when "UNION" %>
+                                        <%= response_init_union(field) %>
                                     <% when "LIST" %>
                                         <%= response_init_list(field) %>
                                     <% when "ENUM" %>
@@ -188,4 +222,5 @@ namespace Shopify.Unity {
             return nodes;
         }
     }
+    <% end %>
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/unity-buy-sdk/issues/537

The Storefront API introduced `PricingValue` which is the first UNION GraphQL type to be used in the API. We didnt have a way of handling UNION types so this PR adds that functionality to the generator. The approach here is to do a similiar thing we do for interfaces since a union is just a GraphQL interface that has no shared members. The main code difference is that since unions dont have any fields, the field generation code is omitted.