### PR TITLE
Embed bitcode for iOS static lib target

### DIFF
--- a/PluginDependencies/iOSPlugin/UnityBuySDKPlugin.xcodeproj/project.pbxproj
+++ b/PluginDependencies/iOSPlugin/UnityBuySDKPlugin.xcodeproj/project.pbxproj
@@ -570,6 +570,7 @@
 		E98FCB8B25E44C47001DB1A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = A7XGC83MZE;
 				OTHER_LDFLAGS = "-ObjC";
@@ -583,6 +584,7 @@
 		E98FCB8C25E44C47001DB1A9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = A7XGC83MZE;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Resolves https://github.com/Shopify/unity-buy-sdk/issues/611.

Archiving release builds using the Unity SDK cause errors when trying to build with a bitcode enabled build (this is enabled by default). This fix enables bitcode generation for the new static library target we use for the iOS native plugin.