### PR TITLE
Fixes DontDestroyOnLoad error for Edit Mode UIToolkit tests

### DIFF
--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestBaseShopControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestBaseShopControllerEditor.cs
@@ -23,10 +23,12 @@ namespace Shopify.UIToolkit.Test.Unit {
 
         private ShopControllerBaseEditor _editor;
         private MockShopController _controller;
+        private GameObject _gameObject;
 
         [SetUp]
         public void Setup() {
-            _controller = GlobalGameObject.AddComponent<MockShopController>();
+            _gameObject = new GameObject("TestBaseShopControllerEditor");
+            _controller = _gameObject.AddComponent<MockShopController>();
             _controller.Credentials = new ShopCredentials();
             _editor = Editor.CreateEditor(_controller) as ShopControllerBaseEditor;
             _editor.View = Substitute.For<IShopControllerBaseEditorView>();
@@ -34,7 +36,7 @@ namespace Shopify.UIToolkit.Test.Unit {
 
         [TearDown]
         public void TearDown() {
-            GlobalGameObject.Destroy();
+            GameObject.DestroyImmediate(_gameObject);
         }
 
         [Test]
@@ -46,7 +48,7 @@ namespace Shopify.UIToolkit.Test.Unit {
 
         [Test]
         public void TestBoundShopDoesNotDrawHelpBox() {
-            GlobalGameObject.AddComponent<DebugSingleProductShop>();
+            _gameObject.AddComponent<DebugSingleProductShop>();
             _editor.OnInspectorGUI();
             _editor.View.DidNotReceive().DrawShopHelp();
         }

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestShopControllerBase.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestShopControllerBase.cs
@@ -1,6 +1,7 @@
 namespace Shopify.UIToolkit.Test.Unit {
     using NUnit.Framework;
     using Shopify.Tests;
+    using Shopify.Unity.SDK.Editor;
     using Shopify.Unity.SDK;
     using Shopify.Unity;
     using System.Linq;
@@ -19,14 +20,22 @@ namespace Shopify.UIToolkit.Test.Unit {
 
         private MockShopController _shopController;
         private IShop _shop;
+        private GameObject _gameObject;
 
         [SetUp]
         public void Setup() {
-            _shopController = GlobalGameObject.AddComponent<MockShopController>();
+            _gameObject = new GameObject("TestShopControllerBase");
+            _shopController = _gameObject.AddComponent<MockShopController>();
             _shopController.Credentials = new ShopCredentials(Utils.TestShopDomain, Utils.TestAccessToken);
+            _shopController.LoaderProvider = new UnityEditorLoaderProvider();
 
             _shop = Substitute.For<IShop>();
             _shopController.Shop = _shop;
+        }
+
+        [TearDown]
+        public void TearDown() {
+            GameObject.DestroyImmediate(_gameObject);
         }
 
         [Test]

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductShopController.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductShopController.cs
@@ -15,14 +15,22 @@
     public class TestSingleProductShopController {
         private SingleProductShopController _controller;
         private ISingleProductShop _shop;
+        private GameObject _gameObject;
 
         [SetUp]
         public void Setup() {
-            _controller = GlobalGameObject.AddComponent<SingleProductShopController>();
+            _gameObject = new GameObject("TestSingleProductShopController");
+            _controller = _gameObject.AddComponent<SingleProductShopController>();
+            _controller.LoaderProvider = new UnityEditorLoaderProvider();
             _shop = Substitute.For<ISingleProductShop>();
 
             _controller.Shop = _shop;
             _controller.Credentials = new ShopCredentials(Utils.TestShopDomain, Utils.TestAccessToken);
+        }
+
+        [TearDown]
+        public void TearDown() {
+            GameObject.DestroyImmediate(_gameObject);
         }
 
         [Test]

--- a/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductShopControllerEditor.cs
+++ b/Assets/Shopify/UIToolkit/Test/Unit/Editor/TestSingleProductShopControllerEditor.cs
@@ -11,10 +11,12 @@ namespace Shopify.UIToolkit.Test.Unit {
     public class TestSingleProductShopControllerEditor {
         private SingleProductShopControllerEditor _editor;
         private SingleProductShopController _controller;
+        private GameObject _gameObject;
 
         [SetUp]
         public void Setup() {
-            _controller = GlobalGameObject.AddComponent<SingleProductShopController>();
+            _gameObject = new GameObject("TestSingleProductShopControllerEditor");
+            _controller = _gameObject.AddComponent<SingleProductShopController>();
             _controller.Credentials = new ShopCredentials("","");
 
             _editor = Editor.CreateEditor(_controller) as SingleProductShopControllerEditor;
@@ -23,7 +25,7 @@ namespace Shopify.UIToolkit.Test.Unit {
 
         [TearDown]
         public void TearDown() {
-            GlobalGameObject.Destroy();
+            GameObject.DestroyImmediate(_gameObject);
         }
 
         [Test]

--- a/Assets/Shopify/Unity/SDK/Editor/UnityEditorLoader.cs
+++ b/Assets/Shopify/Unity/SDK/Editor/UnityEditorLoader.cs
@@ -81,5 +81,11 @@ namespace Shopify.Unity.SDK.Editor {
 
         #endregion
     }
+
+    public class UnityEditorLoaderProvider : ILoaderProvider {
+        BaseLoader ILoaderProvider.GetLoader(string accessToken, string domain) {
+            return new UnityEditorLoader(domain, accessToken);
+        }
+    }
 }
 #endif


### PR DESCRIPTION
Fixes https://github.com/Shopify/unity-buy-sdk/issues/535

Some of our Edit Mode tests for the UIToolkit were failing because we were calling `DontDestroyOnLoad` from the `GlobalGameObject` which can only be called during Play Mode tests. This PR replaces any calls to adding components to the `GlobalGameObject` to a locally-created GameObject instead to avoid this call. In cases where we query the network, since `UnityLoader` touches the `GlobalGameObject` I've replaced the loader with a `UnityEditorLoader` which is an editor-safe network client.