### PR TITLE
Fixed bug in GraphQL generator that never passed non_null information to recursive call

### DIFF
--- a/scripts/generator/graphql_generator/csharp.rb
+++ b/scripts/generator/graphql_generator/csharp.rb
@@ -148,7 +148,7 @@ module GraphQLGenerator
       when "SCALAR"
         scalars[type.name].cast_value(value)
       else
-        "(#{graph_type_to_csharp_type(type)}) #{value}"
+        "(#{graph_type_to_csharp_type(type, is_non_null: is_non_null)}) #{value}"
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/unity-buy-sdk/issues/533

When generating the `CurrencyCode` field for `MoneyInput`, we were generating a nullable cast which doesn't compile since `CurrencyCode` is an enum type. The reason this was happening was because we were not passing down the `is_non_null` flag to recursive calls in `graph_type_to_csharp_cast`. This fix passes the flag down so we can properly recognize non-null types.