### PR TITLE
Fix the generator for interfaces

### DIFF
--- a/scripts/generator/graphql_generator/csharp/type_response.cs.erb
+++ b/scripts/generator/graphql_generator/csharp/type_response.cs.erb
@@ -58,7 +58,7 @@ namespace Shopify.Unity {
         public interface <%= type.classify_name %> {
             <% type.fields(include_deprecated: true).each do |field| %>
                 <%= docs_response_field(field) %>
-                <%= graph_type_to_csharp_type(field.type) %> <%= field.name %>();
+                <%= graph_type_to_csharp_type(field.type) %> <%= field.name %>(<%= 'string alias = null' if field.args.any? %>);
             <% end %>
         }
 


### PR DESCRIPTION
Before
```
    /// <summary>
    /// Represents information about the metafields associated to the specified resource.
    /// </summary>
    public interface HasMetafields {
        /// <summary>
        /// The metafield associated with the resource.
        /// </summary>
        /// <param name="alias">
        /// If the original field queried was queried using an alias, then pass the matching string.
        /// </param>
        Metafield metafield();

        /// <summary>
        /// A paginated list of metafields associated with the resource.
        /// </summary>
        /// <param name="alias">
        /// If the original field queried was queried using an alias, then pass the matching string.
        /// </param>
        MetafieldConnection metafields();
    }
```

After:
```
    /// <summary>
    /// Represents information about the metafields associated to the specified resource.
    /// </summary>
    public interface HasMetafields {
        /// <summary>
        /// The metafield associated with the resource.
        /// </summary>
        /// <param name="alias">
        /// If the original field queried was queried using an alias, then pass the matching string.
        /// </param>
        Metafield metafield(string alias = null);

        /// <summary>
        /// A paginated list of metafields associated with the resource.
        /// </summary>
        /// <param name="alias">
        /// If the original field queried was queried using an alias, then pass the matching string.
        /// </param>
        MetafieldConnection metafields(string alias = null);
    }
```