### PR TITLE
Fix ApplePay flow test failures

### DIFF
--- a/Assets/Editor/TestDefaultCheckoutQueries.cs
+++ b/Assets/Editor/TestDefaultCheckoutQueries.cs
@@ -51,7 +51,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.AvailableShippingRatesPoll(query, checkoutId);
             Assert.AreEqual(
-                "{node (id:\"an-id\"){__typename ...on Checkout{id webUrl currencyCode requiresShipping subtotalPriceV2 {amount currencyCode }totalTaxV2 {amount currencyCode }totalPriceV2 {amount currencyCode }ready availableShippingRates {shippingRates {handle title price }ready }}}}",
+                "{node (id:\"an-id\"){__typename ...on Checkout{id webUrl currencyCode requiresShipping subtotalPriceV2 {amount currencyCode }totalTaxV2 {amount currencyCode }totalPriceV2 {amount currencyCode }ready availableShippingRates {shippingRates {handle title priceV2 {amount currencyCode }}ready }}}}",
                 query.ToString()
             );
         }
@@ -127,7 +127,7 @@ namespace Shopify.Tests
 
             DefaultQueries.checkout.ShippingLineUpdate(query, checkoutId, "handle");
             Assert.AreEqual(
-                "mutation{checkoutShippingLineUpdate (checkoutId:\"an-id\",shippingRateHandle:\"handle\"){checkout {id webUrl currencyCode requiresShipping subtotalPriceV2 {amount currencyCode }totalTaxV2 {amount currencyCode }totalPriceV2 {amount currencyCode }ready shippingLine {handle title price }}checkoutUserErrors {code field message }}}",
+                "mutation{checkoutShippingLineUpdate (checkoutId:\"an-id\",shippingRateHandle:\"handle\"){checkout {id webUrl currencyCode requiresShipping subtotalPriceV2 {amount currencyCode }totalTaxV2 {amount currencyCode }totalPriceV2 {amount currencyCode }ready shippingLine {handle title priceV2 {amount currencyCode }}}checkoutUserErrors {code field message }}}",
                 query.ToString()
             );
         }

--- a/Assets/Shopify/Unity/SDK/DefaultCheckoutQueries.cs
+++ b/Assets/Shopify/Unity/SDK/DefaultCheckoutQueries.cs
@@ -183,7 +183,10 @@ namespace Shopify.Unity.SDK {
             return shippingRate
                 .handle()
                 .title()
-                .price();
+                .priceV2((queryBuilder)=> { queryBuilder
+                    .amount()
+                    .currencyCode();
+                });
         }
 
         private CheckoutQuery CheckoutLineItems(CheckoutQuery checkout, int first = 250, string after = null) {

--- a/Assets/Shopify/Unity/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs
+++ b/Assets/Shopify/Unity/SDK/iOS/iOSNativeCheckout.ApplePayEventReceiver.cs
@@ -248,7 +248,7 @@ namespace Shopify.Unity.SDK.iOS {
         public void FetchApplePayCheckoutStatusForToken(string serializedMessage) {
             var checkout = CartState.CurrentCheckout;
             var message = NativeMessage.CreateFromJSON(serializedMessage);
-            var paymentAmount = new MoneyInput(checkout.totalPrice(), checkout.currencyCode());
+            var paymentAmount = new MoneyInput(checkout.totalPriceV2().amount(), checkout.currencyCode());
             var payment = new NativePayment(message.Content);
             var tokenizedPaymentInputV2 = new TokenizedPaymentInputV2(
               paymentAmount: paymentAmount,

--- a/Assets/Shopify/Unity/SDK/iOS/iOSNativeCheckout.cs
+++ b/Assets/Shopify/Unity/SDK/iOS/iOSNativeCheckout.cs
@@ -126,18 +126,18 @@ namespace Shopify.Unity.SDK.iOS {
             }
 
             var summaryItems = new List<SummaryItem>();
-            summaryItems.Add(new SummaryItem("SUBTOTAL", checkout.subtotalPrice().ToString()));
+            summaryItems.Add(new SummaryItem("SUBTOTAL", checkout.subtotalPriceV2().amount().ToString()));
 
             if (checkout.requiresShipping()) {
                 try {
-                    summaryItems.Add(new SummaryItem("SHIPPING", checkout.shippingLine().price().ToString()));
+                    summaryItems.Add(new SummaryItem("SHIPPING", checkout.shippingLine().priceV2().amount().ToString()));
                 } catch { }
             }
 
             summaryItems.Add(new SummaryItem("TAXES", checkout.totalTax().ToString()));
 
             // We used the store name here instead of TOTAL due to Apple Pay design guidelines. This will read as `Pay storeName`.
-            summaryItems.Add(new SummaryItem(StoreName, checkout.totalPrice().ToString()));
+            summaryItems.Add(new SummaryItem(StoreName, checkout.totalPriceV2().amount().ToString()));
 
             return summaryItems;
         }
@@ -150,7 +150,7 @@ namespace Shopify.Unity.SDK.iOS {
                 var availableShippingRates = checkout.availableShippingRates().shippingRates();
 
                 foreach (var shippingRate in availableShippingRates) {
-                    shippingMethods.Add(new ShippingMethod(shippingRate.title(), shippingRate.price().ToString(), shippingRate.handle()));
+                    shippingMethods.Add(new ShippingMethod(shippingRate.title(), shippingRate.priceV2().amount().ToString(), shippingRate.handle()));
                 }
             } catch (Exception e) {
                 throw new Exception("Attempted to gather information on available shipping rates on CurrentCheckout, but CurrentCheckout do not have those properties queried", e);

--- a/Assets/Shopify/Unity/SDK/iOS/iOSNativeCheckout.cs
+++ b/Assets/Shopify/Unity/SDK/iOS/iOSNativeCheckout.cs
@@ -134,7 +134,7 @@ namespace Shopify.Unity.SDK.iOS {
                 } catch { }
             }
 
-            summaryItems.Add(new SummaryItem("TAXES", checkout.totalTax().ToString()));
+            summaryItems.Add(new SummaryItem("TAXES", checkout.totalTaxV2().amount().ToString()));
 
             // We used the store name here instead of TOTAL due to Apple Pay design guidelines. This will read as `Pay storeName`.
             summaryItems.Add(new SummaryItem(StoreName, checkout.totalPriceV2().amount().ToString()));


### PR DESCRIPTION
This is fix for some failing ios test specific tests. 

Please see this PR for some context: https://github.com/Shopify/unity-buy-sdk/pull/580

The failing tests were:

> ApplePayFlowTests.testCompleteInvalidBillingAddressCheckout()
> 	ApplePayFlowTests.testCompleteInvalidShippingAddressCheckout()
> 	ApplePayFlowTests.testCompleteInvalidShippingAddressCheckoutIos11()
> 	ApplePayFlowTests.testCompleteInvalidShippingContactCheckout()
> 	ApplePayFlowTests.testCompleteSuccessfulCheckout()
> 	ApplePayFlowTests.testSelectShippingMethod()
> 	ApplePayFlowTests.testSetInvalidShippingContact()
> 	ApplePayFlowTests.testSetInvalidShippingContactIos11()
> 	ApplePayFlowTests.testSetShippingContact()