### PR TITLE
Added -all_load linker flag to UnityFramework for static linking symbols

### DIFF
--- a/Assets/Shopify/Unity/Editor/BuildPipeline/ExtendedPBXProject.cs
+++ b/Assets/Shopify/Unity/Editor/BuildPipeline/ExtendedPBXProject.cs
@@ -19,6 +19,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
         public static string LibrarySearchPathsKey = "LIBRARY_SEARCH_PATHS";
         public static string EnableBitcodeKey = "ENABLE_BITCODE";
         public static string ClangAllowNonModularIncludesInFrameworkModules = "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES";
+        public static string OtherLinkerFlagsKey = "OTHER_LDFLAGS";
 
         public readonly string BuildPath;
         public readonly string TestTargetGuid;

--- a/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
+++ b/Assets/Shopify/Unity/Editor/BuildPipeline/iOSPostProcessor.cs
@@ -31,6 +31,7 @@ namespace Shopify.Unity.Editor.BuildPipeline {
             project.AddBuildProperty(project.GetUnityFrameworkTargetGuid(), ExtendedPBXProject.LibrarySearchPathsKey, "$(inherited)");
             project.AddBuildProperty(project.GetUnityFrameworkTargetGuid(), ExtendedPBXProject.LibrarySearchPathsKey, "$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)");
             project.AddBuildProperty(project.GetUnityFrameworkTargetGuid(), ExtendedPBXProject.LibrarySearchPathsKey, "$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)");
+            project.AddBuildProperty(project.GetUnityFrameworkTargetGuid(), ExtendedPBXProject.OtherLinkerFlagsKey, "-all_load");
 
             bool isBelowMinimumTarget = false;
 


### PR DESCRIPTION
Adds -all_load linker flag to load in all symbols required from the new iOS static library on release builds.