### PR TITLE
Upgrade travis build unity from 2017.1.1 to 2018.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ osx_image: xcode10
 env:
   UNITY_DOWNLOAD_DIR: $HOME/unity
   UNITY_PKG_LOCATION: $HOME/unity/Unity.pkg
-  UNITY_PKG_URL: https://download.unity3d.com/download_unity/5d30cf096e79/MacEditorInstaller/Unity-2017.1.1f1.pkg
+  UNITY_PKG_URL: https://download.unity3d.com/download_unity/6e9a27477296/MacEditorInstaller/Unity-2018.3.0f2.pkg
   IOS_PKG_LOCATION: $HOME/unity/Unity-iOS.pkg
   IOS_PKG_URL: http://netstorage.unity3d.com/unity/5d30cf096e79/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor.pkg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   UNITY_PKG_LOCATION: $HOME/unity/Unity.pkg
   UNITY_PKG_URL: https://download.unity3d.com/download_unity/6e9a27477296/MacEditorInstaller/Unity-2018.3.0f2.pkg
   IOS_PKG_LOCATION: $HOME/unity/Unity-iOS.pkg
-  IOS_PKG_URL: http://netstorage.unity3d.com/unity/5d30cf096e79/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor.pkg
+  IOS_PKG_URL: http://netstorage.unity3d.com/unity/6e9a27477296/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor.pkg
 
 notifications:
   slack:

--- a/scripts/install_unity.sh
+++ b/scripts/install_unity.sh
@@ -2,10 +2,10 @@
 
 . "$(dirname "$0")"/common.sh
 
-# set UNITY_DOWNLOAD_DIR if it hasn't been set. It may have been set from 
+# set UNITY_DOWNLOAD_DIR if it hasn't been set. It may have been set from
 UNITY_DOWNLOAD_DIR="${UNITY_DOWNLOAD_DIR:-`pwd`/unity}"
 UNITY_PKG_LOCATION=${UNITY_PKG_LOCATION:-"$UNITY_DOWNLOAD_DIR"/Unity.pkg}
-UNITY_PKG_URL=${UNITY_PKG_URL:-https://download.unity3d.com/download_unity/5d30cf096e79/MacEditorInstaller/Unity-2017.1.1f1.pkg}
+UNITY_PKG_URL=${UNITY_PKG_URL:-https://download.unity3d.com/download_unity/6e9a27477296/MacEditorInstaller/Unity-2018.3.0f2.pkg}
 IOS_PKG_LOCATION=${IOS_PKG_LOCATION:-"$UNITY_DOWNLOAD_DIR"/Unity-iOS.pkg}
 IOS_PKG_URL=${IOS_PKG_URL:-http://netstorage.unity3d.com/unity/5d30cf096e79/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor.pkg}
 

--- a/scripts/install_unity.sh
+++ b/scripts/install_unity.sh
@@ -7,7 +7,7 @@ UNITY_DOWNLOAD_DIR="${UNITY_DOWNLOAD_DIR:-`pwd`/unity}"
 UNITY_PKG_LOCATION=${UNITY_PKG_LOCATION:-"$UNITY_DOWNLOAD_DIR"/Unity.pkg}
 UNITY_PKG_URL=${UNITY_PKG_URL:-https://download.unity3d.com/download_unity/6e9a27477296/MacEditorInstaller/Unity-2018.3.0f2.pkg}
 IOS_PKG_LOCATION=${IOS_PKG_LOCATION:-"$UNITY_DOWNLOAD_DIR"/Unity-iOS.pkg}
-IOS_PKG_URL=${IOS_PKG_URL:-http://netstorage.unity3d.com/unity/5d30cf096e79/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor.pkg}
+IOS_PKG_URL=${IOS_PKG_URL:-http://netstorage.unity3d.com/unity/6e9a27477296/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor.pkg}
 
 if [[ ! -e $UNITY_PKG_LOCATION ]] ; then
     out "Downloading Unity to $UNITY_DOWNLOAD_DIR"


### PR DESCRIPTION
The version of unity on the travis build is currently a `2017.1.1f1`. We want this to always match the targeted version of the sdk which is currently - `2018.3.0f2`

We want to upgrade the unity project to a more recent `2019.x` build very soon. But we will do this incrementally as there are some new deprecations that break the sample app (vending machine)