### PR TITLE
Override UNITY_APP_PATH with custom Unity path

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -19,6 +19,6 @@ end() {
 
 PROJECT_ROOT=${PROJECT_ROOT:-$(pwd)}
 SCRIPTS_ROOT="$PROJECT_ROOT/scripts"
-UNITY_APP_PATH="/Applications/Unity/Unity.app"
+UNITY_APP_PATH="${UNITY_APP_PATH:-/Applications/Unity/Unity.app}"
 UNITY_PATH="$UNITY_APP_PATH/Contents/MacOS/Unity"
 UNITY_PACKAGE_MANAGER_PATH="$UNITY_APP_PATH/Contents/PackageManager/Unity/PackageManager"


### PR DESCRIPTION
https://github.com/Shopify/unity-buy-sdk/issues/521

Allow overriding of UNITY_APP_PATH environment variable to allow users to pass in installations from Unity Hub or other sources. Default is still set to point to `/Applications/Unity/Unity.app` in case your not using Hub or an older version of Unity.