### PR TITLE
Migrate iOS plugin to Swift 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10
+osx_image: xcode10.2
 
 env:
   UNITY_DOWNLOAD_DIR: $HOME/unity

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10.2
+osx_image: xcode10
 
 env:
   UNITY_DOWNLOAD_DIR: $HOME/unity

--- a/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
+++ b/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
@@ -23,7 +23,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         /// Sets the correct build properties to run
         private static void SetBuildProperties(ExtendedPBXProject project) {
             iOSPostProcessor.SetBuildProperties(project);
-            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "4.0");
+            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "5.0");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Tests-Bridging-Header.h");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@loader_path/Frameworks");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.ProjectModuleNameKey, "$(PRODUCT_NAME:c99extidentifier)Tests");

--- a/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
+++ b/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
@@ -23,7 +23,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         /// Sets the correct build properties to run
         private static void SetBuildProperties(ExtendedPBXProject project) {
             iOSPostProcessor.SetBuildProperties(project);
-            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "5.0");
+            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "4.0");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Tests-Bridging-Header.h");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@loader_path/Frameworks");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.ProjectModuleNameKey, "$(PRODUCT_NAME:c99extidentifier)Tests");

--- a/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
+++ b/Assets/Editor/BuildPipeline/iOSTestPostProcessor.cs
@@ -23,6 +23,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         /// Sets the correct build properties to run
         private static void SetBuildProperties(ExtendedPBXProject project) {
             iOSPostProcessor.SetBuildProperties(project);
+            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "4.0");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Tests-Bridging-Header.h");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@loader_path/Frameworks");
             project.SetBuildProperty(project.TestTargetGuid, ExtendedPBXProject.ProjectModuleNameKey, "$(PRODUCT_NAME:c99extidentifier)Tests");

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayErrorDeserializingTests.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayErrorDeserializingTests.swift
@@ -77,7 +77,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -97,7 +97,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -117,7 +117,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -137,7 +137,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -157,7 +157,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -177,7 +177,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -197,7 +197,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -217,7 +217,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -244,7 +244,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -264,7 +264,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -284,7 +284,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -304,7 +304,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -324,7 +324,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -344,7 +344,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -364,7 +364,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -384,7 +384,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
             
             createErrorExpectation.fulfill()
         }
@@ -411,7 +411,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField)
             
             createErrorExpectation.fulfill()
         }
@@ -431,7 +431,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField)
             
             createErrorExpectation.fulfill()
         }
@@ -451,7 +451,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField)
             
             createErrorExpectation.fulfill()
         }
@@ -471,7 +471,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField)
             
             createErrorExpectation.fulfill()
         }
@@ -491,7 +491,7 @@ extension ApplePayErrorDeserializingTests {
             let paymentError  = PKPaymentRequest.paymentError(with: errorJson)! as NSError
             
             XCTAssertEqual(paymentError.localizedDescription, expectedError.localizedDescription)
-            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey] as! PKContactField)
+            XCTAssertEqual(paymentError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField, expectedError.userInfo[PKPaymentErrorKey.contactFieldUserInfoKey.rawValue] as! PKContactField)
             
             createErrorExpectation.fulfill()
         }

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayFlowTests.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/ApplePayFlowTests.swift
@@ -382,7 +382,7 @@ extension ApplePayFlowTests {
                 // Error Asserts
                 XCTAssertEqual(error.domain, expectedError.domain)
                 XCTAssertEqual(error.localizedDescription, expectedError.localizedDescription)
-                XCTAssertEqual(error.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+                XCTAssertEqual(error.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
                 XCTAssertEqual(update.errors.count, 1)
 
                 expectation.fulfill()
@@ -439,7 +439,7 @@ extension ApplePayFlowTests {
 
                     XCTAssertEqual(error.domain, expectedError.domain)
                     XCTAssertEqual(error.localizedDescription, expectedError.localizedDescription)
-                    XCTAssertEqual(error.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey] as! String)
+                    XCTAssertEqual(error.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String, expectedError.userInfo[PKPaymentErrorKey.postalAddressUserInfoKey.rawValue] as! String)
                     XCTAssertEqual(result.errors.count, 1)
 
                     authorizePaymentExpectation.fulfill()

--- a/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/BuyTests/Models/Models.swift
@@ -184,7 +184,7 @@ struct Models {
                 supportedNetworks: supportedPaymentNetworks,
                 summaryItems: createSummaryItems(),
                 shippingMethods: createShippingMethods(),
-                controllerType: controllerType)
+                controllerType: controllerType)!
         } else {
             return PaymentSession(
                 merchantId: merchantId,
@@ -193,7 +193,7 @@ struct Models {
                 requiringShippingAddressFields: requiringShippingAddressFields,
                 supportedNetworks: supportedPaymentNetworks,
                 summaryItems: createSummaryItems(),
-                shippingMethods: createShippingMethods())
+                shippingMethods: createShippingMethods())!
         }
     }
     

--- a/Assets/Shopify/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -56,7 +56,7 @@ import PassKit
         }
 
         dispatcher = ApplePayEventDispatcher(receiver: unityDelegateObjectName)
-        session    = PaymentSession(
+        self.session = PaymentSession(
                         merchantId: merchantID,
                         countryCode: countryCode,
                         currencyCode: currencyCode,
@@ -65,7 +65,7 @@ import PassKit
                         summaryItems: summaryItems,
                         shippingMethods: shippingMethods)
         
-        session!.delegate = dispatcher
+        self.session?.delegate = dispatcher
         
         return true
     }

--- a/Assets/Shopify/Plugins/iOS/Shopify/Cart+ApplePay.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Cart+ApplePay.swift
@@ -32,7 +32,7 @@ import PassKit
     private(set) static var session: PaymentSession?
     private static var dispatcher: ApplePayEventDispatcher?
     
-    static func createApplePaySession(unityDelegateObjectName: String, merchantID: String, countryCode: String, currencyCode: String, serializedSupportedNetworks: String, serializedSummaryItems: String, serializedShippingMethods: String?, requiringShipping: Bool) -> Bool {
+    @objc static func createApplePaySession(unityDelegateObjectName: String, merchantID: String, countryCode: String, currencyCode: String, serializedSupportedNetworks: String, serializedSummaryItems: String, serializedShippingMethods: String?, requiringShipping: Bool) -> Bool {
         
         guard
             let summaryItemsJson  = extractItems(from: serializedSummaryItems),
@@ -70,7 +70,7 @@ import PassKit
         return true
     }
     
-    public static func presentAuthorizationController() -> Bool {
+    @objc public static func presentAuthorizationController() -> Bool {
         guard let session = session else {
             return false
         }
@@ -85,7 +85,7 @@ import PassKit
 //  MARK: - Static PaymentSession helpers -
 //
 extension Cart {
-    public static func canMakePayments(usingSerializedNetworks networks: String) -> Bool {
+    @objc public static func canMakePayments(usingSerializedNetworks networks: String) -> Bool {
         
         if let supportedNetworks = supportedPaymentNetworks(from: networks) {
             return PaymentSession.canMakePayments(usingNetworks: supportedNetworks)
@@ -94,7 +94,7 @@ extension Cart {
         return false
     }
     
-    public static func canShowSetup(forSerializedNetworks networks: String) -> Bool {
+    @objc public static func canShowSetup(forSerializedNetworks networks: String) -> Bool {
         
         if let supportedNetworks = supportedPaymentNetworks(from: networks) {
             return PaymentSession.canShowSetup(forNetworks: supportedNetworks)
@@ -103,7 +103,7 @@ extension Cart {
         return false
     }
     
-    public static func showPaymentSetup() {
+    @objc public static func showPaymentSetup() {
         PaymentSession.showSetup()
     }
 }

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/Deserializable.swift.meta
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/Deserializable.swift.meta
@@ -1,33 +1,32 @@
 fileFormatVersion: 2
 guid: d7d955b7896714a788f5c6da56b76ae1
-timeCreated: 1496953311
-licenseType: Free
 PluginImporter:
+  externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
-    data:
-      first:
-        Any: 
-      second:
-        enabled: 0
-        settings: {}
-    data:
-      first:
-        Editor: Editor
-      second:
-        enabled: 0
-        settings:
-          DefaultValueInitialized: true
-    data:
-      first:
-        iPhone: iOS
-      second:
-        enabled: 1
-        settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift
@@ -29,7 +29,7 @@ import PassKit
 
 extension PKPaymentSummaryItem: Deserializable {
     
-    class func deserialize(_ json: JSON) -> Self? {
+    @objc class func deserialize(_ json: JSON) -> Self? {
         guard
             let label  = json[Field.label.rawValue] as? String,
             let amount = json[Field.amount.rawValue] as? String

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift.meta
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKPaymentSummaryItem+Deserializable.swift.meta
@@ -1,21 +1,30 @@
 fileFormatVersion: 2
 guid: aa24f40967b864ad0802f01100734879
-timeCreated: 1496435410
-licenseType: Free
 PluginImporter:
-  serializedVersion: 1
+  externalObjects: {}
+  serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
-    Any:
+  - first:
+      Any: 
+    second:
       enabled: 0
       settings: {}
-    Editor:
+  - first:
+      Editor: Editor
+    second:
       enabled: 0
       settings:
         DefaultValueInitialized: true
-    iOS:
+  - first:
+      iPhone: iOS
+    second:
       enabled: 1
       settings: {}
   userData: 

--- a/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift.meta
+++ b/Assets/Shopify/Plugins/iOS/Shopify/Deserializable/PKShippingMethod+Deserializable.swift.meta
@@ -1,21 +1,30 @@
 fileFormatVersion: 2
 guid: e3c158bf3e4df49a9942b88f1582aed9
-timeCreated: 1496435410
-licenseType: Free
 PluginImporter:
-  serializedVersion: 1
+  externalObjects: {}
+  serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
-    Any:
+  - first:
+      Any: 
+    second:
       enabled: 0
       settings: {}
-    Editor:
+  - first:
+      Editor: Editor
+    second:
       enabled: 0
       settings:
         DefaultValueInitialized: true
-    iOS:
+  - first:
+      iPhone: iOS
+    second:
       enabled: 1
       settings: {}
   userData: 

--- a/Assets/Shopify/Plugins/iOS/Shopify/MessageCenter.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/MessageCenter.swift
@@ -51,7 +51,7 @@ import PassKit
         UnitySendMessage(object, method, content)
     }
     
-    static func message(forIdentifier identifier: String) -> UnityMessage? {
+    @objc static func message(forIdentifier identifier: String) -> UnityMessage? {
         return messages[identifier]
     }
 }

--- a/Assets/Shopify/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PaymentAuthorizationControlling.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/PaymentAuthorizationControlling/PaymentAuthorizationControlling.swift
@@ -31,7 +31,7 @@ import PassKit
     
     var authorizationDelegate: NSObjectProtocol? { get set }
     
-    init(paymentRequest request: PKPaymentRequest)
+    init?(paymentRequest request: PKPaymentRequest)
     func present(completion: ((Bool) -> Void)?)
     func dismiss(completion: (() -> Void)?)
 }

--- a/Assets/Shopify/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/PaymentSession.swift
@@ -80,7 +80,7 @@ import PassKit
     // ----------------------------------
     //  MARK: - Init -
     //
-    init(
+    init?(
         merchantId: String,
         countryCode: String,
         currencyCode: String,
@@ -103,11 +103,15 @@ import PassKit
         request.paymentSummaryItems = summaryItems
         request.shippingMethods     = shippingMethods
     
-        controller = controllerType.init(paymentRequest: request)!
+        guard let controller = controllerType.init(paymentRequest: request) else {
+            return nil
+        }
+        
+        self.controller = controller
     
         super.init()
         
-        controller.authorizationDelegate = self
+        self.controller.authorizationDelegate = self
     }
     
     /// Presents the PKAuthorizationController with the current shipping methods

--- a/Assets/Shopify/Plugins/iOS/Shopify/PaymentSession.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/PaymentSession.swift
@@ -103,7 +103,7 @@ import PassKit
         request.paymentSummaryItems = summaryItems
         request.shippingMethods     = shippingMethods
     
-        controller = controllerType.init(paymentRequest: request)
+        controller = controllerType.init(paymentRequest: request)!
     
         super.init()
         

--- a/Assets/Shopify/Plugins/iOS/Shopify/UnityMessage.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/UnityMessage.swift
@@ -58,7 +58,7 @@ import Foundation
         }
     }
     
-    func complete(with response: String? = nil) {
+    @objc func complete(with response: String? = nil) {
         self.response = response
         semaphore.signal()
     }

--- a/Assets/Shopify/Plugins/iOS/Shopify/WebCheckoutSession.swift
+++ b/Assets/Shopify/Plugins/iOS/Shopify/WebCheckoutSession.swift
@@ -31,7 +31,7 @@ import SafariServices
 private var activeWebPaySession: WebCheckoutSession?
 
 @objc class WebCheckoutSession: NSObject {
-    static func createSession(unityDelegateObjectName: String, url: String) -> WebCheckoutSession {
+    @objc static func createSession(unityDelegateObjectName: String, url: String) -> WebCheckoutSession {
         let session = WebCheckoutSession(unityDelegateObjectName: unityDelegateObjectName,
                                          checkoutURL: url)
         activeWebPaySession = session
@@ -48,7 +48,7 @@ private var activeWebPaySession: WebCheckoutSession?
         super.init()
     }
     
-    func startCheckout() -> Bool {
+    @objc func startCheckout() -> Bool {
         guard let url = URL(string: checkoutURL) else {
             return false
         }

--- a/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
+++ b/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
@@ -25,7 +25,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
 
         // Sets the required project settings for the Xcode project to work with the SDK.
         public static void SetBuildProperties(ExtendedPBXProject project) {
-            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "5.0");
+            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "4.0");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@executable_path/Frameworks");
 

--- a/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
+++ b/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
@@ -25,7 +25,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
 
         // Sets the required project settings for the Xcode project to work with the SDK.
         public static void SetBuildProperties(ExtendedPBXProject project) {
-            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "4.0");
+            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "5.0");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@executable_path/Frameworks");
 

--- a/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
+++ b/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
@@ -25,7 +25,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
 
         // Sets the required project settings for the Xcode project to work with the SDK.
         public static void SetBuildProperties(ExtendedPBXProject project) {
-            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "3.0");
+            project.SetBuildProperty(project.GetAllTargetGuids(), ExtendedPBXProject.SwiftVersionKey, "4.0");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.SwiftBridgingHeaderKey, "Libraries/Shopify/Plugins/iOS/Shopify/Unity-iPhone-Bridging-Header.h");
             project.SetBuildProperty(project.UnityTargetGuid, ExtendedPBXProject.RunpathSearchKey, "@executable_path/Frameworks");
 


### PR DESCRIPTION
Migrates the iOS plugin to support Swift 4 and resolves any errors that were caused from the switch. The two key errors that were happening were:

1. Illegal overriding of a Swift extension method in Deserializable. Fixed this by added in `@objc` prefix to make it into an ObjC extension instead.
2. Failable initializer not captured in `PaymentAuthorizationController` protocol. The `PaymentAuthorizationViewController` framework class has a failable initializer and since it implements this protocol the protocol method definition should match.