### PR TITLE
Checkout + Build Fixes

### DIFF
--- a/Assets/NativeTesting/Native/Tester.cs
+++ b/Assets/NativeTesting/Native/Tester.cs
@@ -6,7 +6,8 @@
     using Shopify.Unity.SDK.iOS;
 
     public class Tester : MonoBehaviour {
-
+        
+#if UNITY_IOS
         [DllImport ("__Internal")]
         protected static extern void _TesterObjectFinishedLoading();
 
@@ -24,5 +25,6 @@
                 _TesterObjectFinishedLoading();
             }
         }
+#endif
     }
 }

--- a/Assets/Shopify/Unity/SDK/CartLineItems.cs
+++ b/Assets/Shopify/Unity/SDK/CartLineItems.cs
@@ -252,6 +252,8 @@ namespace Shopify.Unity.SDK {
                     OnChange(LineItemChangeType.Add, lineItem);
                 }
             }
+            
+            _IsSaved = false;
         }
 
         /// <summary>
@@ -379,6 +381,7 @@ namespace Shopify.Unity.SDK {
                     OnChange(LineItemChangeType.Remove, lineItemRemoved);
                 }
 
+                _IsSaved = false;
                 return true;
             }
         }


### PR DESCRIPTION
-- Note: I see that the PR Guidelines request that I target the 'beta' branch, but there is no 'beta' branch.

-- Tester.cs
- Adds UNITY_IOS preprocessor tags around code that will cause non iOS builds to fail because of unavailable DllImport target

-- CartLineItem.cs
- Sets cart to an unsaved state when you add/remove items to force checkouts to always update the remote cart
- To reproduce this bug: (1) Add an item to a cart, (2) go to checkout, (3) close the checkout, (4) add a second item to the cart, (5) go to checkout again. The cart will only contain the first item because adding/removing items does not dirty the cart.